### PR TITLE
Prefix ragun properties with Serilog$ to decrease likelyhood of key clas...

### DIFF
--- a/src/Serilog.Sinks.Raygun/Sinks/Raygun/RaygunSink.cs
+++ b/src/Serilog.Sinks.Raygun/Sinks/Raygun/RaygunSink.cs
@@ -68,8 +68,8 @@ namespace Serilog.Sinks.Raygun
                          .ToDictionary(a => a.Name, b => b.Value);
 
             // Add the message 
-            properties.Add("Serilog$Message", logEvent.RenderMessage(_formatProvider));
-            properties.Add("Serilog$MessageTemplate", logEvent.MessageTemplate.Text);
+            properties.Add("RenderedLogMessage", logEvent.RenderMessage(_formatProvider));
+            properties.Add("LogMessageTemplate", logEvent.MessageTemplate.Text);
 
             // Create new message
             var raygunMessage = new RaygunMessage


### PR DESCRIPTION
Hi,

I encountered an issue with duplicate keys when trying to destructure a template parameter called {@Message}. This is due to another parameter named message being added to the parameters sent to Raygun in the Raygun Sink. I've included a change to prefix the additional Message and MessageTemplate parameters with Serilog$. Although this does not completely solve the problem, it is a small/simple change that I feel will make key clashes less likely. A more permanent solution can be devised to be smarter about the Message and MessageTemplate property key generation, but a prefix is an OK stop gap I think. 
