### PR TITLE
Added Sink for Microsoft Application Insights for Visual Studio Online

### DIFF
--- a/Serilog.sln
+++ b/Serilog.sln
@@ -71,6 +71,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Serilog.Sinks.MSSqlServer",
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Serilog.Sinks.Raygun", "src\Serilog.Sinks.Raygun\Serilog.Sinks.Raygun.csproj", "{B4EEC1AD-6E2B-49F6-A4C0-A9D39E9C4EFA}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Serilog.Sinks.ApplicationInsights", "src\Serilog.Sinks.ApplicationInsights\Serilog.Sinks.ApplicationInsights.csproj", "{3F08FA19-8D51-427D-8CDA-965CF79B9ECF}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -193,6 +195,10 @@ Global
 		{B4EEC1AD-6E2B-49F6-A4C0-A9D39E9C4EFA}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B4EEC1AD-6E2B-49F6-A4C0-A9D39E9C4EFA}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B4EEC1AD-6E2B-49F6-A4C0-A9D39E9C4EFA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3F08FA19-8D51-427D-8CDA-965CF79B9ECF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3F08FA19-8D51-427D-8CDA-965CF79B9ECF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3F08FA19-8D51-427D-8CDA-965CF79B9ECF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3F08FA19-8D51-427D-8CDA-965CF79B9ECF}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -227,5 +233,6 @@ Global
 		{4F81EDAE-2E06-4024-925A-E495C852BDCF} = {0D135C0C-A60B-454A-A2F4-CD74A30E04B0}
 		{31C64BE9-4EF6-42D5-A811-D7D24613EEF6} = {037440DE-440B-4129-9F7A-09B42D00397E}
 		{B4EEC1AD-6E2B-49F6-A4C0-A9D39E9C4EFA} = {037440DE-440B-4129-9F7A-09B42D00397E}
+		{3F08FA19-8D51-427D-8CDA-965CF79B9ECF} = {037440DE-440B-4129-9F7A-09B42D00397E}
 	EndGlobalSection
 EndGlobal

--- a/packages/repositories.config
+++ b/packages/repositories.config
@@ -2,6 +2,7 @@
 <repositories>
   <repository path="..\src\Serilog.Extras.MSOwin\packages.config" />
   <repository path="..\src\Serilog.Extras.TopShelf\packages.config" />
+  <repository path="..\src\Serilog.Sinks.ApplicationInsights\packages.config" />
   <repository path="..\src\Serilog.Sinks.AzureTableStorage\packages.config" />
   <repository path="..\src\Serilog.Sinks.Couchbase\packages.config" />
   <repository path="..\src\Serilog.Sinks.ElasticSearch\packages.config" />

--- a/src/Serilog.Sinks.ApplicationInsights/LoggerConfigurationAzureTableStorageExtensions.cs
+++ b/src/Serilog.Sinks.ApplicationInsights/LoggerConfigurationAzureTableStorageExtensions.cs
@@ -1,0 +1,55 @@
+﻿// Copyright 2014 Serilog Contributors
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using Serilog.Configuration;
+using Serilog.Events;
+using Serilog.Sinks.ApplicationInsights;
+
+namespace Serilog
+{
+    /// <summary>
+    /// Adds the WriteTo.ApplicationInsights() extension method to <see cref="LoggerConfiguration"/>.
+    /// </summary>
+    public static class LoggerConfigurationApplicationInsightsExtensions
+    {
+        /// <summary>
+        /// Adds a sink that writes log events against Microsoft Application Insights for the provided component id.
+        /// </summary>
+        /// <param name="loggerConfiguration">The logger configuration.</param>
+        /// <param name="applicationInsightsComponentId">The ID that determines the application component under which your data appears in Application Insights.</param>
+        /// <param name="restrictedToMinimumLevel">The minimum log event level required in order to write an event to the sink.</param>
+        /// <param name="formatProvider">Supplies culture-specific formatting information, or null.</param>
+        /// <returns>
+        /// Logger configuration, allowing configuration to continue.
+        /// </returns>
+        /// <exception cref="System.ArgumentNullException">loggerConfiguration</exception>
+        /// <exception cref="ArgumentNullException">A required parameter is null.</exception>
+        public static LoggerConfiguration ApplicationInsights(
+            this LoggerSinkConfiguration loggerConfiguration,
+            string applicationInsightsComponentId,
+            LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
+            IFormatProvider formatProvider = null)
+        {
+            if (loggerConfiguration == null) throw new ArgumentNullException("loggerConfiguration");
+
+            if (applicationInsightsComponentId == null) throw new ArgumentNullException("applicationInsightsComponentId");
+            if (string.IsNullOrWhiteSpace(applicationInsightsComponentId)) throw new ArgumentOutOfRangeException("applicationInsightsComponentId", "Cannot be empty.");
+
+            return loggerConfiguration.Sink(
+                new ApplicationInsightsSink(applicationInsightsComponentId, formatProvider),
+                restrictedToMinimumLevel);
+        }
+    }
+}

