### PR TITLE
Fixed a bug in JsonFormatter

### DIFF
--- a/src/Serilog/Formatting/Json/JsonFormatter-net40.cs
+++ b/src/Serilog/Formatting/Json/JsonFormatter-net40.cs
@@ -88,7 +88,7 @@ namespace Serilog.Formatting.Json
                 { typeof(string), (v, q, w) => WriteString((string)v, w) },
                 { typeof(DateTime), (v, q, w) => WriteDateTime((DateTime)v, w) },
                 { typeof(DateTimeOffset), (v, q, w) => WriteOffset((DateTimeOffset)v, w) },
-                { typeof(ScalarValue), (v, q, w) => WriteLiteral(((ScalarValue)v).Value, w) },
+                { typeof(ScalarValue), (v, q, w) => WriteLiteral(((ScalarValue)v).Value, w, q) },
                 { typeof(SequenceValue), (v, q, w) => WriteSequence(((SequenceValue)v).Elements, w) },
                 { typeof(DictionaryValue), (v, q, w) => WriteDictionary(((DictionaryValue)v).Elements, w) },
                 { typeof(StructureValue), (v, q, w) => WriteStructure(((StructureValue)v).TypeTag, ((StructureValue)v).Properties, w) },

--- a/src/Serilog/Formatting/Json/JsonFormatter.cs
+++ b/src/Serilog/Formatting/Json/JsonFormatter.cs
@@ -88,7 +88,7 @@ namespace Serilog.Formatting.Json
                 { typeof(string), (v, q, w) => WriteString((string)v, w) },
                 { typeof(DateTime), (v, q, w) => WriteDateTime((DateTime)v, w) },
                 { typeof(DateTimeOffset), (v, q, w) => WriteOffset((DateTimeOffset)v, w) },
-                { typeof(ScalarValue), (v, q, w) => WriteLiteral(((ScalarValue)v).Value, w) },
+                { typeof(ScalarValue), (v, q, w) => WriteLiteral(((ScalarValue)v).Value, w, q) },
                 { typeof(SequenceValue), (v, q, w) => WriteSequence(((SequenceValue)v).Elements, w) },
                 { typeof(DictionaryValue), (v, q, w) => WriteDictionary(((DictionaryValue)v).Elements, w) },
                 { typeof(StructureValue), (v, q, w) => WriteStructure(((StructureValue)v).TypeTag, ((StructureValue)v).Properties, w) },


### PR DESCRIPTION
When JsonFormatter formats a dictionary of <int, object>, the key should be double quoted.

Current behavior:
new Dictionary<int, string> { { 1, "This is the value" } } => {1:"This is the value"}

Should be
new Dictionary<int, string> { { 1, "This is the value" } } => {"1":"This is the value"}
