### PR TITLE
Add static methods to differentiate message from message templates.

### DIFF
--- a/src/Serilog/Log.cs
+++ b/src/Serilog/Log.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014 Serilog Contributors
+// Copyright 2014 Serilog Contributors
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -20,28 +20,25 @@ using Serilog.Events;
 namespace Serilog
 {
     /// <summary>
-    /// An optional static entry point for logging that can be easily referenced
-    /// by different parts of an application. To configure the <see cref="Log"/>
-    /// set the Logger static property to a logger instance.
+    ///     An optional static entry point for logging that can be easily referenced
+    ///     by different parts of an application. To configure the <see cref="Log" />
+    ///     set the Logger static property to a logger instance.
     /// </summary>
     /// <example>
-    /// Log.Logger = new LoggerConfiguration()
+    ///     Log.Logger = new LoggerConfiguration()
     ///     .WithConsoleSink()
     ///     .CreateLogger();
-    /// 
-    /// var thing = "World";
-    /// Log.Logger.Information("Hello, {Thing}!", thing);
+    ///     var thing = "World";
+    ///     Log.Logger.Information("Hello, {Thing}!", thing);
     /// </example>
     /// <remarks>
-    /// The methods on <see cref="Log"/> (and its dynamic sibling <see cref="ILogger"/>) are guaranteed
-    /// never to throw exceptions. Methods on all other types may.
+    ///     The methods on <see cref="Log" /> (and its dynamic sibling <see cref="ILogger" />) are guaranteed
+    ///     never to throw exceptions. Methods on all other types may.
     /// </remarks>
     public static class Log
     {
-        static ILogger _logger = new SilentLogger();
-
         /// <summary>
-        /// The globally-shared logger.
+        ///     The globally-shared logger.
         /// </summary>
         /// <exception cref="ArgumentNullException"></exception>
         public static ILogger Logger
@@ -55,7 +52,7 @@ namespace Serilog
         }
 
         /// <summary>
-        /// Create a logger that enriches log events via the provided enrichers.
+        ///     Create a logger that enriches log events via the provided enrichers.
         /// </summary>
         /// <param name="enrichers">Enrichers that apply in the context.</param>
         /// <returns>A logger that will enrich log events as specified.</returns>
@@ -65,7 +62,7 @@ namespace Serilog
         }
 
         /// <summary>
-        /// Create a logger that enriches log events with the specified property.
+        ///     Create a logger that enriches log events with the specified property.
         /// </summary>
         /// <returns>A logger that will enrich log events as specified.</returns>
         public static ILogger ForContext(string propertyName, object value, bool destructureObjects = false)
@@ -74,8 +71,8 @@ namespace Serilog
         }
 
         /// <summary>
-        /// Create a logger that marks log events as being from the specified
-        /// source type.
+        ///     Create a logger that marks log events as being from the specified
+        ///     source type.
         /// </summary>
         /// <typeparam name="TSource">Type generating log messages in the context.</typeparam>
         /// <returns>A logger that will enrich log events as specified.</returns>
@@ -85,8 +82,8 @@ namespace Serilog
         }
 
         /// <summary>
-        /// Create a logger that marks log events as being from the specified
-        /// source type.
+        ///     Create a logger that marks log events as being from the specified
+        ///     source type.
         /// </summary>
         /// <param name="source">Type generating log messages in the context.</param>
         /// <returns>A logger that will enrich log events as specified.</returns>
@@ -96,7 +93,7 @@ namespace Serilog
         }
 
         /// <summary>
-        /// Write an event to the log.
+        ///     Write an event to the log.
         /// </summary>
         /// <param name="logEvent">The event to write.</param>
         public static void Write(LogEvent logEvent)
@@ -105,7 +102,7 @@ namespace Serilog
         }
 
         /// <summary>
-        /// Write a log event with the specified level.
+        ///     Write a log event with the specified level.
         /// </summary>
         /// <param name="level">The level of the event.</param>
         /// <param name="messageTemplate"></param>
@@ -116,7 +113,7 @@ namespace Serilog
         }
 
         /// <summary>
