### PR TITLE
Update NLogSink to map Verbose level to Trace level in NLog

### DIFF
--- a/src/Serilog.Sinks.NLog/Sinks/NLog/NLogSink.cs
+++ b/src/Serilog.Sinks.NLog/Sinks/NLog/NLogSink.cs
@@ -36,6 +36,8 @@ namespace Serilog.Sinks.NLog
             switch (logEvent.Level)
             {
                 case LogEventLevel.Verbose:
+                    logger.Trace(message, exception);
+                    break;
                 case LogEventLevel.Debug:
                     logger.Debug(message, exception);
                     break;
@@ -52,7 +54,7 @@ namespace Serilog.Sinks.NLog
                     logger.Fatal(message, exception);
                     break;
                 default:
-                    SelfLog.WriteLine("Unexpected logging level, writing to log4net as Info");
+                    SelfLog.WriteLine("Unexpected logging level, writing to NLog as Info");
                     logger.Info(message, exception);
                     break;
             }


### PR DESCRIPTION
Mapped Verbose level messages to Trace in NLog.  They are both the "lowest" or most verbose log level so they seem to map naturally: https://github.com/NLog/NLog/wiki/Log-levels.  If this was omitted intentionally I would be interested in the reasoning.  Also corrected the default log message which indicated log4net instead of NLog.
