### PR TITLE
IncludeFieldsWhenDestructuringAttribute for inclusive field destructuring

### DIFF
--- a/src/Serilog.Extras.Attributed/Extras/Attributed/IncludeFieldsWhenDestructuringAttribute.cs
+++ b/src/Serilog.Extras.Attributed/Extras/Attributed/IncludeFieldsWhenDestructuringAttribute.cs
@@ -1,0 +1,26 @@
+﻿// Copyright 2014 Serilog Contributors
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+
+namespace Serilog.Extras.Attributed
+{
+    /// <summary>
+    /// Specifies that fields should be included when destructuring
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class)]
+    public class IncludeFieldsWhenDestructuringAttribute : Attribute
+    {
+    }
+}

--- a/src/Serilog.Extras.Attributed/Serilog.Extras.Attributed.csproj
+++ b/src/Serilog.Extras.Attributed/Serilog.Extras.Attributed.csproj
@@ -57,6 +57,7 @@
       <Link>Extras\Attributed\GetablePropertyFinder.cs</Link>
     </Compile>
     <Compile Include="Extras\Attributed\AttributedDestructuringPolicy.cs" />
+    <Compile Include="Extras\Attributed\IncludeFieldsWhenDestructuringAttribute.cs" />
     <Compile Include="Extras\Attributed\NotLoggedAttribute.cs" />
     <Compile Include="Extras\Attributed\LogAsScalarAttribute.cs" />
     <Compile Include="LoggerConfigurationAttributedExtensions.cs" />


### PR DESCRIPTION
Still a WIP, but below is the basic usage...

```csharp
class Program
    {
        static void Main(string[] args)
        {
            var logger = new LoggerConfiguration()
                .Destructure.UsingAttributes()
                .WriteTo.ColoredConsole()
                .CreateLogger();

            var record = new RecordWithFields {FieldA = "A"};
            logger.Information("Logging {@record}", record);
        }
    }

    [IncludeFieldsWhenDestructuring]
    class RecordWithFields
    {
        public string FieldA;
    }
```