-        /// Write a log event with the specified level and associated exception.
+        ///     Write a log event with the specified level and associated exception.
         /// </summary>
         /// <param name="level">The level of the event.</param>
         /// <param name="exception">Exception related to the event.</param>
@@ -128,8 +125,8 @@ namespace Serilog
         }
 
         /// <summary>
-        /// Determine if events at the specified level will be passed through
-        /// to the log sinks.
+        ///     Determine if events at the specified level will be passed through
+        ///     to the log sinks.
         /// </summary>
         /// <param name="level">Level to check.</param>
         /// <returns>True if the level is enabled; otherwise, false.</returns>
@@ -139,12 +136,167 @@ namespace Serilog
         }
 
         /// <summary>
-        /// Write a log event with the <see cref="LogEventLevel.Verbose"/> level and associated exception.
+        ///     Write a log event with the <see cref="LogEventLevel.Verbose" /> level and associated exception.
+        /// </summary>
+        /// <param name="message">Simple text message describing the event.</param>
+        /// <example>
+        ///     Log.Verbose("Staring into space, wondering where this comet came from.");
+        /// </example>
+        public static void Verbose(string message)
+        {
+            Logger.Verbose(stringTemplate, message);
+        }
+
+        /// <summary>
+        ///     Write a log event with the <see cref="LogEventLevel.Verbose" /> level and associated exception.
+        /// </summary>
+        /// <param name="exception">Exception related to the event.</param>
+        /// <param name="message">Simple text message describing the event.</param>
+        /// <example>
+        ///     Log.Verbose(ex, "Staring into space, wondering where this comet came from.");
+        /// </example>
+        public static void Verbose(Exception exception, string message)
+        {
+            Logger.Verbose(exception, stringTemplate, message);
+        }
+
+
+        /// <summary>
+        ///     Write a log event with the <see cref="LogEventLevel.Debug" /> level and associated exception.
+        /// </summary>
+        /// <param name="message">Simple text message describing the event.</param>
+        /// <example>
+        ///     Log.Debug("Staring into space, wondering where this comet came from.");
+        /// </example>
+        public static void Debug(string message)
+        {
+            Logger.Debug(stringTemplate, message);
+        }
+
+        /// <summary>
+        ///     Write a log event with the <see cref="LogEventLevel.Debug" /> level and associated exception.
+        /// </summary>
+        /// <param name="exception">Exception related to the event.</param>
+        /// <param name="message">Simple text message describing the event.</param>
+        /// <example>
+        ///     Log.Debug(ex, "Staring into space, wondering where this comet came from.");
+        /// </example>
+        public static void Debug(Exception exception, string message)
+        {
+            Logger.Debug(exception, stringTemplate, message);
+        }
+
+
+        /// <summary>
+        ///     Write a log event with the <see cref="LogEventLevel.Information" /> level and associated exception.
+        /// </summary>
+        /// <param name="message">Simple text message describing the event.</param>
+        /// <example>
+        ///     Log.Information("Staring into space, wondering where this comet came from.");
+        /// </example>
+        public static void Information(string message)
+        {
+            Logger.Information(stringTemplate, message);
+        }
+
+        /// <summary>
+        ///     Write a log event with the <see cref="LogEventLevel.Information" /> level and associated exception.
+        /// </summary>
+        /// <param name="exception">Exception related to the event.</param>
+        /// <param name="message">Simple text message describing the event.</param>
+        /// <example>
+        ///     Log.Information(ex, "Staring into space, wondering where this comet came from.");
+        /// </example>
+        public static void Information(Exception exception, string message)
+        {
+            Logger.Information(exception, stringTemplate, message);
+        }
+
+
+        /// <summary>
+        ///     Write a log event with the <see cref="LogEventLevel.Warning" /> level and associated exception.
+        /// </summary>
+        /// <param name="message">Simple text message describing the event.</param>
+        /// <example>
+        ///     Log.Warning("Staring into space, wondering where this comet came from.");
+        /// </example>
+        public static void Warning(string message)
+        {
+            Logger.Warning(stringTemplate, message);
+        }
+
+        /// <summary>
+        ///     Write a log event with the <see cref="LogEventLevel.Warning" /> level and associated exception.
+        /// </summary>
+        /// <param name="exception">Exception related to the event.</param>
+        /// <param name="message">Simple text message describing the event.</param>
+        /// <example>
+        ///     Log.Warning(ex, "Staring into space, wondering where this comet came from.");
+        /// </example>
+        public static void Warning(Exception exception, string message)
+        {
+            Logger.Warning(exception, stringTemplate, message);
+        }
+
+
+        /// <summary>
+        ///     Write a log event with the <see cref="LogEventLevel.Error" /> level and associated exception.
+        /// </summary>
+        /// <param name="message">Simple text message describing the event.</param>
+        /// <example>
+        ///     Log.Error("Staring into space, wondering where this comet came from.");
+        /// </example>
+        public static void Error(string message)
+        {
+            Logger.Error(stringTemplate, message);
+        }
+
+        /// <summary>
+        ///     Write a log event with the <see cref="LogEventLevel.Error" /> level and associated exception.
+        /// </summary>
+        /// <param name="exception">Exception related to the event.</param>
+        /// <param name="message">Simple text message describing the event.</param>
+        /// <example>
+        ///     Log.Error(ex, "Staring into space, wondering where this comet came from.");
+        /// </example>
+        public static void Error(Exception exception, string message)
+        {
+            Logger.Error(exception, stringTemplate, message);
+        }
+
+
+        /// <summary>
+        ///     Write a log event with the <see cref="LogEventLevel.Fatal" /> level and associated exception.
+        /// </summary>
+        /// <param name="message">Simple text message describing the event.</param>
+        /// <example>
+        ///     Log.Fatal("Staring into space, wondering where this comet came from.");
+        /// </example>
+        public static void Fatal(string message)
+        {
+            Logger.Fatal(stringTemplate, message);
+        }
+
+        /// <summary>
+        ///     Write a log event with the <see cref="LogEventLevel.Fatal" /> level and associated exception.
+        /// </summary>
+        /// <param name="exception">Exception related to the event.</param>
+        /// <param name="message">Simple text message describing the event.</param>
+        /// <example>
+        ///     Log.Fatal(ex, "Staring into space, wondering where this comet came from.");
+        /// </example>
+        public static void Fatal(Exception exception, string message)
+        {
+            Logger.Fatal(exception, stringTemplate, message);
+        }
+
+        /// <summary>
+        ///     Write a log event with the <see cref="LogEventLevel.Verbose" /> level and associated exception.
         /// </summary>
         /// <param name="messageTemplate">Message template describing the event.</param>
         /// <param name="propertyValues">Objects positionally formatted into the message template.</param>
         /// <example>
