### PR TITLE
First checklist item from #125 - remove `dynamic`

### DIFF
--- a/src/Serilog/Policies/NullableScalarConversionPolicy.cs
+++ b/src/Serilog/Policies/NullableScalarConversionPolicy.cs
@@ -29,10 +29,9 @@ namespace Serilog.Policies
                 return false;
             }
 
-            var dynamicValue = (dynamic)value;
-            var innerValue = dynamicValue.HasValue ? (object)dynamicValue.Value : null;
+            var targetType = type.GenericTypeArguments[0];
+            var innerValue = Convert.ChangeType(value, targetType);
             result = propertyValueFactory.CreatePropertyValue(innerValue) as ScalarValue;
-
             return result != null;
         }
     }


### PR DESCRIPTION
Nullable type destructuring can be achieved without using `dynamic` - this change makes it possible to destructure `Nullable<T>` as scalar values on iOS.
