### PR TITLE
Expanded the log timing abilities

### DIFF
--- a/src/Serilog.Extras.Timing/Extras/Timing/ITimedScope.cs
+++ b/src/Serilog.Extras.Timing/Extras/Timing/ITimedScope.cs
@@ -1,0 +1,31 @@
+﻿using System;
+
+namespace Serilog.Extras.Timing
+{
+    /// <summary>
+    /// Disposable scope for the timing. Supports explicit completetion messages.
+    /// </summary>
+    public interface ITimedScope : IDisposable
+    {
+        /// <summary>
+        /// Sets an alternative completetion message.
+        /// </summary>
+        /// <param name="messageTemplate"></param>
+        /// <param name="propertyValues"></param>
+        void SetCompletetionMessage(string messageTemplate, params object[] propertyValues);
+
+        /// <summary>
+        /// Sets an alternative completetion message and sets the log level to Error.
+        /// </summary>
+        /// <param name="messageTemplate"></param>
+        /// <param name="propertyValues"></param>
+        void SetErrorMessage(string messageTemplate, params object[] propertyValues);
+
+        /// <summary>
+        /// Sets an alternative completetion message and sets the log level to Warning.
+        /// </summary>
+        /// <param name="messageTemplate"></param>
+        /// <param name="propertyValues"></param>
+        void SetWarningMessage(string messageTemplate, params object[] propertyValues);
+    }
+}