--- a/src/Serilog.Sinks.ApplicationInsights/Properties/AssemblyInfo.cs
+++ b/src/Serilog.Sinks.ApplicationInsights/Properties/AssemblyInfo.cs
@@ -1,0 +1,14 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+
+[assembly: AssemblyTitle("Serilog.Sinks.ApplicationInsights")]
+[assembly: AssemblyDescription("Serilog sink for Microsoft Application Insights")]
+[assembly: AssemblyCopyright("Copyright © Serilog Contributors 2013")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]
+
+[assembly: InternalsVisibleTo("Serilog.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100fb8d13fd344a1c" +
+                                                       "6fe0fe83ef33c1080bf30690765bc6eb0df26ebfdf8f21670c64265b30db09f73a0dea5b3db4c9" +
+                                                       "d18dbf6d5a25af5ce9016f281014d79dc3b4201ac646c451830fc7e61a2dfd633d34c39f87b818" +
+                                                       "94191652df5ac63cc40c77f3542f702bda692e6e8a9158353df189007a49da0f3cfd55eb250066" +
+                                                       "b19485ec")]

--- a/src/Serilog.Sinks.ApplicationInsights/Serilog.Sinks.ApplicationInsights.csproj
+++ b/src/Serilog.Sinks.ApplicationInsights/Serilog.Sinks.ApplicationInsights.csproj
@@ -1,0 +1,102 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{3F08FA19-8D51-427D-8CDA-965CF79B9ECF}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Serilog</RootNamespace>
+    <AssemblyName>Serilog.Sinks.ApplicationInsights</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <DocumentationFile>bin\Debug\Serilog.Sinks.ApplicationInsights.xml</DocumentationFile>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <DocumentationFile>bin\Release\Serilog.Sinks.ApplicationInsights.XML</DocumentationFile>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+  </PropertyGroup>
+  <PropertyGroup>
+    <SignAssembly>true</SignAssembly>
+  </PropertyGroup>
+  <PropertyGroup>
+    <AssemblyOriginatorKeyFile>..\..\assets\Serilog.snk</AssemblyOriginatorKeyFile>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Microsoft.ApplicationInsights">
+      <HintPath>..\..\packages\Microsoft.ApplicationInsights.0.7.1\lib\net35\Microsoft.ApplicationInsights.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.ApplicationInsights.Tracing">
+      <HintPath>..\..\packages\Microsoft.ApplicationInsights.Tracing.0.7.1\lib\net35\Microsoft.ApplicationInsights.Tracing.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Diagnostics.Tracing.EventSource">
+      <HintPath>..\..\packages\Microsoft.Diagnostics.Tracing.EventSource.1.0.16\lib\net40\Microsoft.Diagnostics.Tracing.EventSource.dll</HintPath>
+    </Reference>
+    <Reference Include="Newtonsoft.Json, Version=4.5.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Newtonsoft.Json.5.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="LoggerConfigurationAzureTableStorageExtensions.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Sinks\ApplicationInsights\ApplicationInsightsDictionaryJsonConverter.cs" />
+    <Compile Include="Sinks\ApplicationInsights\ApplicationInsightsSink.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="..\..\assets\Serilog.snk">
+      <Link>Serilog.snk</Link>
+    </None>
+    <None Include="packages.config" />
+    <None Include="Serilog.Sinks.ApplicationInsights.nuspec">
+      <SubType>Designer</SubType>
+    </None>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Serilog.FullNetFx\Serilog.FullNetFx.csproj">
+      <Project>{7A9E1095-167D-402A-B43D-B36B97FF183D}</Project>
+      <Name>Serilog.FullNetFx</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\Serilog\Serilog.csproj">
+      <Project>{0915DBD9-0F7C-4439-8D9E-74C3D579B219}</Project>
+      <Name>Serilog</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="..\..\packages\Microsoft.Diagnostics.Tracing.EventRegister.1.0.16\tools\Microsoft.Diagnostics.Tracing.EventRegister.targets" Condition="Exists('..\..\packages\Microsoft.Diagnostics.Tracing.EventRegister.1.0.16\tools\Microsoft.Diagnostics.Tracing.EventRegister.targets')" />
+  <Target Name="EnsureEventRegisterImported" BeforeTargets="BeforeBuild" Condition="'$(EventRegisterImported)' == ''">
+    <Error Condition="!Exists('..\..\packages\Microsoft.Diagnostics.Tracing.EventRegister.1.0.16\tools\Microsoft.Diagnostics.Tracing.EventRegister.targets')" Text="This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=317567." HelpKeyword="BCLBUILD2001" />
+    <Error Condition="Exists('..\..\packages\Microsoft.Diagnostics.Tracing.EventRegister.1.0.16\tools\Microsoft.Diagnostics.Tracing.EventRegister.targets')" Text="The build restored NuGet packages. Build the project again to include these packages in the build. For more information, see http://go.microsoft.com/fwlink/?LinkID=317567." HelpKeyword="BCLBUILD2002" />
+  </Target>
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/src/Serilog.Sinks.ApplicationInsights/Serilog.Sinks.ApplicationInsights.nuspec
+++ b/src/Serilog.Sinks.ApplicationInsights/Serilog.Sinks.ApplicationInsights.nuspec
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+  <metadata>
+    <id>Serilog.Sinks.ApplicationInsights</id>
+    <version>0.1.0</version>
+    <authors>Joerg Battermann</authors>
+    <description>Serilog event sink that writes to Microsoft Application Insights for Visual Studio Online.</description>
+    <language>en-US</language>
+    <projectUrl>http://serilog.net</projectUrl>
+    <licenseUrl>http://www.apache.org/licenses/LICENSE-2.0</licenseUrl>
+    <iconUrl>http://serilog.net/images/serilog-nuget.png</iconUrl>
+    <tags>serilog logging azure</tags>
+    <dependencies>
+      <dependency id="Serilog" />
+      <dependency id="Microsoft.ApplicationInsights.Tracing" />
+    </dependencies>
+  </metadata>
+  <files>
+    <file src="src\Serilog.Sinks.ApplicationInsights\bin\Release\Serilog.Sinks.ApplicationInsights.dll" target="lib\net45" />
+    <file src="src\Serilog.Sinks.ApplicationInsights\bin\Release\Serilog.Sinks.ApplicationInsights.xml" target="lib\net45" />
+  </files>
+</package>

