### PR TITLE
Azure DocumentDB sink

### DIFF
--- a/Serilog.sln
+++ b/Serilog.sln
@@ -91,6 +91,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Serilog.Sinks.Splunk.FullNe
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Serilog.Sinks.Seq", "src\Serilog.Sinks.Seq\Serilog.Sinks.Seq.csproj", "{B6A720E1-732B-4B8B-868B-5914AF85983C}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Serilog.Sinks.AzureDocumentDb", "src\Serilog.Sinks.AzureDocumentDb\Serilog.Sinks.AzureDocumentDb.csproj", "{C1875BEA-4509-4E04-AB8F-C2F8169BF001}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -253,6 +255,10 @@ Global
 		{B6A720E1-732B-4B8B-868B-5914AF85983C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B6A720E1-732B-4B8B-868B-5914AF85983C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B6A720E1-732B-4B8B-868B-5914AF85983C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C1875BEA-4509-4E04-AB8F-C2F8169BF001}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C1875BEA-4509-4E04-AB8F-C2F8169BF001}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C1875BEA-4509-4E04-AB8F-C2F8169BF001}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C1875BEA-4509-4E04-AB8F-C2F8169BF001}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -297,5 +303,6 @@ Global
 		{13771374-CF5A-4955-BCDB-EBEFE70944B8} = {037440DE-440B-4129-9F7A-09B42D00397E}
 		{17DEED0F-F9CB-48FB-B4DC-53FB6AEE64D7} = {037440DE-440B-4129-9F7A-09B42D00397E}
 		{B6A720E1-732B-4B8B-868B-5914AF85983C} = {037440DE-440B-4129-9F7A-09B42D00397E}
+		{C1875BEA-4509-4E04-AB8F-C2F8169BF001} = {037440DE-440B-4129-9F7A-09B42D00397E}
 	EndGlobalSection
 EndGlobal

--- a/packages/repositories.config
+++ b/packages/repositories.config
@@ -3,6 +3,7 @@
   <repository path="..\src\Serilog.Extras.MSOwin\packages.config" />
   <repository path="..\src\Serilog.Extras.TopShelf\packages.config" />
   <repository path="..\src\Serilog.Sinks.ApplicationInsights\packages.config" />
+  <repository path="..\src\Serilog.Sinks.AzureDocumentDb\packages.config" />
   <repository path="..\src\Serilog.Sinks.AzureTableStorage\packages.config" />
   <repository path="..\src\Serilog.Sinks.Couchbase\packages.config" />
   <repository path="..\src\Serilog.Sinks.ElasticSearch\packages.config" />
@@ -16,6 +17,7 @@
   <repository path="..\src\Serilog.Sinks.NLog\packages.config" />
   <repository path="..\src\Serilog.Sinks.RavenDB\packages.config" />
   <repository path="..\src\Serilog.Sinks.Raygun\packages.config" />
+  <repository path="..\src\Serilog.Sinks.Seq\packages.config" />
   <repository path="..\src\Serilog.Sinks.SignalR\packages.config" />
   <repository path="..\src\Serilog.Sinks.Splunk.FullNetFx\packages.config" />
   <repository path="..\src\Serilog.Sinks.Splunk\packages.config" />

--- a/src/Serilog.Sinks.AzureDocumentDb/LoggerConfigurationAzureDocumentDbExtensions.cs
+++ b/src/Serilog.Sinks.AzureDocumentDb/LoggerConfigurationAzureDocumentDbExtensions.cs
@@ -1,0 +1,51 @@
+﻿// Copyright 2014 Serilog Contributors
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using Serilog.Configuration;
+using Serilog.Events;
+using Serilog.Sinks.AzureDocumentDb;
+
+namespace Serilog
+{
+    /// <summary>
+    /// Adds the WriteTo.AzureDocumentDb() extension method to <see cref="LoggerConfiguration"/>.
+    /// </summary>
+    public static class LoggerConfigurationAzureDocumentDbExtensions
+    {
+        /// <summary>
+        /// Adds a sink that writes log events to a Azure DocumentDB table in the provided endpoint.
+        /// </summary>
+        /// <param name="loggerConfiguration">The logger configuration.</param>
+        /// <param name="endpointUri">The endpoint URI of the document db.</param>
+        /// <param name="authorizationKey">The authorization key of the db.</param>
+        /// <param name="restrictedToMinimumLevel">The minimum log event level required in order to write an event to the sink.</param>
+        /// <param name="formatProvider">Supplies culture-specific formatting information, or null.</param>
+        /// <exception cref="ArgumentNullException">A required parameter is null.</exception>
+        public static LoggerConfiguration AzureDocumentDb(
+            this LoggerSinkConfiguration loggerConfiguration,
+            Uri endpointUri,
+            string authorizationKey,
+            LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
+            IFormatProvider formatProvider = null)
+        {
+            if (loggerConfiguration == null) throw new ArgumentNullException("loggerConfiguration");
+            if (endpointUri == null) throw new ArgumentNullException("endpointUri");
+            if (authorizationKey == null) throw new ArgumentNullException("authorizationKey");
+            return loggerConfiguration.Sink(
+                new AzureDocumentDbSink(endpointUri, authorizationKey, formatProvider),
+                restrictedToMinimumLevel);
+        }
+    }
+}

