### PR TITLE
Expose public default constructors to enable serialization

### DIFF
--- a/src/Serilog/Events/DictionaryValue.cs
+++ b/src/Serilog/Events/DictionaryValue.cs
@@ -27,6 +27,14 @@ namespace Serilog.Events
         private readonly IReadOnlyDictionary<ScalarValue, LogEventPropertyValue> _elements;
 
         /// <summary>
+        /// Construct an empty <see cref="DictionaryValue"/>.
+        /// </summary>
+        public DictionaryValue()
+        {
+            
+        }
+
+        /// <summary>
         /// Create a <see cref="DictionaryValue"/> with the provided <paramref name="elements"/>.
         /// </summary>
         /// <param name="elements">The key-value mappings represented in the dictionary.</param>

--- a/src/Serilog/Events/LogEvent.cs
+++ b/src/Serilog/Events/LogEvent.cs
@@ -30,6 +30,11 @@ namespace Serilog.Events
         private readonly Dictionary<string, LogEventPropertyValue> _properties;
 
         /// <summary>
+        /// Construct an empty <seealso cref="LogEvent"/>.
+        /// </summary>
+        public LogEvent() {}
+
+        /// <summary>
         /// Construct a new <seealso cref="LogEvent"/>.
         /// </summary>
         /// <param name="timestamp">The time at which the event occurred.</param>

--- a/src/Serilog/Events/LogEventProperty.cs
+++ b/src/Serilog/Events/LogEventProperty.cs
@@ -25,6 +25,14 @@ namespace Serilog.Events
         private readonly LogEventPropertyValue _value;
 
         /// <summary>
+        /// Construct an empty <see cref="LogEventProperty"/>.
+        /// </summary>
+        public LogEventProperty()
+        {
+            
+        }
+
+        /// <summary>
         /// Construct a <see cref="LogEventProperty"/> with the specified name and value.
         /// </summary>
         /// <param name="name">The name of the property.</param>

--- a/src/Serilog/Events/ScalarValue.cs
+++ b/src/Serilog/Events/ScalarValue.cs
@@ -26,6 +26,14 @@ namespace Serilog.Events
         readonly object _value;
 
         /// <summary>
+        /// Construct an empty <see cref="ScalarValue"/>
+        /// </summary>
+        public ScalarValue()
+        {
+            
+        }
+
+        /// <summary>
         /// Construct a <see cref="ScalarValue"/> with the specified
         /// value.
         /// </summary>

--- a/src/Serilog/Events/SequenceValue.cs
+++ b/src/Serilog/Events/SequenceValue.cs
@@ -27,6 +27,14 @@ namespace Serilog.Events
         private readonly LogEventPropertyValue[] _elements;
 
         /// <summary>
+        /// Construct an empty <see cref="SequenceValue"/>.
+        /// </summary>
+        public SequenceValue()
+        {
+            
+        }
+
+        /// <summary>
         /// Create a <see cref="SequenceValue"/> with the provided <paramref name="elements"/>.
         /// </summary>
         /// <param name="elements">The elements of the sequence.</param>

--- a/src/Serilog/Events/StructureValue.cs
+++ b/src/Serilog/Events/StructureValue.cs
@@ -28,6 +28,14 @@ namespace Serilog.Events
         private readonly LogEventProperty[] _properties;
 
         /// <summary>
+        /// Construct an empty <see cref="StructureValue"/>.
+        /// </summary>
+        public StructureValue()
+        {
+            
+        }
+
+        /// <summary>
         /// Construct a <see cref="StructureValue"/> with the provided properties.
         /// </summary>
         /// <param name="typeTag">Optionally, a piece of metadata describing the "type" of the

--- a/src/Serilog/Formatting/Display/LogEventPropertyMessageValue.cs
+++ b/src/Serilog/Formatting/Display/LogEventPropertyMessageValue.cs
@@ -25,6 +25,11 @@ namespace Serilog.Formatting.Display
         private readonly MessageTemplate _template;
         private readonly IReadOnlyDictionary<string, LogEventPropertyValue> _properties;
 
+        public LogEventPropertyMessageValue()
+        {
+            
+        }
+
         public LogEventPropertyMessageValue(MessageTemplate template, IReadOnlyDictionary<string, LogEventPropertyValue> properties)
         {
             _template = template;


### PR DESCRIPTION
I would like to be able to serialize `LogEvent` to send it over the wire before writing to a sink.
