### PR TITLE
Initial roll-on-locked implementation for issue #93.

### DIFF
--- a/src/Serilog.FullNetFx/Serilog.FullNetFx.csproj
+++ b/src/Serilog.FullNetFx/Serilog.FullNetFx.csproj
@@ -58,6 +58,7 @@
     <Compile Include="Sinks\PeriodicBatching\PeriodicBatchingSink.cs" />
     <Compile Include="Sinks\RollingFile\Clock.cs" />
     <Compile Include="Sinks\RollingFile\RollingFileSink.cs" />
+    <Compile Include="Sinks\RollingFile\RollingLogFile.cs" />
     <Compile Include="Sinks\RollingFile\TemplatedPathRoller.cs" />
     <Compile Include="Sinks\SystemConsole\ColoredConsoleSink.cs" />
     <Compile Include="Sinks\SystemConsole\ConsoleSink.cs" />

--- a/src/Serilog.FullNetFx/Sinks/RollingFile/RollingFileSink.cs
+++ b/src/Serilog.FullNetFx/Sinks/RollingFile/RollingFileSink.cs
@@ -15,6 +15,7 @@
 using System;
 using System.IO;
 using System.Linq;
+using System.Runtime.InteropServices;
 using Serilog.Core;
 using Serilog.Debugging;
 using Serilog.Events;
@@ -106,12 +107,54 @@ namespace Serilog.Sinks.RollingFile
 
         void OpenFile(DateTime now)
         {
-            string path;
-            DateTime nextCheckpoint;
-            _roller.GetLogFilePath(now, out path, out nextCheckpoint);
-            _nextCheckpoint = nextCheckpoint;            
-            _currentFile = new FileSink(path, _textFormatter, _fileSizeLimitBytes);
-            ApplyRetentionPolicy(path);
+            var date = now.Date;
+
+            // We only take one attempt at it because repeated failures
+            // to open log files REALLY slow an app down.
+            _nextCheckpoint = date.AddDays(1);            
+
+            var existingFiles = Enumerable.Empty<string>();
+            try
+            {
+                existingFiles = Directory.GetFiles(_roller.LogFileDirectory, _roller.DirectorySearchPattern)
+                                         .Select(Path.GetFileName);
+            }
+            catch (DirectoryNotFoundException) { }
+
+            var latestForThisDate = _roller
+                .SelectMatches(existingFiles)
+                .Where(m => m.Date == date)
+                .OrderByDescending(m => m.SequenceNumber)
+                .FirstOrDefault();
+
+            var sequence = latestForThisDate != null ? latestForThisDate.SequenceNumber : 0;
+
+            const int maxAttempts = 3;
+            for (var attempt = 0; attempt < maxAttempts; attempt++)
+            {
+                string path;
+                _roller.GetLogFilePath(now, sequence, out path);
+
+                try
+                {
+                    _currentFile = new FileSink(path, _textFormatter, _fileSizeLimitBytes);
+                }
+                catch (IOException ex)
+                {
+                    var errorCode = Marshal.GetHRForException(ex) & ((1 << 16) - 1);
+                    if (errorCode == 32 || errorCode == 33)
+                    {
+                        SelfLog.WriteLine("Rolling file target {0} was locked, attempting to open next in sequence (attempt {1})", path, attempt + 1);
+                        sequence++;
+                        continue;
+                    }
+
+                    throw;
+                }
+
+                ApplyRetentionPolicy(path);
+                return;
+            }
         }
 
         void ApplyRetentionPolicy(string currentFilePath)
@@ -123,10 +166,15 @@ namespace Serilog.Sinks.RollingFile
             // We consider the current file to exist, even if nothing's been written yet,
             // because files are only opened on response to an event being processed.
             var potentialMatches = Directory.GetFiles(_roller.LogFileDirectory, _roller.DirectorySearchPattern)
-                .Union(new [] { currentFileName })
-                .Select(Path.GetFileName);
+                .Select(Path.GetFileName)
+                .Union(new [] { currentFileName });
 
-            var newestFirst = _roller.OrderMatchingByAge(potentialMatches);
+            var newestFirst = _roller
+                .SelectMatches(potentialMatches)
+                .OrderByDescending(m => m.Date)
+                .ThenByDescending(m => m.SequenceNumber)
+                .Select(m => m.Filename);
+
             var toRemove = newestFirst
                 .Where(n => StringComparer.OrdinalIgnoreCase.Compare(currentFileName, n) != 0)
                 .Skip(_retainedFileCountLimit.Value - 1)

