### PR TITLE
Upgraded the elmah.io package

### DIFF
--- a/src/Serilog.Sinks.ElmahIO/Serilog.Sinks.ElmahIO.csproj
+++ b/src/Serilog.Sinks.ElmahIO/Serilog.Sinks.ElmahIO.csproj
@@ -44,8 +44,9 @@
     <Reference Include="Elmah">
       <HintPath>..\..\packages\elmah.corelibrary.1.2.2\lib\Elmah.dll</HintPath>
     </Reference>
-    <Reference Include="Elmah.Io">
-      <HintPath>..\..\packages\elmah.io.1.0.0.30\lib\net40\Elmah.Io.dll</HintPath>
+    <Reference Include="Elmah.Io, Version=1.0.0.30, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\elmah.io.core.1.0.0.38\lib\net40\Elmah.Io.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/src/Serilog.Sinks.ElmahIO/Serilog.Sinks.ElmahIO.nuspec
+++ b/src/Serilog.Sinks.ElmahIO/Serilog.Sinks.ElmahIO.nuspec
@@ -12,8 +12,8 @@
     <tags>serilog logging elmah elmah.io error</tags>
     <dependencies>
       <dependency id="Serilog" />
-      <dependency id="elmah.corelibrary" version="1.2.2"/>
-      <dependency id="elmah.io" version="1.0.0.30"  />
+      <dependency id="elmah.corelibrary" version="1.2.2" />
+      <dependency id="elmah.io.core" version="1.0.0.38" />
     </dependencies>
   </metadata>
   <files>

--- a/src/Serilog.Sinks.ElmahIO/packages.config
+++ b/src/Serilog.Sinks.ElmahIO/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="elmah.corelibrary" version="1.2.2" targetFramework="net45" />
-  <package id="elmah.io" version="1.0.0.30" targetFramework="net45" />
+  <package id="elmah.io.core" version="1.0.0.38" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
Replaced dependency from elmah.io package to elmah.io.core. The elmah.io package contain web.config transformations, which is not needed in this usage. I've also upgraded the package to the most recent version, which contains some nice bugfixes.