--- a/src/Serilog.Sinks.ApplicationInsights/Sinks/ApplicationInsights/ApplicationInsightsDictionaryJsonConverter.cs
+++ b/src/Serilog.Sinks.ApplicationInsights/Sinks/ApplicationInsights/ApplicationInsightsDictionaryJsonConverter.cs
@@ -1,0 +1,98 @@
+// Copyright 2013 Serilog Contributors
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using Microsoft.ApplicationInsights.Tracing.Serialization;
+using Newtonsoft.Json;
+
+namespace Serilog.Sinks.ApplicationInsights
+{
+    /// <summary>
+    /// Pipes JsonConversion through the Microsoft <see cref="DictionaryConverter"/>.
+    /// </summary>
+    public class ApplicationInsightsDictionaryJsonConverter : JsonConverter
+    {
+        /// <summary>
+        /// Gets the singleton instance. Not pretty, but simply adhering to the MS implementation style (as this is forwarding to it).
+        /// </summary>
+        /// <value>
+        /// The singleton instance.
+        /// </value>
+        public static ApplicationInsightsDictionaryJsonConverter Instance
+        {
+            get { return instance.Value; }
+        }
+
+        private static readonly Lazy<ApplicationInsightsDictionaryJsonConverter> instance = new Lazy<ApplicationInsightsDictionaryJsonConverter>(() => new ApplicationInsightsDictionaryJsonConverter());
+
+        /// <summary>
+        /// Prevents a default instance of the <see cref="ApplicationInsightsDictionaryJsonConverter"/> class from being created.
+        /// </summary>
+        private ApplicationInsightsDictionaryJsonConverter() { }
+
+        /// <summary>
+        /// Determines whether this instance can convert the specified object type.
+        /// </summary>
+        /// <param name="objectType">Type of the object.</param>
+        /// <returns>
+        /// <c>true</c> if this instance can convert the specified object type; otherwise, <c>false</c>.
+        /// </returns>
+        public override bool CanConvert(Type objectType)
+        {
+            return DictionaryConverter.Instance.CanConvert(objectType);
+        }
+
+        /// <summary>
+        /// Reads the JSON representation of the object.
+        /// </summary>
+        /// <param name="reader">The <see cref="T:Newtonsoft.Json.JsonReader" /> to read from.</param>
+        /// <param name="objectType">Type of the object.</param>
+        /// <param name="existingValue">The existing value of object being read.</param>
+        /// <param name="serializer">The calling serializer.</param>
+        /// <returns>
+        /// The object value.
+        /// </returns>
+        /// <exception cref="System.NotImplementedException">Dictionary de-serialization is not implemented.</exception>
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            throw new NotImplementedException("Dictionary de-serialization is not implemented.");
+        }
+
+        /// <summary>
+        /// Writes the JSON representation of the object.
+        /// </summary>
+        /// <param name="writer">The <see cref="T:Newtonsoft.Json.JsonWriter" /> to write to.</param>
+        /// <param name="value">The value.</param>
+        /// <param name="serializer">The calling serializer.</param>
+        /// <exception cref="System.ArgumentNullException">serializer</exception>
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            if (serializer == null) throw new ArgumentNullException("serializer");
+
+            bool flag = serializer.Converters.Remove(this);
+
+            try
+            {
+                ObjectConverter.Instance.WriteJson(writer, value, serializer);
+            }
+            finally
+            {
+                if (flag)
+                {
+                    serializer.Converters.Add(this);
+                }
+            }
+        }
+    }
+}