-        /// Log.Verbose("Staring into space, wondering if we're alone.");
+        ///     Log.Verbose("Staring into space, wondering if we're alone.");
         /// </example>
         public static void Verbose(string messageTemplate, params object[] propertyValues)
         {
@@ -152,26 +304,28 @@ namespace Serilog
         }
 
         /// <summary>
-        /// Write a log event with the <see cref="LogEventLevel.Verbose"/> level and associated exception.
+        ///     Write a log event with the <see cref="LogEventLevel.Verbose" /> level and associated exception.
         /// </summary>
         /// <param name="exception">Exception related to the event.</param>
         /// <param name="messageTemplate">Message template describing the event.</param>
         /// <param name="propertyValues">Objects positionally formatted into the message template.</param>
         /// <example>
-        /// Log.Verbose(ex, "Staring into space, wondering where this comet came from.");
+        ///     Log.Verbose(ex, "Staring into space, wondering where this comet came from.");
         /// </example>
         public static void Verbose(Exception exception, string messageTemplate, params object[] propertyValues)
         {
             Logger.Verbose(exception, messageTemplate, propertyValues);
         }
 
+
+
         /// <summary>
-        /// Write a log event with the <see cref="LogEventLevel.Debug"/> level and associated exception.
+        ///     Write a log event with the <see cref="LogEventLevel.Debug" /> level and associated exception.
         /// </summary>
         /// <param name="messageTemplate">Message template describing the event.</param>
         /// <param name="propertyValues">Objects positionally formatted into the message template.</param>
         /// <example>
