### PR TITLE
#357 PeriodicBatchingSink now flushes on unhandled exceptions

### DIFF
--- a/src/Serilog.FullNetFx/Sinks/PeriodicBatching/PeriodicBatchingSink-net40.cs
+++ b/src/Serilog.FullNetFx/Sinks/PeriodicBatching/PeriodicBatchingSink-net40.cs
@@ -58,10 +58,15 @@ namespace Serilog.Sinks.PeriodicBatching
 
             AppDomain.CurrentDomain.DomainUnload += OnAppDomainUnloading;
             AppDomain.CurrentDomain.ProcessExit += OnAppDomainUnloading;
+            AppDomain.CurrentDomain.UnhandledException += OnAppDomainUnloading;
         }
 
         void OnAppDomainUnloading(object sender, EventArgs args)
         {
+            var eventArgs = args as UnhandledExceptionEventArgs;
+            if (eventArgs != null && !eventArgs.IsTerminating)
+                return;
+
             CloseAndFlush();
         }
 
@@ -77,6 +82,7 @@ namespace Serilog.Sinks.PeriodicBatching
 
             AppDomain.CurrentDomain.DomainUnload -= OnAppDomainUnloading;
             AppDomain.CurrentDomain.ProcessExit -= OnAppDomainUnloading;
+            AppDomain.CurrentDomain.UnhandledException -= OnAppDomainUnloading;
 
             var wh = new ManualResetEvent(false);
             if (_timer.Dispose(wh))

--- a/src/Serilog.FullNetFx/Sinks/PeriodicBatching/PeriodicBatchingSink.cs
+++ b/src/Serilog.FullNetFx/Sinks/PeriodicBatching/PeriodicBatchingSink.cs
@@ -65,16 +65,11 @@ namespace Serilog.Sinks.PeriodicBatching
 
         void OnAppDomainUnloading(object sender, EventArgs args)
         {
-            if (ComeFromInvalidAppDomainContext(args)) 
+            var eventArgs = args as UnhandledExceptionEventArgs;
+            if (eventArgs != null && !eventArgs.IsTerminating) 
                 return;
 
             CloseAndFlush();
-        }
-
-        static bool ComeFromInvalidAppDomainContext(EventArgs args)
-        {
-            var eventArgs = args as UnhandledExceptionEventArgs;
-            return eventArgs == null || !eventArgs.IsTerminating;
         }
 
         void CloseAndFlush()

--- a/src/Serilog.FullNetFx/Sinks/PeriodicBatching/PeriodicBatchingSink.cs
+++ b/src/Serilog.FullNetFx/Sinks/PeriodicBatching/PeriodicBatchingSink.cs
@@ -84,7 +84,7 @@ namespace Serilog.Sinks.PeriodicBatching
 
             AppDomain.CurrentDomain.DomainUnload -= OnAppDomainUnloading;
             AppDomain.CurrentDomain.ProcessExit -= OnAppDomainUnloading;
-            AppDomain.CurrentDomain.UnhandledException += OnAppDomainUnloading;
+            AppDomain.CurrentDomain.UnhandledException -= OnAppDomainUnloading;
 
             var wh = new ManualResetEvent(false);
             if (_timer.Dispose(wh))


### PR DESCRIPTION
Context for this in issue #357 

Not very happy with the name "ComeFromInvalidAppDomainContext" for the method, but couldn't think of a better one!

Also tried to create a unit test, but it's to do so when the AppDomain and unhandled exceptions are at play. Any suggestions for how to do this?