### PR TITLE
Added option to provide LogentriesSink with ITextFormatter

### DIFF
--- a/src/Serilog.Sinks.Logentries/LoggerConfigurationLogentriesExtensions.cs
+++ b/src/Serilog.Sinks.Logentries/LoggerConfigurationLogentriesExtensions.cs
@@ -16,6 +16,7 @@ using System;
 using Serilog.Configuration;
 using Serilog.Events;
 using Serilog.Sinks.Logentries;
+using Serilog.Formatting;
 
 namespace Serilog
 {
@@ -62,5 +63,41 @@ namespace Serilog
                 restrictedToMinimumLevel);
         }
 
+        /// <summary>
+        /// Adds a sink that writes log events to the Logentries.com webservice. 
+        /// Create a token TCP input for this on the logentries website. 
+        /// </summary>
+        /// <param name="loggerConfiguration">The logger configuration.</param>
+        /// <param name="token">The token as found on the Logentries.com website.</param>
+        /// <param name="restrictedToMinimumLevel">The minimum log event level required in order to write an event to the sink.</param>
+        /// <param name="textFormatter">Used to format the logs sent to Logentries.</param>
+        /// <param name="useSsl">Specify if the connection needs to be secured.</param>
+        /// <param name="batchPostingLimit">The maximum number of events to post in a single batch.</param>
+        /// <param name="period">The time to wait between checking for event batches.</param>
+        /// <returns>Logger configuration, allowing configuration to continue.</returns>
+        /// <exception cref="ArgumentNullException">A required parameter is null.</exception>
+        public static LoggerConfiguration Logentries(
+            this LoggerSinkConfiguration loggerConfiguration,
+             string token, 
+            ITextFormatter textFormatter,
+            bool useSsl = true,
+            int batchPostingLimit = LogentriesSink.DefaultBatchPostingLimit,
+            TimeSpan? period = null,
+            LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum)
+        {
+            if (loggerConfiguration == null) throw new ArgumentNullException("loggerConfiguration");
+
+            if (string.IsNullOrWhiteSpace(token))
+                throw new ArgumentNullException("token");
+
+            if (textFormatter == null)
+                throw new ArgumentNullException("textFormatter");
+
+            var defaultedPeriod = period ?? LogentriesSink.DefaultPeriod;
+
+            return loggerConfiguration.Sink(
+                new LogentriesSink(textFormatter, token, useSsl, batchPostingLimit, defaultedPeriod),
+                restrictedToMinimumLevel);
+        }
     }
 }

--- a/src/Serilog.Sinks.Logentries/Sinks/Logentries/LogentriesSink.cs
+++ b/src/Serilog.Sinks.Logentries/Sinks/Logentries/LogentriesSink.cs
@@ -52,7 +52,8 @@ namespace Serilog.Sinks.Logentries
         public static readonly TimeSpan DefaultPeriod = TimeSpan.FromSeconds(2);
 
         /// <summary>
-        /// Construct a sink that saves logs to the specified storage account. Properties are being send as data and the level is used as tag.
+        /// Construct a sink that sends logs to the specified Logentries log using a <see cref="MessageTemplateTextFormatter"/> to format
+        /// the logs as simple display messages.
         /// </summary>
         /// <param name="batchPostingLimit">The maximum number of events to post in a single batch.</param>
         /// <param name="period">The time to wait between checking for event batches.</param>
@@ -61,10 +62,23 @@ namespace Serilog.Sinks.Logentries
         /// <param name="token">The input key as found on the Logentries website.</param>
         /// <param name="useSsl">Indicates if you want to use SSL or not.</param>
         public LogentriesSink(string outputTemplate, IFormatProvider formatProvider, string token, bool useSsl, int batchPostingLimit, TimeSpan period)
+            : this(new MessageTemplateTextFormatter(outputTemplate, formatProvider), token, useSsl, batchPostingLimit, period)
+        {
+        }
+
+        /// <summary>
+        /// Construct a sink that sends logs to the specified Logentries log using a provided <see cref="ITextFormatter"/>.
+        /// </summary>
+        /// <param name="textFormatter">Used to format the logs sent to Logentries.</param>
+        /// <param name="token">The input key as found on the Logentries website.</param>
+        /// <param name="useSsl">Indicates if you want to use SSL or not.</param>
+        /// <param name="batchPostingLimit">The maximum number of events to post in a single batch.</param>
+        /// <param name="period">The time to wait between checking for event batches.</param>
+        public LogentriesSink(ITextFormatter textFormatter, string token, bool useSsl, int batchPostingLimit, TimeSpan period)
             : base(batchPostingLimit, period)
         {
-            if (outputTemplate == null) throw new ArgumentNullException("outputTemplate");
-            _textFormatter = new MessageTemplateTextFormatter(outputTemplate, formatProvider);
+            if (textFormatter == null) throw new ArgumentNullException("textFormatter");
+            _textFormatter = textFormatter;
 
             _token = token;
             _useSsl = useSsl;


### PR DESCRIPTION
[Logentries](https://logentries.com/) has support for receiving JSON formatted log events. When it receives JSON logs, it allows users to search for events with certain properties or property values. It also allows you to create tags and alerts based on properties and property values.

Before these changes, the `LogentriesSink` only allowed simple display messages to be sent to Logentries. With these changes, the developer can provide their own `ITextFormatter` when creating the `LogentriesSink`. With this support, a developer could configure the sink to send JSON logs.

```csharp
var logger = new LoggerConfiguration()
            .WriteTo.Logentries(logentriesToken, new JsonFormatter(), useSsl:false)
            .CreateLogger();
```