### PR TITLE
Added glimpse tag and removed log4net tag

### DIFF
--- a/src/Serilog.Sinks.Glimpse/Serilog.Sinks.Glimpse.nuspec
+++ b/src/Serilog.Sinks.Glimpse/Serilog.Sinks.Glimpse.nuspec
@@ -11,7 +11,7 @@
       <iconUrl>http://serilog.net/images/serilog-nuget.png</iconUrl>
       <requireLicenseAcceptance>false</requireLicenseAcceptance>
       <description>Serilog event sink that writes to a Glimpse tab.</description>
-      <tags>serilog logging log4net</tags>
+      <tags>serilog logging glimpse</tags>
       <dependencies>
             <dependency id="Glimpse" />
             <dependency id="Serilog" />


### PR DESCRIPTION
This pull request fixes [Serilog issue 62](https://github.com/serilog/serilog/issues/62) 
