### PR TITLE
#277 Changing ElasticSearchSink json parser to Json.Net

### DIFF
--- a/src/Serilog.Sinks.ElasticSearch/Serilog.Sinks.ElasticSearch.csproj
+++ b/src/Serilog.Sinks.ElasticSearch/Serilog.Sinks.ElasticSearch.csproj
@@ -48,7 +48,13 @@
   <ItemGroup>
     <Reference Include="Elasticsearch.Net, Version=1.0.0.0, Culture=neutral, PublicKeyToken=96c599bbe3e70f5d, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Elasticsearch.Net.1.1.2\lib\Elasticsearch.Net.dll</HintPath>
+      <HintPath>..\..\packages\Elasticsearch.Net.1.2.3\lib\Elasticsearch.Net.dll</HintPath>
+    </Reference>
+    <Reference Include="Elasticsearch.Net.JsonNet">
+      <HintPath>..\..\packages\Elasticsearch.Net.JsonNET.1.2.3\lib\Elasticsearch.Net.JsonNet.dll</HintPath>
+    </Reference>
+    <Reference Include="Newtonsoft.Json">
+      <HintPath>..\..\packages\Newtonsoft.Json.6.0.6\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.Composition" />

--- a/src/Serilog.Sinks.ElasticSearch/Serilog.Sinks.ElasticSearch.nuspec
+++ b/src/Serilog.Sinks.ElasticSearch/Serilog.Sinks.ElasticSearch.nuspec
@@ -12,7 +12,9 @@
     <tags>serilog logging elasticsearch</tags>
     <dependencies>
       <dependency id="Serilog" />
-      <dependency id="Elasticsearch.Net" version="1.1.2" />
+      <dependency id="Elasticsearch.Net" version="1.2.3" />
+      <dependency id="Elasticsearch.Net.JsonNET" version="1.2.3" />
+      <dependency id="Newtonsoft.Json" version="6.0.6" />
     </dependencies>
   </metadata>
   <files>

--- a/src/Serilog.Sinks.ElasticSearch/Sinks/ElasticSearch/ElasticSearchSink.cs
+++ b/src/Serilog.Sinks.ElasticSearch/Sinks/ElasticSearch/ElasticSearchSink.cs
@@ -19,7 +19,7 @@ using Elasticsearch.Net;
 using Elasticsearch.Net.Connection;
 using Serilog.Events;
 using Serilog.Sinks.PeriodicBatching;
-using System.Text;
+using Elasticsearch.Net.JsonNet;
 
 namespace Serilog.Sinks.ElasticSearch
 {
@@ -65,7 +65,7 @@ namespace Serilog.Sinks.ElasticSearch
         {
 			_indexFormat = indexFormat;
             _formatProvider = formatProvider;
-			_client = new ElasticsearchClient(connectionConfiguration);
+			_client = new ElasticsearchClient(connectionConfiguration, serializer: new ElasticsearchJsonNetSerializer());
         }
 
         /// <summary>

--- a/src/Serilog.Sinks.ElasticSearch/packages.config
+++ b/src/Serilog.Sinks.ElasticSearch/packages.config
@@ -1,4 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Elasticsearch.Net" version="1.1.2" targetFramework="net45" />
+  <package id="Elasticsearch.Net" version="1.2.3" targetFramework="net45" />
+  <package id="Elasticsearch.Net.JsonNET" version="1.2.3" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="6.0.6" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
This is to fix the Exception parsing problems generated by Elasticsearch.Net's default json parser, SimpleJson. It reintroduces the dependency on Json.Net but not on NEST.

Also updated Elasticsearch.Net to latest version.