-        /// Log.Debug("Starting up at {StartedAt}.", DateTime.Now);
+        ///     Log.Debug("Starting up at {StartedAt}.", DateTime.Now);
         /// </example>
         public static void Debug(string messageTemplate, params object[] propertyValues)
         {
@@ -179,13 +333,13 @@ namespace Serilog
         }
 
         /// <summary>
-        /// Write a log event with the <see cref="LogEventLevel.Debug"/> level and associated exception.
+        ///     Write a log event with the <see cref="LogEventLevel.Debug" /> level and associated exception.
         /// </summary>
         /// <param name="exception">Exception related to the event.</param>
         /// <param name="messageTemplate">Message template describing the event.</param>
         /// <param name="propertyValues">Objects positionally formatted into the message template.</param>
         /// <example>
-        /// Log.Debug(ex, "Swallowing a mundane exception.");
+        ///     Log.Debug(ex, "Swallowing a mundane exception.");
         /// </example>
         public static void Debug(Exception exception, string messageTemplate, params object[] propertyValues)
         {
@@ -193,12 +347,12 @@ namespace Serilog
         }
 
         /// <summary>
-        /// Write a log event with the <see cref="LogEventLevel.Information"/> level and associated exception.
+        ///     Write a log event with the <see cref="LogEventLevel.Information" /> level and associated exception.
         /// </summary>
         /// <param name="messageTemplate">Message template describing the event.</param>
         /// <param name="propertyValues">Objects positionally formatted into the message template.</param>
         /// <example>
-        /// Log.Information("Processed {RecordCount} records in {TimeMS}.", records.Length, sw.ElapsedMilliseconds);
+        ///     Log.Information("Processed {RecordCount} records in {TimeMS}.", records.Length, sw.ElapsedMilliseconds);
         /// </example>
         public static void Information(string messageTemplate, params object[] propertyValues)
         {
@@ -206,13 +360,13 @@ namespace Serilog
         }
 
         /// <summary>
-        /// Write a log event with the <see cref="LogEventLevel.Information"/> level and associated exception.
+        ///     Write a log event with the <see cref="LogEventLevel.Information" /> level and associated exception.
         /// </summary>
         /// <param name="exception">Exception related to the event.</param>
         /// <param name="messageTemplate">Message template describing the event.</param>
         /// <param name="propertyValues">Objects positionally formatted into the message template.</param>
         /// <example>
-        /// Log.Information(ex, "Processed {RecordCount} records in {TimeMS}.", records.Length, sw.ElapsedMilliseconds);
+        ///     Log.Information(ex, "Processed {RecordCount} records in {TimeMS}.", records.Length, sw.ElapsedMilliseconds);
         /// </example>
         public static void Information(Exception exception, string messageTemplate, params object[] propertyValues)
         {
@@ -220,12 +374,12 @@ namespace Serilog
         }
 
         /// <summary>
-        /// Write a log event with the <see cref="LogEventLevel.Warning"/> level and associated exception.
+        ///     Write a log event with the <see cref="LogEventLevel.Warning" /> level and associated exception.
         /// </summary>
         /// <param name="messageTemplate">Message template describing the event.</param>
         /// <param name="propertyValues">Objects positionally formatted into the message template.</param>
         /// <example>
-        /// Log.Warning("Skipped {SkipCount} records.", skippedRecords.Length);
+        ///     Log.Warning("Skipped {SkipCount} records.", skippedRecords.Length);
         /// </example>
         public static void Warning(string messageTemplate, params object[] propertyValues)
         {
@@ -233,13 +387,13 @@ namespace Serilog
         }
 
         /// <summary>
-        /// Write a log event with the <see cref="LogEventLevel.Warning"/> level and associated exception.
+        ///     Write a log event with the <see cref="LogEventLevel.Warning" /> level and associated exception.
         /// </summary>
         /// <param name="exception">Exception related to the event.</param>
         /// <param name="messageTemplate">Message template describing the event.</param>
         /// <param name="propertyValues">Objects positionally formatted into the message template.</param>
         /// <example>