--- a/src/Serilog.Extras.Timing/Extras/Timing/TimedScope.cs
+++ b/src/Serilog.Extras.Timing/Extras/Timing/TimedScope.cs
@@ -1,0 +1,126 @@
+﻿using System;
+using System.Diagnostics;
+using System.Linq;
+using Serilog.Events;
+
+namespace Serilog.Extras.Timing
+{
+    /// <summary>
+    /// Disposable scope for the timing. Supports explicit completetion messages.
+    /// </summary>
+    public class TimedScope : ITimedScope
+    {
+        private const string StartingFormat = "Starting {{TimedScopeId}}: {0}";
+        private const string CompletedFormat = "Completed {{TimedScopeId}} in {{TimedScopeElapsed}} ({{TimedScopeElapsedInMs}} ms): {0}";
+        private const string CompletedWithWarningFormat = "Completed {{TimedScopeId}} in {{TimedScopeElapsed}} ({{TimedScopeElapsedInMs}} ms), limit {{TimedScopeWarningLimit}} exceeded: {0}";
+
+        private readonly ILogger _logger;
+        private readonly object _scopeId;
+        private readonly TimeSpan? _warnIfExceeds;
+        private LogEventLevel _level;
+        private string _messageTemplate;
+        private object[] _propertyValues;
+        private readonly Stopwatch _sw;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TimedScope" /> class.
+        /// </summary>
+        /// <param name="logger">The logger.</param>
+        /// <param name="scopeId">The identifier used for the timing. If non specified, a random guid will be used.</param>
+        /// <param name="warnIfExceeds">Specifies a limit, if it takes more than this limit, the level will be set to warning. By default this is not used.</param>
+        /// <param name="level">The level used to write the timing operation details to the log. By default this is the information level.</param>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <param name="propertyValues">Objects positionally formatted into the message template.</param>
+        public TimedScope(ILogger logger, object scopeId, TimeSpan? warnIfExceeds, LogEventLevel level, string messageTemplate, object[] propertyValues)
+        {
+            _logger = logger;
+            _scopeId = scopeId ?? ToShortGuid(Guid.NewGuid());
+            _warnIfExceeds = warnIfExceeds;
+            _level = level;
+            _messageTemplate = messageTemplate;
+            _propertyValues = propertyValues;
+
+            propertyValues = new object[_propertyValues.Length + 1];
+            _propertyValues.CopyTo(propertyValues, 1);
+            propertyValues[0] = _scopeId;
+
+            _logger.Write(level, string.Format(StartingFormat, messageTemplate), propertyValues);
+
+            _sw = Stopwatch.StartNew();
+        }
+
+        private static string ToShortGuid(Guid guid, int length = 22)
+        {
+            var encoded = Convert.ToBase64String(guid.ToByteArray());
+            return encoded.Substring(0, length).Replace("/", "").Replace("+", "").Replace("_", "").Replace("-", "");
+        }
+
+        /// <summary>
+        /// Sets an alternative completetion message.
+        /// </summary>
+        /// <param name="messageTemplate"></param>
+        /// <param name="propertyValues"></param>
+        public void SetCompletetionMessage(string messageTemplate, params object[] propertyValues)
+        {
+            SetCompletetionMessage(_level, messageTemplate, propertyValues);
+        }
+
+        /// <summary>
+        /// Sets an alternative completetion message and sets the log level to Error.
+        /// </summary>
+        /// <param name="messageTemplate"></param>
+        /// <param name="propertyValues"></param>
+        public void SetErrorMessage(string messageTemplate, params object[] propertyValues)
+        {
+            SetCompletetionMessage(LogEventLevel.Error, messageTemplate, propertyValues);
+        }
+
+        /// <summary>
+        /// Sets an alternative completetion message and sets the log level to Warning.
+        /// </summary>
+        /// <param name="messageTemplate"></param>
+        /// <param name="propertyValues"></param>
+        public void SetWarningMessage(string messageTemplate, params object[] propertyValues)
+        {
+            SetCompletetionMessage(LogEventLevel.Warning, messageTemplate, propertyValues);
+        }
+
+        private void SetCompletetionMessage(LogEventLevel level, string messageTemplate, params object[] propertyValues)
+        {
+            _level = level;
+            _messageTemplate = messageTemplate;
+            _propertyValues = propertyValues;
+        }
+
+        /// <summary>
+        /// Ends the timed scope and triggers the logging of the completetion message.
+        /// If no completetion message was specified, the original message is used.
+        /// </summary>
+        public void Dispose()
+        {
+            _sw.Stop();
+
+            if (_warnIfExceeds.HasValue && _sw.Elapsed > _warnIfExceeds.Value)
+            {
+                var propertyValues = new object[_propertyValues.Length + 4];
+                _propertyValues.CopyTo(propertyValues, 4);
+                propertyValues[0] = _scopeId;
+                propertyValues[1] = _sw.Elapsed;
+                propertyValues[2] = _sw.ElapsedMilliseconds;
+                propertyValues[3] = _warnIfExceeds.Value;
+
+                _logger.Write(_level <= LogEventLevel.Warning ? LogEventLevel.Warning : _level, string.Format(CompletedWithWarningFormat, _messageTemplate), propertyValues);
+            }
+            else
+            {
+                var propertyValues = new object[_propertyValues.Length + 3];
+                _propertyValues.CopyTo(propertyValues, 3);
+                propertyValues[0] = _scopeId;
+                propertyValues[1] = _sw.Elapsed;
+                propertyValues[2] = _sw.ElapsedMilliseconds;
+
+                _logger.Write(_level, string.Format(CompletedFormat, _messageTemplate), propertyValues);
+            }
+        }
+    }
+}

--- a/src/Serilog.Extras.Timing/LoggerExtensions.cs
+++ b/src/Serilog.Extras.Timing/LoggerExtensions.cs
@@ -130,5 +130,121 @@ namespace Serilog
         }
 
 
