### PR TITLE
Added additional time in ms property to timing extension

### DIFF
--- a/src/Serilog.Extras.Timing/Extras/Timing/TimedOperation.cs
+++ b/src/Serilog.Extras.Timing/Extras/Timing/TimedOperation.cs
@@ -42,9 +42,9 @@ namespace Serilog.Extras.Timing
             _sw.Stop();
 
             if (_warnIfExceeds.HasValue && _sw.Elapsed > _warnIfExceeds.Value)
-                _logger.Write(LogEventLevel.Warning, "Operation {TimedOperationId}: {TimedOperationDescription} exceeded the limit of {WarningLimit} by completing in {TimedOperationElapsed}", _identifier, _description, _warnIfExceeds.Value, _sw.Elapsed);
+                _logger.Write(LogEventLevel.Warning, "Operation {TimedOperationId}: {TimedOperationDescription} exceeded the limit of {WarningLimit} by completing in {TimedOperationElapsed}  ({TimedOperationElapsedInMs} ms)", _identifier, _description, _warnIfExceeds.Value, _sw.Elapsed, _sw.ElapsedMilliseconds);
             else
-                _logger.Write(_level, "Completed operation {TimedOperationId}: {TimedOperationDescription} in {TimedOperationElapsed}", _identifier, _description, _sw.Elapsed);
+                _logger.Write(_level, "Completed operation {TimedOperationId}: {TimedOperationDescription} in {TimedOperationElapsed} ({TimedOperationElapsedInMs} ms)", _identifier, _description, _sw.Elapsed, _sw.ElapsedMilliseconds);
         }
     }
 }


### PR DESCRIPTION
Added additional time in ms property to timing extension so you can report on this value. The current time is readable but harder to run metrics on. So this is a non string representation. Useful with tools like ElasticSearch.
