### PR TITLE
Upgraded Topshelf to 3.1.122.0

### DIFF
--- a/src/Serilog.Extras.Topshelf/Serilog.Extras.Topshelf.csproj
+++ b/src/Serilog.Extras.Topshelf/Serilog.Extras.Topshelf.csproj
@@ -44,9 +44,9 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="Topshelf, Version=3.1.118.0, Culture=neutral, PublicKeyToken=b800c4cfcdeea87b, processorArchitecture=MSIL">
+    <Reference Include="Topshelf, Version=3.1.122.0, Culture=neutral, PublicKeyToken=b800c4cfcdeea87b, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Topshelf.3.1.2\lib\net40-full\Topshelf.dll</HintPath>
+      <HintPath>..\..\packages\Topshelf.3.1.3\lib\net40-full\Topshelf.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/src/Serilog.Extras.Topshelf/packages.config
+++ b/src/Serilog.Extras.Topshelf/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Topshelf" version="3.1.2" targetFramework="net45" />
+  <package id="Topshelf" version="3.1.3" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
Issue #182.

Upgrade Serilog.Extras.Topshelf to use Topshelf 3.1.122.0 instead of 3.1.118.0 to match current NuGet Topshelf release.