+        /// <summary>
+        /// Begins a logging scope by placing the code to be timed inside a using block. 
+        /// When the block is being exited, the time it took is logged.
+        /// </summary>
+        /// <param name="logger">The logger.</param>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <param name="propertyValues">Objects positionally formatted into the message template.</param>
+        /// <returns>A disposable object. Wrap this inside a using block so the dispose can be called to stop the timing.</returns>
+        public static ITimedScope BeginTimedScope(this ILogger logger, string messageTemplate, params object[] propertyValues)
+        {
+            return logger.BeginTimedScope(null, null, LogEventLevel.Information, messageTemplate, propertyValues);
+        }
+
+        /// <summary>
+        /// Begins a logging scope by placing the code to be timed inside a using block. 
+        /// When the block is being exited, the time it took is logged.
+        /// </summary>
+        /// <param name="logger">The logger.</param>
+        /// <param name="level">The level used to write the timing operation details to the log. By default this is the information level.</param>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <param name="propertyValues">Objects positionally formatted into the message template.</param>
+        /// <returns>A disposable object. Wrap this inside a using block so the dispose can be called to stop the timing.</returns>
+        public static ITimedScope BeginTimedScope(this ILogger logger, LogEventLevel level, string messageTemplate, params object[] propertyValues)
+        {
+            return logger.BeginTimedScope(null, null, level, messageTemplate, propertyValues);
+        }
+
+        /// <summary>
+        /// Begins a logging scope by placing the code to be timed inside a using block. 
+        /// When the block is being exited, the time it took is logged.
+        /// </summary>
+        /// <param name="logger">The logger.</param>
+        /// <param name="scopeId">The identifier used for the timing. If non specified, a random guid will be used.</param>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <param name="propertyValues">Objects positionally formatted into the message template.</param>
+        /// <returns>A disposable object. Wrap this inside a using block so the dispose can be called to stop the timing.</returns>
+        public static ITimedScope BeginTimedScope(this ILogger logger, string scopeId, string messageTemplate, params object[] propertyValues)
+        {
+            return logger.BeginTimedScope(scopeId, null, LogEventLevel.Information, messageTemplate, propertyValues);
+        }
+
+        /// <summary>
+        /// Begins a logging scope by placing the code to be timed inside a using block. 
+        /// When the block is being exited, the time it took is logged.
+        /// </summary>
+        /// <param name="logger">The logger.</param>
+        /// <param name="scopeId">The identifier used for the timing. If non specified, a random guid will be used.</param>
+        /// <param name="level">The level used to write the timing operation details to the log. By default this is the information level.</param>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <param name="propertyValues">Objects positionally formatted into the message template.</param>
+        /// <returns>A disposable object. Wrap this inside a using block so the dispose can be called to stop the timing.</returns>
+        public static ITimedScope BeginTimedScope(this ILogger logger, string scopeId, LogEventLevel level, string messageTemplate, params object[] propertyValues)
+        {
+            return logger.BeginTimedScope(scopeId, null, level, messageTemplate, propertyValues);
+        }
+
+        /// <summary>
+        /// Begins a logging scope by placing the code to be timed inside a using block. 
+        /// When the block is being exited, the time it took is logged.
+        /// </summary>
+        /// <param name="logger">The logger.</param>
+        /// <param name="warnIfExceeds">Specifies a limit, if it takes more than this limit, the level will be set to warning. By default this is not used.</param>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <param name="propertyValues">Objects positionally formatted into the message template.</param>
+        /// <returns>A disposable object. Wrap this inside a using block so the dispose can be called to stop the timing.</returns>
+        public static ITimedScope BeginTimedScope(this ILogger logger, TimeSpan? warnIfExceeds, string messageTemplate, params object[] propertyValues)
+        {
+            return logger.BeginTimedScope(null, warnIfExceeds, LogEventLevel.Information, messageTemplate, propertyValues);
+        }
+
+        /// <summary>
+        /// Begins a logging scope by placing the code to be timed inside a using block. 
+        /// When the block is being exited, the time it took is logged.
+        /// </summary>
+        /// <param name="logger">The logger.</param>
+        /// <param name="warnIfExceeds">Specifies a limit, if it takes more than this limit, the level will be set to warning. By default this is not used.</param>
+        /// <param name="level">The level used to write the timing operation details to the log. By default this is the information level.</param>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <param name="propertyValues">Objects positionally formatted into the message template.</param>
+        /// <returns>A disposable object. Wrap this inside a using block so the dispose can be called to stop the timing.</returns>
+        public static ITimedScope BeginTimedScope(this ILogger logger, TimeSpan? warnIfExceeds, LogEventLevel level, string messageTemplate, params object[] propertyValues)
+        {
+            return logger.BeginTimedScope(null, warnIfExceeds, level, messageTemplate, propertyValues);
+        }
+
+        /// <summary>
+        /// Begins a logging scope by placing the code to be timed inside a using block. 
+        /// When the block is being exited, the time it took is logged.
+        /// </summary>
+        /// <param name="logger">The logger.</param>
+        /// <param name="scopeId">The identifier used for the timing. If non specified, a random guid will be used.</param>
+        /// <param name="warnIfExceeds">Specifies a limit, if it takes more than this limit, the level will be set to warning. By default this is not used.</param>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <param name="propertyValues">Objects positionally formatted into the message template.</param>
+        /// <returns>A disposable object. Wrap this inside a using block so the dispose can be called to stop the timing.</returns>
+        public static ITimedScope BeginTimedScope(this ILogger logger, string scopeId, TimeSpan? warnIfExceeds, string messageTemplate, params object[] propertyValues)
+        {
+            return new TimedScope(logger, string.IsNullOrEmpty(scopeId) ? null : scopeId, warnIfExceeds, LogEventLevel.Information, messageTemplate, propertyValues);
+        }
+
+        /// <summary>
+        /// Begins a logging scope by placing the code to be timed inside a using block. 
+        /// When the block is being exited, the time it took is logged.
+        /// </summary>
+        /// <param name="logger">The logger.</param>
+        /// <param name="scopeId">The identifier used for the timing. If non specified, a random guid will be used.</param>
+        /// <param name="warnIfExceeds">Specifies a limit, if it takes more than this limit, the level will be set to warning. By default this is not used.</param>
+        /// <param name="level">The level used to write the timing operation details to the log. By default this is the information level.</param>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <param name="propertyValues">Objects positionally formatted into the message template.</param>
+        /// <returns>A disposable object. Wrap this inside a using block so the dispose can be called to stop the timing.</returns>
+        public static ITimedScope BeginTimedScope(this ILogger logger, string scopeId, TimeSpan? warnIfExceeds, LogEventLevel level, string messageTemplate, params object[] propertyValues)
+        {
+            return new TimedScope(logger, string.IsNullOrEmpty(scopeId) ? null : scopeId, warnIfExceeds, level, messageTemplate, propertyValues);
+        }
     }
