### PR TITLE
Added the ability to configure which type an event will be indexed as in elasticsearch

### DIFF
--- a/src/Serilog.Sinks.ElasticSearch/LoggerConfigurationElasticSearchExtensions.cs
+++ b/src/Serilog.Sinks.ElasticSearch/LoggerConfigurationElasticSearchExtensions.cs
@@ -36,6 +36,7 @@ namespace Serilog
         /// </summary>
         /// <param name="loggerConfiguration">The logger configuration.</param>
         /// <param name="indexFormat">The index format where the events are send to. It defaults to the logstash index per day format. It uses a String.Format using the DateTime.UtcNow parameter.</param>
+        /// <param name="type">The type the log event will be indexed as in elasticsearch</param>
         /// <param name="node">The URI to the node where ElasticSearch is running. When null, will fall back to http://localhost:9200</param>
         /// <param name="connectionTimeOutInMilliseconds">The connection time out in milliseconds. Default value is 5000.</param>
         /// <param name="restrictedToMinimumLevel">The minimum log event level required in order to write an event to the sink.</param>
@@ -50,6 +51,7 @@ namespace Serilog
         public static LoggerConfiguration ElasticSearch(
             this LoggerSinkConfiguration loggerConfiguration,
             string indexFormat = ElasticSearchSink.DefaultIndexFormat,
+            string type = ElasticSearchSink.DefaultType,
             Uri node = null,
             int connectionTimeOutInMilliseconds = ElasticSearchSink.DefaultConnectionTimeout,
             LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
@@ -66,6 +68,7 @@ namespace Serilog
 				loggerConfiguration,
 				connectionConfiguration, 
 				indexFormat,
+                type,
 				restrictedToMinimumLevel, 
 				batchPostingLimit, 
 				period, 
@@ -73,29 +76,31 @@ namespace Serilog
 			);
         }
 
-		/// <summary>
-		/// Adds a sink that writes log events as documents to an ElasticSearch index.
-		/// This works great with the Kibana web interface when using the default settings.
-		/// Make sure to add a template to ElasticSearch like the one found here:
-		/// https://gist.github.com/mivano/9688328
-		/// </summary>
-		/// <param name="loggerConfiguration">The logger configuration.</param>
-		/// <param name="nodes">The node URIs of the Elasticsearch cluster.</param>
-		/// <param name="indexFormat">The index format where the events are send to. It defaults to the logstash index per day format. It uses a String.Format using the DateTime.UtcNow parameter.</param>
-		/// <param name="connectionTimeOutInMilliseconds">The connection time out in milliseconds. Default value is 5000.</param>
-		/// <param name="restrictedToMinimumLevel">The minimum log event level required in order to write an event to the sink.</param>
-		/// <param name="batchPostingLimit">The maximum number of events to post in a single batch.</param>
-		/// <param name="period">The time to wait between checking for event batches.</param>
-		/// <param name="formatProvider">Supplies culture-specific formatting information, or null.</param>
-		/// <returns>
-		/// Logger configuration, allowing configuration to continue.
-		/// </returns>
-		/// <exception cref="System.ArgumentNullException">loggerConfiguration</exception>
-		/// <exception cref="ArgumentNullException">A required parameter is null.</exception>
-		public static LoggerConfiguration ElasticSearch(
+        /// <summary>
+        /// Adds a sink that writes log events as documents to an ElasticSearch index.
+        /// This works great with the Kibana web interface when using the default settings.
+        /// Make sure to add a template to ElasticSearch like the one found here:
+        /// https://gist.github.com/mivano/9688328
+        /// </summary>
+        /// <param name="loggerConfiguration">The logger configuration.</param>
+        /// <param name="nodes">The node URIs of the Elasticsearch cluster.</param>
+        /// <param name="indexFormat">The index format where the events are send to. It defaults to the logstash index per day format. It uses a String.Format using the DateTime.UtcNow parameter.</param>
+        /// <param name="type">The type the log event will be indexed as in elasticsearch</param>
+        /// <param name="connectionTimeOutInMilliseconds">The connection time out in milliseconds. Default value is 5000.</param>
+        /// <param name="restrictedToMinimumLevel">The minimum log event level required in order to write an event to the sink.</param>
+        /// <param name="batchPostingLimit">The maximum number of events to post in a single batch.</param>
+        /// <param name="period">The time to wait between checking for event batches.</param>
+        /// <param name="formatProvider">Supplies culture-specific formatting information, or null.</param>
+        /// <returns>
+        /// Logger configuration, allowing configuration to continue.
+        /// </returns>
+        /// <exception cref="System.ArgumentNullException">loggerConfiguration</exception>
+        /// <exception cref="ArgumentNullException">A required parameter is null.</exception>
+        public static LoggerConfiguration ElasticSearch(
 			this LoggerSinkConfiguration loggerConfiguration,
 			IEnumerable<Uri> nodes,
 			string indexFormat = ElasticSearchSink.DefaultIndexFormat,
+            string type = ElasticSearchSink.DefaultType,
 			int connectionTimeOutInMilliseconds = ElasticSearchSink.DefaultConnectionTimeout,
 			LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
 			int batchPostingLimit = ElasticSearchSink.DefaultBatchPostingLimit,
@@ -111,6 +116,7 @@ namespace Serilog
 				loggerConfiguration,
 				connectionConfiguration,
 				indexFormat,
+                type,
 				restrictedToMinimumLevel,
 				batchPostingLimit,
 				period,
@@ -118,28 +124,30 @@ namespace Serilog
 			);
 		}
 