-        /// Log.Warning(ex, "Skipped {SkipCount} records.", skippedRecords.Length);
+        ///     Log.Warning(ex, "Skipped {SkipCount} records.", skippedRecords.Length);
         /// </example>
         public static void Warning(Exception exception, string messageTemplate, params object[] propertyValues)
         {
@@ -247,12 +401,12 @@ namespace Serilog
         }
 
         /// <summary>
-        /// Write a log event with the <see cref="LogEventLevel.Error"/> level and associated exception.
+        ///     Write a log event with the <see cref="LogEventLevel.Error" /> level and associated exception.
         /// </summary>
         /// <param name="messageTemplate">Message template describing the event.</param>
         /// <param name="propertyValues">Objects positionally formatted into the message template.</param>
         /// <example>
-        /// Log.Error("Failed {ErrorCount} records.", brokenRecords.Length);
+        ///     Log.Error("Failed {ErrorCount} records.", brokenRecords.Length);
         /// </example>
         public static void Error(string messageTemplate, params object[] propertyValues)
         {
@@ -260,13 +414,13 @@ namespace Serilog
         }
 
         /// <summary>
-        /// Write a log event with the <see cref="LogEventLevel.Error"/> level and associated exception.
+        ///     Write a log event with the <see cref="LogEventLevel.Error" /> level and associated exception.
         /// </summary>
         /// <param name="exception">Exception related to the event.</param>
         /// <param name="messageTemplate">Message template describing the event.</param>
         /// <param name="propertyValues">Objects positionally formatted into the message template.</param>
         /// <example>
-        /// Log.Error(ex, "Failed {ErrorCount} records.", brokenRecords.Length);
+        ///     Log.Error(ex, "Failed {ErrorCount} records.", brokenRecords.Length);
         /// </example>
         public static void Error(Exception exception, string messageTemplate, params object[] propertyValues)
         {
@@ -274,12 +428,12 @@ namespace Serilog
         }
 
         /// <summary>
-        /// Write a log event with the <see cref="LogEventLevel.Fatal"/> level and associated exception.
+        ///     Write a log event with the <see cref="LogEventLevel.Fatal" /> level and associated exception.
         /// </summary>
         /// <param name="messageTemplate">Message template describing the event.</param>
         /// <param name="propertyValues">Objects positionally formatted into the message template.</param>
         /// <example>
-        /// Log.Fatal("Process terminating.");
+        ///     Log.Fatal("Process terminating.");
         /// </example>
         public static void Fatal(string messageTemplate, params object[] propertyValues)
         {
@@ -287,17 +441,20 @@ namespace Serilog
         }
 
         /// <summary>
-        /// Write a log event with the <see cref="LogEventLevel.Fatal"/> level and associated exception.
+        ///     Write a log event with the <see cref="LogEventLevel.Fatal" /> level and associated exception.
         /// </summary>
         /// <param name="exception">Exception related to the event.</param>
         /// <param name="messageTemplate">Message template describing the event.</param>
         /// <param name="propertyValues">Objects positionally formatted into the message template.</param>
         /// <example>
-        /// Log.Fatal(ex, "Process terminating.");
+        ///     Log.Fatal(ex, "Process terminating.");
         /// </example>
         public static void Fatal(Exception exception, string messageTemplate, params object[] propertyValues)
         {
             Logger.Fatal(exception, messageTemplate, propertyValues);
         }
+
+        const string stringTemplate = "{_}";
+        static ILogger _logger = new SilentLogger();
     }
 }


### PR DESCRIPTION
Ideally, everything Serilog methods take are message templates, which is great! But more often than not, we do have to end up writing simple text messages, like 

```
Log.Information("That is complete!");
```

The problem with this, is that message templates are cached internally, and hence, adds pressure and reduces performance, being a different string each time. Using message templates is the best practice, but for the simplest of the situations, this ends up being counter-intuitive. 

**Solution**: Pass all the text without parameters into the same template "{_}" so that it always uses that specific cached template, and pass the text as a parameter, thereby also having the ability to pass simple strings without the performance hit.
