### PR TITLE
Fixes #146 (I think)

### DIFF
--- a/src/Serilog.FullNetFx/LoggerConfigurationFullNetFxExtensions.cs
+++ b/src/Serilog.FullNetFx/LoggerConfigurationFullNetFxExtensions.cs
@@ -14,6 +14,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Globalization;
 using System.Threading;
 using Serilog.Configuration;
 using Serilog.Enrichers;
@@ -56,6 +57,7 @@ namespace Serilog
         {
             if (sinkConfiguration == null) throw new ArgumentNullException("sinkConfiguration");
             if (outputTemplate == null) throw new ArgumentNullException("outputTemplate");
+            formatProvider = formatProvider ?? CultureInfo.CurrentCulture;
             var formatter = new MessageTemplateTextFormatter(outputTemplate, formatProvider);
             return sinkConfiguration.Sink(new ConsoleSink(formatter), restrictedToMinimumLevel);
         }
@@ -79,6 +81,7 @@ namespace Serilog
         {
             if (sinkConfiguration == null) throw new ArgumentNullException("sinkConfiguration");
             if (outputTemplate == null) throw new ArgumentNullException("outputTemplate");
+            formatProvider = formatProvider ?? CultureInfo.CurrentCulture;
             return sinkConfiguration.Sink(new ColoredConsoleSink(outputTemplate, formatProvider), restrictedToMinimumLevel);
         }
 


### PR DESCRIPTION
You can't do `IFormatProvider formatProvider = CultureInfo.CurrentCulture` as it's not a compile time constant - hence this approach.