-		/// <summary>
-		/// Adds a sink that writes log events as documents to an ElasticSearch index.
-		/// This works great with the Kibana web interface when using the default settings.
-		/// Make sure to add a template to ElasticSearch like the one found here:
-		/// https://gist.github.com/mivano/9688328
-		/// </summary>
-		/// <param name="loggerConfiguration">The logger configuration.</param>
-		/// <param name="connectionConfiguration">The configuration to use for connecting to the Elasticsearch cluster.</param>
-		/// <param name="indexFormat">The index format where the events are send to. It defaults to the logstash index per day format. It uses a String.Format using the DateTime.UtcNow parameter.</param>
-		/// <param name="restrictedToMinimumLevel">The minimum log event level required in order to write an event to the sink.</param>
-		/// <param name="batchPostingLimit">The maximum number of events to post in a single batch.</param>
-		/// <param name="period">The time to wait between checking for event batches.</param>
-		/// <param name="formatProvider">Supplies culture-specific formatting information, or null.</param>
-		/// <returns>
-		/// Logger configuration, allowing configuration to continue.
-		/// </returns>
-		/// <exception cref="System.ArgumentNullException">loggerConfiguration</exception>
-		/// <exception cref="ArgumentNullException">A required parameter is null.</exception>
-		public static LoggerConfiguration ElasticSearch(
+        /// <summary>
+        /// Adds a sink that writes log events as documents to an ElasticSearch index.
+        /// This works great with the Kibana web interface when using the default settings.
+        /// Make sure to add a template to ElasticSearch like the one found here:
+        /// https://gist.github.com/mivano/9688328
+        /// </summary>
+        /// <param name="loggerConfiguration">The logger configuration.</param>
+        /// <param name="connectionConfiguration">The configuration to use for connecting to the Elasticsearch cluster.</param>
+        /// <param name="indexFormat">The index format where the events are send to. It defaults to the logstash index per day format. It uses a String.Format using the DateTime.UtcNow parameter.</param>
+        /// <param name="type">The type the log event will be indexed as in elasticsearch</param>
+        /// <param name="restrictedToMinimumLevel">The minimum log event level required in order to write an event to the sink.</param>
+        /// <param name="batchPostingLimit">The maximum number of events to post in a single batch.</param>
+        /// <param name="period">The time to wait between checking for event batches.</param>
+        /// <param name="formatProvider">Supplies culture-specific formatting information, or null.</param>
+        /// <returns>
+        /// Logger configuration, allowing configuration to continue.
+        /// </returns>
+        /// <exception cref="System.ArgumentNullException">loggerConfiguration</exception>
+        /// <exception cref="ArgumentNullException">A required parameter is null.</exception>
+        public static LoggerConfiguration ElasticSearch(
 			this LoggerSinkConfiguration loggerConfiguration,
 			ConnectionConfiguration connectionConfiguration,
 			string indexFormat = ElasticSearchSink.DefaultIndexFormat,
+			string type = ElasticSearchSink.DefaultIndexFormat,
 			LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
 			int batchPostingLimit = ElasticSearchSink.DefaultBatchPostingLimit,
 			TimeSpan? period = null,
@@ -150,8 +158,9 @@ namespace Serilog
 
 			var defaultedPeriod = period ?? ElasticSearchSink.DefaultPeriod;
 			var defaultedIndexFormat = indexFormat ?? ElasticSearchSink.DefaultIndexFormat;
+            var defaultType = type ?? ElasticSearchSink.DefaultType;
 			var elasticsearchSink = new ElasticSearchSink(
-				connectionConfiguration, defaultedIndexFormat, batchPostingLimit, defaultedPeriod, formatProvider);
+				connectionConfiguration, defaultedIndexFormat, defaultType, batchPostingLimit, defaultedPeriod, formatProvider);
 
 			return loggerConfiguration.Sink(elasticsearchSink, restrictedToMinimumLevel);
 		}

