### PR TITLE
Added SelfLog.SendSelfLogToSink

### DIFF
--- a/src/Serilog/Debugging/SelfLog.cs
+++ b/src/Serilog/Debugging/SelfLog.cs
@@ -32,6 +32,11 @@ namespace Serilog.Debugging
         public static TextWriter Out { get; set; }
 
         /// <summary>
+        /// If true the self log will try to write to the sink(s).
+        /// </summary>
+        public static bool SendSelfLogToSink { get; set; }
+
+        /// <summary>
         /// Write a message to the self-log.
         /// </summary>
         /// <param name="format">Standard .NET format string containing the message.</param>
@@ -45,6 +50,29 @@ namespace Serilog.Debugging
             {
                 o.WriteLine(DateTime.Now.ToString("s") + " " + format, arg0, arg1, arg2);
                 o.Flush();
+            }
+
+            if (SendSelfLogToSink)
+            {
+                Exception ex = null;
+                if (arg0 is Exception)
+                    ex = (Exception)arg0;
+                if (arg1 is Exception)
+                    ex = (Exception)arg1;
+                if (arg2 is Exception)
+                    ex = (Exception)arg2;
+
+                if (ex != null)
+                {
+                    if (!ex.StackTrace.Contains("WriteLine"))
+                    {
+                        Log.Error(ex, string.Format(format, arg0, arg1, arg2));
+                    }
+                }
+                else
+                {
+                    Log.Error(string.Format(format, arg0, arg1, arg2));
+                }
             }
         }
     }


### PR DESCRIPTION
Hi

I love the concepts in Serilog and Seq and have been integrating the solution into one of my applications. When trying to make it really work I found the diagnostics part (ie. SelfLog) to be lacking something.
I configured SelfLog to write to a text file and then I ran my integration tests for the application. Here is a snippet of the SelfLog file after the integration test run:

2014-04-27T22:21:53 Maximium destructuring depth reached.
2014-04-27T22:21:53 The property accessor System.Web.SessionState.HttpSessionState Session threw exception System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation. ---> System.Web.HttpException: Session state is not available in this context.
   at System.Web.HttpApplication.get_Session()
   --- End of inner exception stack trace ---
   at System.RuntimeMethodHandle.InvokeMethod(Object target, Object[] arguments, Signature sig, Boolean constructor)
   at System.Reflection.RuntimeMethodInfo.UnsafeInvokeInternal(Object obj, Object[] parameters, Object[] arguments)
   at System.Reflection.RuntimeMethodInfo.Invoke(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
   at System.Reflection.RuntimePropertyInfo.GetValue(Object obj, Object[] index)
   at Serilog.Parameters.PropertyValueConverter.<GetProperties>d__11.MoveNext() in c:\TeamCity\buildAgent\work\6ef9c409c82c3cae\src\Serilog\Parameters\PropertyValueConverter.cs:line 187
2014-04-27T22:21:53 Maximium destructuring depth reached.
2014-04-27T22:21:53 Maximium destructuring depth reached.
2014-04-27T22:21:53 Maximium destructuring depth reached.

It is very hard to correlate these errors with anything in my code... so what to do ??...
It would be nice if I could get these kind of errors written to the configured Sinks. That would make it a lot easier to pinpoint which log lines in my code is generating these errors.
I realize that since SelfLog only has one WriteLine method it is used for all kinds of errors including "Not able to connect to the sink"-kind of errors. So just writting to the sink(s) from the WriteLine method could cause an infinite loop. This pull-request includes a naive atempt to avoid this infinite loop.

Another solution that requires a bit more work would be to make two "WriteLine" methods in the SelfLog: One for critical connection errors and one for more warning like errors, and then write the "warning like errors" to the sink(s).

What are your thoughts on this ?
