### PR TITLE
Fix bug with Logentries handling of multi-line messages

### DIFF
--- a/src/Serilog.Sinks.Logentries/LoggerConfigurationLogentriesExtensions.cs
+++ b/src/Serilog.Sinks.Logentries/LoggerConfigurationLogentriesExtensions.cs
@@ -25,7 +25,7 @@ namespace Serilog
     public static class LoggerConfigurationLogentriesExtensions
     {
         const string DefaultLogentriesOutputTemplate = "{Timestamp:G} [{Level}] {Message}{NewLine}{Exception}";
-     
+
         /// <summary>
         /// Adds a sink that writes log events to the Logentries.com webservice. 
         /// Create a token TCP input for this on the logentries website. 
@@ -58,7 +58,7 @@ namespace Serilog
             var defaultedPeriod = period ?? LogentriesSink.DefaultPeriod;
 
             return loggerConfiguration.Sink(
-                new LogentriesSink(outputTemplate,formatProvider, token, useSsl, batchPostingLimit, defaultedPeriod),
+                new LogentriesSink(outputTemplate, formatProvider, token, useSsl, batchPostingLimit, defaultedPeriod),
                 restrictedToMinimumLevel);
         }
 

--- a/src/Serilog.Sinks.Logentries/Sinks/Logentries/LogentriesSink.cs
+++ b/src/Serilog.Sinks.Logentries/Sinks/Logentries/LogentriesSink.cs
@@ -33,10 +33,10 @@ namespace Serilog.Sinks.Logentries
     public class LogentriesSink : PeriodicBatchingSink
     {
         private readonly string _token;
-        private  bool _useSsl;
+        private bool _useSsl;
         private LeClient _client;
         readonly ITextFormatter _textFormatter;
-       
+
         /// <summary>
         /// UTF-8 output character set.
         /// </summary>
@@ -97,13 +97,20 @@ namespace Serilog.Sinks.Logentries
                 SelfLog.WriteLine("Unable to connect to Logentries API.", ex);
                 return;
             }
-            
+
             foreach (var logEvent in events)
             {
                 var renderSpace = new StringWriter();
                 _textFormatter.Format(logEvent, renderSpace);
-         
-                var finalLine = _token + renderSpace.ToString() + '\n';
+
+                string renderedString = renderSpace.ToString();
+
+                // LogEntries uses a NewLine character to determine the end of a log message
+                // this causes problems with stack traces.
+                if (!string.IsNullOrEmpty(renderedString))
+                    renderedString = renderedString.Replace("\n", "");
+
+                var finalLine = _token + renderedString + '\n';
 
                 byte[] data = UTF8.GetBytes(finalLine);
 


### PR DESCRIPTION
The LogEntries API uses a \n character as message a message terminator.  If a '\n' appears in a message (such as with a stack trace) then the remainder of the message will not be logged.
