### PR TITLE
Added optional Encoding parameter to RollingFileSink and FileSink ctors

### DIFF
--- a/src/Serilog.FullNetFx/Sinks/IOFile/FileSink.cs
+++ b/src/Serilog.FullNetFx/Sinks/IOFile/FileSink.cs
@@ -37,10 +37,11 @@ namespace Serilog.Sinks.IOFile
         /// <param name="textFormatter">Formatter used to convert log events to text.</param>
         /// <param name="fileSizeLimitBytes">The maximum size, in bytes, to which a log file will be allowed to grow.
         /// For unrestricted growth, pass null. The default is 1 GB.</param>
+        /// <param name="encoding">Character encoding used to write the text file. The default is UTF-8.</param>
         /// <returns>Configuration object allowing method chaining.</returns>
         /// <remarks>The file will be written using the UTF-8 character set.</remarks>
         /// <exception cref="IOException"></exception>
-        public FileSink(string path, ITextFormatter textFormatter, long? fileSizeLimitBytes)
+        public FileSink(string path, ITextFormatter textFormatter, long? fileSizeLimitBytes, Encoding encoding = null)
         {
             if (path == null) throw new ArgumentNullException("path");
             if (textFormatter == null) throw new ArgumentNullException("textFormatter");
@@ -51,7 +52,7 @@ namespace Serilog.Sinks.IOFile
             TryCreateDirectory(path);
 
             var file = File.Open(path, FileMode.Append, FileAccess.Write, FileShare.Read);
-            var outputWriter = new StreamWriter(file, Encoding.UTF8);
+            var outputWriter = new StreamWriter(file, encoding ?? Encoding.UTF8);
             if (fileSizeLimitBytes != null)
             {
                 var initialBytes = file.Length;

--- a/src/Serilog.FullNetFx/Sinks/RollingFile/RollingFileSink.cs
+++ b/src/Serilog.FullNetFx/Sinks/RollingFile/RollingFileSink.cs
@@ -16,6 +16,7 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
+using System.Text;
 using Serilog.Core;
 using Serilog.Debugging;
 using Serilog.Events;
@@ -35,6 +36,7 @@ namespace Serilog.Sinks.RollingFile
         readonly ITextFormatter _textFormatter;
         readonly long? _fileSizeLimitBytes;
         readonly int? _retainedFileCountLimit;
+        readonly Encoding _encoding;
         readonly object _syncRoot = new object();
 
         bool _isDisposed;
@@ -50,12 +52,14 @@ namespace Serilog.Sinks.RollingFile
         /// For unrestricted growth, pass null. The default is 1 GB.</param>
         /// <param name="retainedFileCountLimit">The maximum number of log files that will be retained,
         /// including the current log file. For unlimited retention, pass null. The default is 31.</param>
+        /// <param name="encoding">Character encoding used to write the text file. The default is UTF-8.</param>
         /// <returns>Configuration object allowing method chaining.</returns>
         /// <remarks>The file will be written using the UTF-8 character set.</remarks>
         public RollingFileSink(string pathFormat, 
                               ITextFormatter textFormatter,
                               long? fileSizeLimitBytes,
-                              int? retainedFileCountLimit)
+                              int? retainedFileCountLimit, 
+                              Encoding encoding = null)
         {
             if (pathFormat == null) throw new ArgumentNullException("pathFormat");
             if (fileSizeLimitBytes.HasValue && fileSizeLimitBytes < 0) throw new ArgumentException("Negative value provided; file size limit must be non-negative");
@@ -65,6 +69,7 @@ namespace Serilog.Sinks.RollingFile
             _textFormatter = textFormatter;
             _fileSizeLimitBytes = fileSizeLimitBytes;
             _retainedFileCountLimit = retainedFileCountLimit;
+            _encoding = encoding ?? Encoding.UTF8;
         }
 
         /// <summary>
@@ -137,7 +142,7 @@ namespace Serilog.Sinks.RollingFile
 
                 try
                 {
-                    _currentFile = new FileSink(path, _textFormatter, _fileSizeLimitBytes);
+                    _currentFile = new FileSink(path, _textFormatter, _fileSizeLimitBytes, _encoding);
                 }
                 catch (IOException ex)
                 {


### PR DESCRIPTION
Referring to the issue 337 (https://github.com/serilog/serilog/issues/337) I've added optional Encoding parameter to FileSink and RollingFileSink constructors. In both places the parameter is optional so it won't break the existing code. And of course the default encoding it UTF-8.