+
 }

--- a/src/Serilog.Extras.Timing/Serilog.Extras.Timing.csproj
+++ b/src/Serilog.Extras.Timing/Serilog.Extras.Timing.csproj
@@ -56,6 +56,8 @@
     <Compile Include="Extras\Timing\ICounterMeasure.cs" />
     <Compile Include="Extras\Timing\IGaugeMeasure.cs" />
     <Compile Include="Extras\Timing\IMeasure.cs" />
+    <Compile Include="Extras\Timing\ITimedScope.cs" />
+    <Compile Include="Extras\Timing\TimedScope.cs" />
     <Compile Include="LoggerExtensions.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="..\..\assets\CommonAssemblyInfo.cs">


### PR DESCRIPTION
Added BeginTimedScope extension to ILogger which returns a disposable ITimedScope
The BeginTimedScope usage allows for the same logging style as ILogger (messageTemplate and params object[]) to keep consistency as well as more powerful logging
ITimedScope supports the (optional) setting of a completion message (if not used the message provided to BeginTimedScope will be used again with a completion preamble)

Here is an example usage:

```c#
using (var logScope = Logger.BeginTimedDebugScope("{HttpMethod} Request {@Request}", CurrentHttpMethod, request))
{
    try
    {
        var response = ProcessRequest(request);
        logScope.SetCompletetionMessage("{HttpMethod} Response {@Response}", CurrentHttpMethod, response);
        return response;
    }
    catch (Exception ex)
    {
        logScope.SetErrorMessage("{HttpMethod} Request {@Request} Failed {@Exception}", CurrentHttpMethod, request, ex);
    }
}
```

If ProcessRequest succeeded the result would be something like the following:
```
Starting "mFj41fuL7kWvOmIlNw4kg": GET Request FooDto { Bar: null }
Completed "mFj41fuL7kWvOmIlNw4kg" in 00:00:00.0838446 (83 ms): GET Response FooResponseDto { Bar: "Baz" }
```

If ProcessRequest threw then:
```
Starting "mFj41fuL7kWvOmIlNw4kg": GET Request FooDto { Bar: null }
Completed "mFj41fuL7kWvOmIlNw4kg" in 00:00:00.0838446 (83 ms): GET Request FooDto { Bar: null } Failed InvalidOperationException...
```