### PR TITLE
Trace sink fix for Azure websites

### DIFF
--- a/src/Serilog.FullNetFx/Sinks/DiagnosticTrace/DiagnosticTraceSink.cs
+++ b/src/Serilog.FullNetFx/Sinks/DiagnosticTrace/DiagnosticTraceSink.cs
@@ -36,7 +36,7 @@ namespace Serilog.Sinks.DiagnosticTrace
             if (logEvent == null) throw new ArgumentNullException("logEvent");
             var sr = new StringWriter();
             _textFormatter.Format(logEvent, sr);
-            Trace.Write(sr.ToString());
+            Trace.WriteLine(sr.ToString().Trim());
         }
     }
 }


### PR DESCRIPTION
Trace.Write isn't picked up in Azure websites (even with newline at the end of the trace string).
But Trace.WriteLine is.
