### PR TITLE
Updated FileSink to use FileShare.ReadWrite

### DIFF
--- a/src/Serilog.FullNetFx/Sinks/IOFile/FileSink.cs
+++ b/src/Serilog.FullNetFx/Sinks/IOFile/FileSink.cs
@@ -49,7 +49,7 @@ namespace Serilog.Sinks.IOFile
 
             TryCreateDirectory(path);
 
-            var file = File.Open(path, FileMode.Append, FileAccess.Write, FileShare.Read);
+            var file = File.Open(path, FileMode.Append, FileAccess.Write, FileShare.ReadWrite);
             var outputWriter = new StreamWriter(file, Encoding.UTF8);
             if (fileSizeLimitBytes != null)
             {


### PR DESCRIPTION
Using this to do async writing to a log file across multiple threads. Ran into a bug with async requests writing to the same logs, and this update seems to have fixed the bug on our end.
