### PR TITLE
Add "optional hint" to tell the logger to ignore that property when emitting it

### DIFF
--- a/sample/Harness/Program.cs
+++ b/sample/Harness/Program.cs
@@ -11,7 +11,7 @@ namespace Harness
             Log.Logger = new LoggerConfiguration()
                 .MinimumLevel.Debug()
                 .WriteTo.Console(
-                    outputTemplate: "{Timestamp:HH:mm:ss} ({ThreadId}) [{Level}] {Message:l}{NewLine:l}{Exception:l}")
+                    outputTemplate: "{Timestamp:HH:mm:ss} ({ThreadId}) [{Level}] {?Id:[0] }{Message:l}{NewLine:l}{Exception:l}")
                 .WriteTo.DumpFile("Dumps\\" + DateTime.Now.Ticks + ".slog")
                 .WriteTo.Trace()
                 .Enrich.WithProperty("App", "Test Harness")
@@ -22,6 +22,9 @@ namespace Harness
             Log.Information("Just biting {Fruit} number {Count}", "Apple", 12);
             Log.ForContext<Program>().Information("Just biting {Fruit} number {Count:0000}", "Apple", 12);
             
+            Log.Information("{?Scope1}{?Scope2}", new { Scope1 = "Test Scope"});
+            Log.ForContext("Id", 1234).Information("This should have an id");
+
             // ReSharper disable CoVariantArrayConversion
             Log.Information("I've eaten {Dinner}", new[] { "potatoes", "peas" });
             // ReSharper restore CoVariantArrayConversion

--- a/src/Serilog/Parsing/MessageTemplateParser.cs
+++ b/src/Serilog/Parsing/MessageTemplateParser.cs
@@ -106,6 +106,12 @@ namespace Serilog.Parsing
             }
 
             var propertyName = propertyNameAndDestructuring;
+            bool optional;
+            if (TryGetOptionalHint(propertyName[0], out optional))
+            {
+                propertyName = propertyName.Substring(1);
+            }
+
             Destructuring destructuring;
             if (TryGetDestructuringHint(propertyName[0], out destructuring))
                 propertyName = propertyName.Substring(1);
@@ -128,7 +134,8 @@ namespace Serilog.Parsing
                 propertyName,
                 rawText,
                 format,
-                destructuring);
+                destructuring,
+                optional);
         }
 
         private static bool IsValidInPropertyTag(char c)
@@ -143,6 +150,21 @@ namespace Serilog.Parsing
         private static bool IsValidInPropertyName(char c)
         {
             return char.IsLetterOrDigit(c);
+        }
+
+        private static bool TryGetOptionalHint(char c, out bool optional)
+        {
+            switch (c)
+            {
+                case '?':
+                {
+                    optional = true;
+                    return true;
+                }
+                default:
+                    optional = false;
+                    return false;
+            }
         }
 
         private static bool TryGetDestructuringHint(char c, out Destructuring destructuring)

--- a/src/Serilog/Parsing/PropertyToken.cs
+++ b/src/Serilog/Parsing/PropertyToken.cs
@@ -30,6 +30,7 @@ namespace Serilog.Parsing
         private readonly Destructuring _destructuring;
         private readonly string _rawText;
         private readonly int? _position;
+        private readonly Boolean _isOptional;
 
         /// <summary>
         /// Construct a <see cref="PropertyToken"/>.
@@ -38,11 +39,13 @@ namespace Serilog.Parsing
         /// <param name="rawText">The token as it appears in the message template.</param>
         /// <param name="format">The format applied to the property, if any.</param>
         /// <param name="destructuring">The destructuring strategy applied to the property, if any.</param>
+        /// <param name="optional">Whether the property can be null and should be omitted from the output</param>
         /// <exception cref="ArgumentNullException"></exception>
-        public PropertyToken(string propertyName, string rawText, string format = null, Destructuring destructuring = Destructuring.Default)
+        public PropertyToken(string propertyName, string rawText, string format = null, Destructuring destructuring = Destructuring.Default, Boolean optional = false)
         {
             if (propertyName == null) throw new ArgumentNullException("propertyName");
             if (rawText == null) throw new ArgumentNullException("rawText");
+            _isOptional = optional;
             _propertyName = propertyName;
             _format = format;
             _destructuring = destructuring;
@@ -69,7 +72,7 @@ namespace Serilog.Parsing
             LogEventPropertyValue propertyValue;
             if (properties.TryGetValue(_propertyName, out propertyValue))
                 propertyValue.Render(output, _format, formatProvider);
-            else
+            else if (!_isOptional)
                 output.Write(_rawText);
         }
 
@@ -127,6 +130,7 @@ namespace Serilog.Parsing
                 pt._destructuring == _destructuring &&
                 pt._format == _format &&
                 pt._propertyName == _propertyName &&
+                pt._isOptional == _isOptional &&
                 pt._rawText == _rawText;
         }
 

--- a/test/Serilog.Tests/Parsing/MessageTemplateParserTests.cs
+++ b/test/Serilog.Tests/Parsing/MessageTemplateParserTests.cs
@@ -43,6 +43,13 @@ namespace Serilog.Tests.Parsing
         }
 
         [Test]
+        public void AMessageWithOptionalPropertyIsParsedAsOptionalPropertyToken()
+        {
+            AssertParsedAs("{?Hello}",
+                new PropertyToken("Hello", "{?Hello}", optional:true));
+        }
+
+        [Test]
         public void DoubledLeftBracketsAreParsedAsASingleBracket()
         {
             AssertParsedAs("{{ Hi! }",


### PR DESCRIPTION
As spurred by the discussion here: https://groups.google.com/forum/#!topic/serilog/O0mSN0au9Pg

Added an "optional hint" to allow for the PropertyToken emitter to "ignore" the parameter if the property is null.

Example usage:
`Log.Information("{?Property1:[0] }{Property2}", new { Property2 = "Value2"});`
`Log.Information("{?Property1:[0] }{Property2}", new { Property1 = 123, Property2 = "Value2"});`
Will output:
`"Value2"`
`[123] "Value2"`

Note: The usage of the inner formatter to deal with the issue of leading spaces etc. Which could also be used just as a boolean nullity check ala:
`Log.Information("{?Property1:Property1 is not null }{Property2}", new { Property2 = "Value2"});`
Which will output: `Property 1 is not null "Value2"`