--- a/src/Serilog.Sinks.ElasticSearch/Sinks/ElasticSearch/ElasticSearchSink.cs
+++ b/src/Serilog.Sinks.ElasticSearch/Sinks/ElasticSearch/ElasticSearchSink.cs
@@ -29,6 +29,7 @@ namespace Serilog.Sinks.ElasticSearch
     class ElasticSearchSink : PeriodicBatchingSink
     {
         readonly string _indexFormat;
+        readonly string _type;
         readonly IFormatProvider _formatProvider;
         readonly ElasticsearchClient _client;
     
@@ -47,6 +48,11 @@ namespace Serilog.Sinks.ElasticSearch
 		/// </summary>
 		public const string DefaultIndexFormat = "logstash-{0:yyyy.MM.dd}";
 
+        /// <summary>
+        /// Defaults to the type of logevent
+        /// </summary>
+        public const string DefaultType = "logevent";
+
 		/// <summary>
 		/// Default connection timeout in milliseconds
 		/// </summary>
@@ -57,15 +63,17 @@ namespace Serilog.Sinks.ElasticSearch
         /// </summary>
         /// <param name="connectionConfiguration">Connection configuration to use for connecting to the cluster.</param>
         /// <param name="indexFormat">The index name formatter. A string.Format using the DateTime.UtcNow is run over this string.</param>
+        /// <param name="type">The type the log event will be indexed as in elasticsearch</param>
         /// <param name="batchPostingLimit">The maximum number of events to post in a single batch.</param>
         /// <param name="period">The time to wait between checking for event batches.</param>
         /// <param name="formatProvider">Supplies culture-specific formatting information, or null.</param>
-        public ElasticSearchSink(ConnectionConfiguration connectionConfiguration, string indexFormat, int batchPostingLimit, TimeSpan period, IFormatProvider formatProvider)
+        public ElasticSearchSink(ConnectionConfiguration connectionConfiguration, string indexFormat, string type, int batchPostingLimit, TimeSpan period, IFormatProvider formatProvider)
             : base(batchPostingLimit, period)
         {
 			_indexFormat = indexFormat;
             _formatProvider = formatProvider;
-			_client = new ElasticsearchClient(connectionConfiguration);
+            _type = type;
+            _client = new ElasticsearchClient(connectionConfiguration);
         }
 
         /// <summary>
@@ -97,7 +105,7 @@ namespace Serilog.Sinks.ElasticSearch
 				document.Add("message", logEvent.RenderedMessage);
 				document.Add("fields", logEvent.Properties);
 
-				payload.Add(new { index = new { _index = indexName, _type = "logevent" } });
+				payload.Add(new { index = new { _index = indexName, _type = _type } });
 				payload.Add(document);
 			}
 


### PR DESCRIPTION
The default type is still logevent. Being able to define you're own type creates a good way of filtering log events in kibana as well as defining specific type mappings within the same index.

This way you can map different systems log events to the same index and separate still give the different mappings (if you want to customize outside of the logstash default). 
