### PR TITLE
Add source file / line logging via [CallerFileName] and friends

### DIFF
--- a/src/Serilog/Events/LogEvent.cs
+++ b/src/Serilog/Events/LogEvent.cs
@@ -28,6 +28,8 @@ namespace Serilog.Events
         private readonly Exception _exception;
         private readonly MessageTemplate _messageTemplate;
         private readonly Dictionary<string, LogEventPropertyValue> _properties;
+        private readonly string _sourceFile;
+        private readonly int _line;
 
         /// <summary>
         /// Construct a new <seealso cref="LogEvent"/>.
@@ -35,15 +37,19 @@ namespace Serilog.Events
         /// <param name="timestamp">The time at which the event occurred.</param>
         /// <param name="level">The level of the event.</param>
         /// <param name="exception">An exception associated with the event, or null.</param>
+        /// <param name="sourceFile">The source file where the event was logged</param>
+        /// <param name="line">The line in sourceFile where the event was logged</param>
         /// <param name="messageTemplate">The message template describing the event.</param>
         /// <param name="properties">Properties associated with the event, including those presented in <paramref name="messageTemplate"/>.</param>
-        public LogEvent(DateTimeOffset timestamp, LogEventLevel level, Exception exception, MessageTemplate messageTemplate, IEnumerable<LogEventProperty> properties)
+        public LogEvent(DateTimeOffset timestamp, LogEventLevel level, Exception exception, MessageTemplate messageTemplate, string sourceFile, int line, IEnumerable<LogEventProperty> properties)
         {
             if (messageTemplate == null) throw new ArgumentNullException("messageTemplate");
             if (properties == null) throw new ArgumentNullException("properties");
             _timestamp = timestamp;
             _level = level;
             _exception = exception;
+            _sourceFile = sourceFile;
+            _line = line;
             _messageTemplate = messageTemplate;
             _properties = new Dictionary<string, LogEventPropertyValue>();
             foreach (var p in properties)
@@ -109,6 +115,22 @@ namespace Serilog.Events
         public Exception Exception
         {
             get { return _exception; }
+        }
+
+        /// <summary>
+        /// The source file where the event was logged
+        /// </summary>
+        public string SourceFile
+        {
+            get { return _sourceFile; }
+        }
+
+        /// <summary>
+        /// The line in SourceFile where the event was logged
+        /// </summary>
+        public int Line
+        {
+            get { return _line; }
         }
 
         /// <summary>


### PR DESCRIPTION
This PR adds source file / line number logging via the C# [CallerFileName] attribute. However, to do this, we have to do some Controversial Stuff (tm), so I'm pushing up this PR before I do the work :cat: 
## The Problem

So, the way you use `[CallerFileName]` is that it must be a Default Parameter. This conflicts Pretty Badly with the `params` keyword, since if the log parameters happen to be `string` and `int`, we now match `sourceFile` and `line`, not the `params` like we wanted. :poop:
## Here's what we do

Instead of using `params`, we T4 Template some explicit overloads via template methods, similar to what we do in ReactiveUI in [VariadicTemplates.cs](https://github.com/reactiveui/ReactiveUI/blob/rxui6-master/ReactiveUI/VariadicTemplates.tt). Something like:

``` cs
public static void Warn<T0>(this ILogger log, string messageTemplate, T0 item0, [CallerFilePath] sourceFile = "", [CallerLineNumber] int line = 0);

public static void Warn<T0,T1>(this ILogger log, string messageTemplate, T0 item0, T1 item1, [CallerFilePath] sourceFile = "", [CallerLineNumber] int line = 0);
```

These are all Extension Methods, because they're super boring, and asking every implementer to implement 3 million methods that just proxy to another one is annoying. 
## TODO:
- [ ] Move most of the methods on `ILogger` onto an extension class that just proxies to `Write(LogEntry entry)`
- [ ] Create a T4 Template to render the overloads of Info / Warn / Etc