--- a/src/Serilog.FullNetFx/Sinks/RollingFile/RollingLogFile.cs
+++ b/src/Serilog.FullNetFx/Sinks/RollingFile/RollingLogFile.cs
@@ -1,0 +1,33 @@
+using System;
+
+namespace Serilog.Sinks.RollingFile
+{
+    class RollingLogFile
+    {
+        readonly string _filename;
+        readonly DateTime _date;
+        readonly int _sequenceNumber;
+
+        public RollingLogFile(string filename, DateTime date, int sequenceNumber)
+        {
+            _filename = filename;
+            _date = date;
+            _sequenceNumber = sequenceNumber;
+        }
+
+        public string Filename
+        {
+            get { return _filename; }
+        }
+
+        public DateTime Date
+        {
+            get { return _date; }
+        }
+
+        public int SequenceNumber
+        {
+            get { return _sequenceNumber; }
+        }
+    }
+}

--- a/src/Serilog.FullNetFx/Sinks/RollingFile/TemplatedPathRoller.cs
+++ b/src/Serilog.FullNetFx/Sinks/RollingFile/TemplatedPathRoller.cs
@@ -14,8 +14,8 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
-using System.Linq;
 using System.Text.RegularExpressions;
 
 namespace Serilog.Sinks.RollingFile
@@ -23,15 +23,7 @@ namespace Serilog.Sinks.RollingFile
     // Rolls files based on the current date, using a path
     // formatting pattern like:
     //    Logs/log-{Date}.txt
-    // In future, additional rolling strategies should be able
-    // to be implemented using patterns like:
-    //    Logs/log-{Hour}.txt
-    //    Logs/log-{Minute}.txt
-    //    Logs/log-{Now:yyyyMMdd-HH:mm.SS}
-    // I.e. tokens in the log format, while not strictly equivalent
-    // to the message template DSL, permit different rolling
-    // strategies to be communicated without broadening
-    // the API or breaking consumers.
+    //
     class TemplatedPathRoller
     {
         const string OldStyleDateSpecifier = "{0}";
@@ -73,30 +65,58 @@ namespace Serilog.Sinks.RollingFile
             _filenameMatcher = new Regex(
                 "^" +
                 Regex.Escape(prefix) +
-                "\\d{" + DateFormat.Length + "}" + 
+                "(?<date>\\d{" + DateFormat.Length + "})" + 
+                "(?<inc>_[0-9]{3,}){0,1}" +
                 Regex.Escape(suffix) +
                 "$");
 
             _directorySearchPattern = filenameTemplate.Replace(DateSpecifier, "*");
             _directory = directory;
-            _pathTemplate = Path.Combine(_directory, filenameTemplate);            
+            _pathTemplate = Path.Combine(_directory, filenameTemplate); 
         }
 
         public string LogFileDirectory { get { return _directory; } }
 
         public string DirectorySearchPattern { get { return _directorySearchPattern; } }
 
-        public void GetLogFilePath(DateTime now, out string path, out DateTime nextCheckpoint)
+        public void GetLogFilePath(DateTime date, int sequenceNumber, out string path)
         {
-            path = _pathTemplate.Replace(DateSpecifier, now.Date.ToString(DateFormat));
-            nextCheckpoint = now.Date.AddDays(1);
+            var tok = date.ToString(DateFormat, CultureInfo.InvariantCulture);
+
+            if (sequenceNumber != 0)
+                tok += "_" + sequenceNumber.ToString("000", CultureInfo.InvariantCulture);
+
+            path = _pathTemplate.Replace(DateSpecifier, tok);
         }
 
-        public IEnumerable<string> OrderMatchingByAge(IEnumerable<string> fileNames)
+        public IEnumerable<RollingLogFile> SelectMatches(IEnumerable<string> filenames)
         {
-            return fileNames
-                .Where(fn => _filenameMatcher.IsMatch(fn))
-                .OrderByDescending(fn => fn);
+            foreach (var filename in filenames)
+            {
+                var match = _filenameMatcher.Match(filename);
+                if (match.Success)
+                {
+                    var inc = 0;
+                    var incGroup = match.Groups["inc"];
+                    if (incGroup.Captures.Count != 0)
+                    {
+                        var incPart = incGroup.Captures[0].Value.Substring(1);
+                        inc = int.Parse(incPart, CultureInfo.InvariantCulture);
+                    }
+
+                    DateTime date;
+                    var datePart = match.Groups["date"].Captures[0].Value;
+                    if (!DateTime.TryParseExact(
+                        datePart, 
+                        DateFormat, 
+                        CultureInfo.InvariantCulture, 
+                        DateTimeStyles.None,
+                        out date))
+                        continue;
+
+                    yield return new RollingLogFile(filename, date, inc);
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Detects file locking when opening rolling files, and if the file is locked, inserts a `_001`-style sequence number into the filename after the `{Date}` token.

To avoid the "next" opener writing to the original file after an increment is created, this change requires searching for existing increments each time a new file is opened. This is where any risk of destabilizing current rolling behavior will lie.

For #93.
