### PR TITLE
Updated to SignalR 2.1.0

### DIFF
--- a/src/Serilog.Sinks.SignalR/Serilog.Sinks.SignalR.csproj
+++ b/src/Serilog.Sinks.SignalR/Serilog.Sinks.SignalR.csproj
@@ -41,9 +41,9 @@
     <AssemblyOriginatorKeyFile>..\..\assets\Serilog.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.AspNet.SignalR.Core, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+    <Reference Include="Microsoft.AspNet.SignalR.Core, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Microsoft.AspNet.SignalR.Core.2.0.0\lib\net45\Microsoft.AspNet.SignalR.Core.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.AspNet.SignalR.Core.2.1.0\lib\net45\Microsoft.AspNet.SignalR.Core.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Owin">
       <HintPath>..\..\packages\Microsoft.Owin.2.0.2\lib\net45\Microsoft.Owin.dll</HintPath>
@@ -79,6 +79,7 @@
     <None Include="..\..\assets\Serilog.snk">
       <Link>Serilog.snk</Link>
     </None>
+    <None Include="app.config" />
     <None Include="packages.config" />
     <None Include="Serilog.Sinks.SignalR.nuspec">
       <SubType>Designer</SubType>

--- a/src/Serilog.Sinks.SignalR/Serilog.Sinks.SignalR.nuspec
+++ b/src/Serilog.Sinks.SignalR/Serilog.Sinks.SignalR.nuspec
@@ -12,7 +12,7 @@
     <tags>serilog logging signalr</tags>
     <dependencies>
       <dependency id="Serilog" version="$version$" />
-      <dependency id="Microsoft.AspNet.SignalR.Core" version="2.0.0" />
+      <dependency id="Microsoft.AspNet.SignalR.Core" version="2.1.0" />
     </dependencies>
   </metadata>
 </package>

--- a/src/Serilog.Sinks.SignalR/app.config
+++ b/src/Serilog.Sinks.SignalR/app.config
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Owin" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.0.2.0" newVersion="2.0.2.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Owin.Security" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.0.2.0" newVersion="2.0.2.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/src/Serilog.Sinks.SignalR/packages.config
+++ b/src/Serilog.Sinks.SignalR/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.AspNet.SignalR.Core" version="2.0.0" targetFramework="net45" />
+  <package id="Microsoft.AspNet.SignalR.Core" version="2.1.0" targetFramework="net45" />
   <package id="Microsoft.Owin" version="2.0.2" targetFramework="net45" />
   <package id="Microsoft.Owin.Security" version="2.0.2" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="5.0.8" targetFramework="net45" />


### PR DESCRIPTION
There's a breaking change in SignalR 2.1.0 which makes code compiled
against 2.0.0 unable to be binding redirected - hence the update (see issue #307)