### PR TITLE
Fix for issue #106

### DIFF
--- a/src/Serilog.Extras.AppSettings/Extras/AppSettings/PrefixedAppSettingsReader.cs
+++ b/src/Serilog.Extras.AppSettings/Extras/AppSettings/PrefixedAppSettingsReader.cs
@@ -22,11 +22,10 @@ using System.Text.RegularExpressions;
 using Serilog.Configuration;
 using Serilog.Events;
 using Serilog.Sinks.RollingFile;
+using System.ComponentModel;
 
 namespace Serilog.Extras.AppSettings
 {
-    using System.ComponentModel;
-
     class PrefixedAppSettingsReader
     {
         const string UsingDirective = "serilog:using";


### PR DESCRIPTION
Added ConvertTypeTo() function which supports extended type conversions for the AppSettings DSL -- currently, only Uri and TimeSpan, but easy to add additional.