--- a/src/Serilog.Sinks.AzureDocumentDb/LoggerConfigurationAzureDocumentDbExtensions.cs
+++ b/src/Serilog.Sinks.AzureDocumentDb/LoggerConfigurationAzureDocumentDbExtensions.cs
@@ -30,6 +30,8 @@ namespace Serilog
         /// <param name="loggerConfiguration">The logger configuration.</param>
         /// <param name="endpointUri">The endpoint URI of the document db.</param>
         /// <param name="authorizationKey">The authorization key of the db.</param>
+        /// <param name="databaseName">The name of the database to use; will create if it doesn't exist.</param>
+        /// <param name="collectionName">The name of the collection to use inside the database; will created if it doesn't exist.</param>
         /// <param name="restrictedToMinimumLevel">The minimum log event level required in order to write an event to the sink.</param>
         /// <param name="formatProvider">Supplies culture-specific formatting information, or null.</param>
         /// <exception cref="ArgumentNullException">A required parameter is null.</exception>
@@ -37,6 +39,8 @@ namespace Serilog
             this LoggerSinkConfiguration loggerConfiguration,
             Uri endpointUri,
             string authorizationKey,
+            string databaseName = "Diagnostics",
+            string collectionName = "Logs",
             LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
             IFormatProvider formatProvider = null)
         {
@@ -44,7 +48,7 @@ namespace Serilog
             if (endpointUri == null) throw new ArgumentNullException("endpointUri");
             if (authorizationKey == null) throw new ArgumentNullException("authorizationKey");
             return loggerConfiguration.Sink(
-                new AzureDocumentDbSink(endpointUri, authorizationKey, formatProvider),
+                new AzureDocumentDbSink(endpointUri, authorizationKey, databaseName, collectionName, formatProvider),
                 restrictedToMinimumLevel);
         }
     }