--- a/src/Serilog.Sinks.ApplicationInsights/Sinks/ApplicationInsights/ApplicationInsightsSink.cs
+++ b/src/Serilog.Sinks.ApplicationInsights/Sinks/ApplicationInsights/ApplicationInsightsSink.cs
@@ -1,0 +1,80 @@
+﻿// Copyright 2013 Serilog Contributors
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using Microsoft.ApplicationInsights.Tracing;
+using Newtonsoft.Json;
+using Serilog.Core;
+using Serilog.Events;
+
+namespace Serilog.Sinks.ApplicationInsights
+{
+    /// <summary>
+    /// Writes log events to a Microsoft Application Insights account. Inspired by their NLog Appender implementation.
+    /// </summary>
+    public class ApplicationInsightsSink : ILogEventSink, IDisposable
+    {
+        private readonly IFormatProvider _formatProvider;
+
+        /// <summary>
+        /// Holds the actual Application Insights Logging Controller
+        /// </summary>
+        private LoggingController _loggingController;
+        
+        /// <summary>
+        /// Construct a sink that saves logs to the specified storage account.
+        /// </summary>
+        /// <param name="applicationInsightsComponentId">The ID that determines the application component under which your data appears in Application Insights.</param>
+        /// <param name="formatProvider">Supplies culture-specific formatting information, or null.</param>
+        public ApplicationInsightsSink(string applicationInsightsComponentId, IFormatProvider formatProvider)
+        {
+            if (applicationInsightsComponentId == null) throw new ArgumentNullException("applicationInsightsComponentId");
+            if (string.IsNullOrWhiteSpace(applicationInsightsComponentId)) throw new ArgumentOutOfRangeException("applicationInsightsComponentId", "Cannot be empty.");
+
+            _formatProvider = formatProvider;
+
+            _loggingController = LoggingController.CreateLoggingController(applicationInsightsComponentId);
+        }
+        
+        #region Implementation of ILogEventSink
+
+        /// <summary>
+        /// Emit the provided log event to the sink.
+        /// </summary>
+        /// <param name="logEvent">The log event to write.</param>
+        public void Emit(LogEvent logEvent)
+        {
+            // this logs the message & its metadata to application insights
+            this._loggingController.LogMessageWithData(logEvent.RenderMessage(this._formatProvider), logEvent, new JsonConverter[] { ApplicationInsightsDictionaryJsonConverter.Instance });
+        }
+
+        #endregion
+
+        #region Implementation of IDisposable
+
+        /// <summary>
+        /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
+        /// </summary>
+        public void Dispose()
+        {
+            if (this._loggingController != null)
+            {
+                this._loggingController.Dispose();
+                this._loggingController = null;
+            }
+        }
+
+        #endregion
+    }
+}

--- a/src/Serilog.Sinks.ApplicationInsights/packages.config
+++ b/src/Serilog.Sinks.ApplicationInsights/packages.config
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.ApplicationInsights" version="0.7.1" targetFramework="net45" />
+  <package id="Microsoft.ApplicationInsights.Tracing" version="0.7.1" targetFramework="net45" />
+  <package id="Microsoft.Diagnostics.Tracing.EventRegister" version="1.0.16" targetFramework="net45" />
+  <package id="Microsoft.Diagnostics.Tracing.EventSource" version="1.0.16" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="5.0.8" targetFramework="net45" />
+</packages>


### PR DESCRIPTION
I've been using Serilog and MS's Application Insights in two different projects in the past but for a new one wanted to use both.. sooo I wrote a Sink for it. MS itself only provides NLog and log4net Appenders but both work internally the same.

I just ported the bits over to Serilog. Let me know what you think!

Cheers,
-Joerg