--- a/src/Serilog.Sinks.AzureDocumentDb/Properties/AssemblyInfo.cs
+++ b/src/Serilog.Sinks.AzureDocumentDb/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Serilog.Sinks.AzureDocumentDb")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Serilog.Sinks.AzureDocumentDb")]
+[assembly: AssemblyCopyright("Copyright ©  2014")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("5c4f5dff-961d-4e1c-beab-e9aa9bbed76b")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/Serilog.Sinks.AzureDocumentDb/Serilog.Sinks.AzureDocumentDb.csproj
+++ b/src/Serilog.Sinks.AzureDocumentDb/Serilog.Sinks.AzureDocumentDb.csproj
@@ -1,0 +1,52 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{C1875BEA-4509-4E04-AB8F-C2F8169BF001}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Serilog</RootNamespace>
+    <AssemblyName>Serilog.Sinks.AzureDocumentDb</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/src/Serilog.Sinks.AzureDocumentDb/Serilog.Sinks.AzureDocumentDb.csproj
+++ b/src/Serilog.Sinks.AzureDocumentDb/Serilog.Sinks.AzureDocumentDb.csproj
@@ -29,7 +29,19 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
+  <PropertyGroup>
+    <SignAssembly>true</SignAssembly>
+  </PropertyGroup>
+  <PropertyGroup>
+    <AssemblyOriginatorKeyFile>..\..\assets\Serilog.snk</AssemblyOriginatorKeyFile>
+  </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Microsoft.Azure.Documents.Client">
+      <HintPath>..\..\packages\Microsoft.Azure.Documents.Client.0.9.0-preview\lib\net40\Microsoft.Azure.Documents.Client.dll</HintPath>
+    </Reference>
+    <Reference Include="Newtonsoft.Json, Version=4.5.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Newtonsoft.Json.4.5.11\lib\net40\Newtonsoft.Json.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
@@ -39,7 +51,24 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="LoggerConfigurationAzureDocumentDbExtensions.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Sinks\AzureDocumentDb\AzureDocumentDbSink.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="..\..\assets\Serilog.snk">
+      <Link>Serilog.snk</Link>
+    </None>
+    <None Include="packages.config" />
+    <None Include="Serilog.Sinks.AzureDocumentDb.nuspec">
+      <SubType>Designer</SubType>
+    </None>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Serilog\Serilog.csproj">
+      <Project>{0915dbd9-0f7c-4439-8d9e-74c3d579b219}</Project>
+      <Name>Serilog</Name>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/src/Serilog.Sinks.AzureDocumentDb/Serilog.Sinks.AzureDocumentDb.csproj
+++ b/src/Serilog.Sinks.AzureDocumentDb/Serilog.Sinks.AzureDocumentDb.csproj
@@ -54,6 +54,8 @@
     <Compile Include="LoggerConfigurationAzureDocumentDbExtensions.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Sinks\AzureDocumentDb\AzureDocumentDbSink.cs" />
+    <Compile Include="Sinks\AzureDocumentDb\Data\LogEvent.cs" />
+    <Compile Include="Sinks\AzureDocumentDb\DocumentDbPropertyFormatter.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\..\assets\Serilog.snk">

--- a/src/Serilog.Sinks.AzureDocumentDb/Serilog.Sinks.AzureDocumentDb.nuspec
+++ b/src/Serilog.Sinks.AzureDocumentDb/Serilog.Sinks.AzureDocumentDb.nuspec
@@ -16,7 +16,7 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="src\Serilog.Sinks.AzureDocumentDb\bin\Release\Serilog.Sinks.AzureDocumentDb\.dll" target="lib\net45" />
-    <file src="src\Serilog.Sinks.AzureDocumentDb\\bin\Release\Serilog.Sinks.AzureDocumentDb\.xml" target="lib\net45" />
+    <file src="src\Serilog.Sinks.AzureDocumentDb\bin\Release\Serilog.Sinks.AzureDocumentDb.dll" target="lib\net45" />
+    <file src="src\Serilog.Sinks.AzureDocumentDb\\bin\Release\Serilog.Sinks.AzureDocumentDb.xml" target="lib\net45" />
   </files>
 </package>

--- a/src/Serilog.Sinks.AzureDocumentDb/Serilog.Sinks.AzureDocumentDb.nuspec
+++ b/src/Serilog.Sinks.AzureDocumentDb/Serilog.Sinks.AzureDocumentDb.nuspec
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+  <metadata>
+    <id>Serilog.Sinks.AzureDocumentDb</id>
+    <version>0.1.0</version>
+    <authors>Robert Moore</authors>
+    <description>Serilog event sink that writes to Azure DocumentDB over HTTP.</description>
+    <language>en-US</language>
+    <projectUrl>http://serilog.net</projectUrl>
+    <licenseUrl>http://www.apache.org/licenses/LICENSE-2.0</licenseUrl>
+    <iconUrl>http://serilog.net/images/serilog-nuget.png</iconUrl>
+    <tags>serilog logging azure</tags>
+    <dependencies>
+      <dependency id="Serilog" />
+      <dependency id="Microsoft.Azure.Documents.Client" version="0.9.0" />
+    </dependencies>
+  </metadata>
+  <files>
+    <file src="src\Serilog.Sinks.AzureDocumentDb\bin\Release\Serilog.Sinks.AzureDocumentDb\.dll" target="lib\net45" />
+    <file src="src\Serilog.Sinks.AzureDocumentDb\\bin\Release\Serilog.Sinks.AzureDocumentDb\.xml" target="lib\net45" />
+  </files>
+</package>

--- a/src/Serilog.Sinks.AzureDocumentDb/Sinks/AzureDocumentDb/AzureDocumentDbSink.cs
+++ b/src/Serilog.Sinks.AzureDocumentDb/Sinks/AzureDocumentDb/AzureDocumentDbSink.cs
@@ -13,6 +13,10 @@
 // limitations under the License.
 
 using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Azure.Documents;
+using Microsoft.Azure.Documents.Client;
 using Serilog.Core;
 using Serilog.Events;
 
@@ -20,14 +24,51 @@ namespace Serilog.Sinks.AzureDocumentDb
 {
     public class AzureDocumentDbSink : ILogEventSink
     {
-        public AzureDocumentDbSink(Uri endpointUri, string authorizationKey, IFormatProvider formatProvider)
+        readonly IFormatProvider _formatProvider;
+        DocumentClient _client;
+        Database _database;
+        DocumentCollection _collection;
+
+        public AzureDocumentDbSink(Uri endpointUri, string authorizationKey, string databaseName, string collectionName, IFormatProvider formatProvider)
         {
-            throw new NotImplementedException();
+            _formatProvider = formatProvider;
+            _client = new DocumentClient(endpointUri, authorizationKey);
+            Task.WaitAll(new []{CreateDatabaseIfNotExistsAsync(databaseName)});
+            Task.WaitAll(new []{CreateCollectionIfNotExistsAsync(collectionName)});
         }
 
         public void Emit(LogEvent logEvent)
         {
-            throw new NotImplementedException();
+            Task.WaitAll(EmitAsync(logEvent));
+        }
+
+        private async Task CreateDatabaseIfNotExistsAsync(string databaseName)
+        {
+            _database = (await _client.ReadDatabaseFeedAsync())
+                .SingleOrDefault(d => d.Id == databaseName);
+
+            if (_database == null)
+                _database = await _client.CreateDatabaseAsync(new Database
+                {
+                    Id = databaseName
+                });
+        }
+
+        private async Task CreateCollectionIfNotExistsAsync(string collectionName)
+        {
+            _collection = (await _client.ReadDocumentCollectionFeedAsync(_database.CollectionsLink))
+                .SingleOrDefault(c => c.Id == collectionName);
+
+            if (_collection == null)
+                _collection = await _client.CreateDocumentCollectionAsync(_database.SelfLink, new DocumentCollection
+                {
+                    Id = collectionName
+                });
+        }
+
+        private Task EmitAsync(LogEvent logEvent)
+        {
+            return _client.CreateDocumentAsync(_collection.SelfLink, new Data.LogEvent(logEvent, logEvent.RenderMessage(_formatProvider)));
         }
     }
 }

--- a/src/Serilog.Sinks.AzureDocumentDb/Sinks/AzureDocumentDb/AzureDocumentDbSink.cs
+++ b/src/Serilog.Sinks.AzureDocumentDb/Sinks/AzureDocumentDb/AzureDocumentDbSink.cs
@@ -1,0 +1,33 @@
+﻿// Copyright 2014 Serilog Contributors
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using Serilog.Core;
+using Serilog.Events;
+
+namespace Serilog.Sinks.AzureDocumentDb
+{
+    public class AzureDocumentDbSink : ILogEventSink
+    {
+        public AzureDocumentDbSink(Uri endpointUri, string authorizationKey, IFormatProvider formatProvider)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Emit(LogEvent logEvent)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/Serilog.Sinks.AzureDocumentDb/Sinks/AzureDocumentDb/Data/LogEvent.cs
+++ b/src/Serilog.Sinks.AzureDocumentDb/Sinks/AzureDocumentDb/Data/LogEvent.cs
@@ -1,0 +1,80 @@
+﻿// Copyright 2014 Serilog Contributors
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using Serilog.Events;
+
+namespace Serilog.Sinks.AzureDocumentDb.Data
+{
+    /// <summary>
+    /// A wrapper class for <see cref="Events.LogEvent"/> that is used to store as a document in Azure DocumentDB.
+    /// </summary>
+    public class LogEvent
+    {
+        /// <summary>
+        /// Construct a new <see cref="LogEvent"/>.
+        /// </summary>
+        public LogEvent()
+        {
+        }
+
+        /// <summary>
+        /// Construct a new <see cref="LogEvent"/>.
+        /// </summary>
+        public LogEvent(Events.LogEvent logEvent, string renderedMessage)
+        {
+            Timestamp = logEvent.Timestamp;
+            Exception = logEvent.Exception;
+            MessageTemplate = logEvent.MessageTemplate.Text;
+            Level = logEvent.Level;
+            RenderedMessage = renderedMessage;
+            Properties = new Dictionary<string, object>();
+            foreach (var pair in logEvent.Properties)
+            {
+                Properties.Add(pair.Key, DocumentDbPropertyFormatter.Simplify(pair.Value));
+            }
+        }
+
+        /// <summary>
+        /// The time at which the event occurred.
+        /// </summary>
+        public DateTimeOffset Timestamp { get; set; }
+
+        /// <summary>
+        /// The template that was used for the log message.
+        /// </summary>
+        public string MessageTemplate { get; set; }
+
+        /// <summary>
+        /// The level of the log.
+        /// </summary>
+        public LogEventLevel Level { get; set; }
+
+        /// <summary>
+        /// A string representation of the exception that was attached to the log (if any).
+        /// </summary>
+        public Exception Exception { get; set; }
+
+        /// <summary>
+        /// The rendered log message.
+        /// </summary>
+        public string RenderedMessage { get; set; }
+
+        /// <summary>
+        /// Properties associated with the event, including those presented in <see cref="Events.LogEvent.MessageTemplate"/>.
+        /// </summary>
+        public IDictionary<string, object> Properties { get; set; }
+    }
+}

--- a/src/Serilog.Sinks.AzureDocumentDb/Sinks/AzureDocumentDb/DocumentDbPropertyFormatter.cs
+++ b/src/Serilog.Sinks.AzureDocumentDb/Sinks/AzureDocumentDb/DocumentDbPropertyFormatter.cs
@@ -1,0 +1,96 @@
+﻿// Copyright 2014 Serilog Contributors
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Serilog.Debugging;
+using Serilog.Events;
+
+namespace Serilog.Sinks.AzureDocumentDb
+{
+    /// <summary>
+    /// Converts <see cref="LogEventProperty"/> values into simple scalars,
+    /// dictionaries and lists so that they can be persisted in Azure DocumentDB.
+    /// </summary>
+    public static class DocumentDbPropertyFormatter
+    {
+        static readonly HashSet<Type> ScalarTypes = new HashSet<Type>
+        {
+            typeof(bool), typeof(byte), typeof(short), typeof(ushort), typeof(int), typeof(uint),
+            typeof(long), typeof(ulong), typeof(float), typeof(double), typeof(decimal), typeof(byte[])
+        }; 
+
+        /// <summary>
+        /// Simplify the object so as to make handling the serialized
+        /// representation easier.
+        /// </summary>
+        /// <param name="value">The value to simplify (possibly null).</param>
+        /// <returns>A simplified representation.</returns>
+        public static object Simplify(LogEventPropertyValue value)
+        {
+            var scalar = value as ScalarValue;
+            if (scalar != null)
+                return SimplifyScalar(scalar.Value);
+
+            var dict = value as DictionaryValue;
+            if (dict != null)
+            {
+                var result = new Dictionary<object, object>();
+                foreach (var element in dict.Elements)
+                {
+                    var key = SimplifyScalar(element.Key);
+                    if (result.ContainsKey(key))
+                    {
+                        SelfLog.WriteLine("The key {0} is not unique in the provided dictionary after simplification to {1}.", element.Key, key);
+                        return dict.Elements.Select(e => new Dictionary<string, object>
+                        {
+                            { "Key", SimplifyScalar(element.Key) },
+                            { "Value", Simplify(element.Value) }
+                        })
+                        .ToArray();
+                    }
+                    
+                    result.Add(key, Simplify(element.Value));
+                }
+                return result;
+            }
+
+            var seq = value as SequenceValue;
+            if (seq != null)
+                return seq.Elements.Select(Simplify).ToArray();
+
+            var str = value as StructureValue;
+            if (str != null)
+            {
+                var props = str.Properties.ToDictionary(p => p.Name, p => Simplify(p.Value));
+                if (str.TypeTag != null)
+                    props["$typeTag"] = str.TypeTag;
+                return props;
+            }
+
+            return null;
+        }
+        
+        static object SimplifyScalar(object value)
+        {
+            if (value == null) return null;
+
+            var valueType = value.GetType();
+            if (ScalarTypes.Contains(valueType)) return value;
+
+            return value.ToString();
+        }
+    }
+}

--- a/src/Serilog.Sinks.AzureDocumentDb/packages.config
+++ b/src/Serilog.Sinks.AzureDocumentDb/packages.config
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.Azure.Documents.Client" version="0.9.0-preview" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="4.5.11" targetFramework="net45" />
+</packages>


### PR DESCRIPTION
Notes:

* Not thoroughly tested yet
* Not batching yet although this should be possible to add using a stored proc as per http://azure.microsoft.com/en-us/documentation/articles/documentdb-get-started/
* The SDK is pre-release so likely to change over time - I wonder if we should lock the nuget dependency version for now to avoid later versions breaking this sink?