### PR TITLE
Updating the MongoDB sink to work with the MongoDB c# v2 driver preview

### DIFF
--- a/src/Serilog.Sinks.MongoDB/LoggerConfigurationMongoDBExtensions.cs
+++ b/src/Serilog.Sinks.MongoDB/LoggerConfigurationMongoDBExtensions.cs
@@ -61,6 +61,40 @@ namespace Serilog
         }
 
         /// <summary>
+        /// Adds a sink that writes log events as documents to a MongoDb database.
+        /// </summary>
+        /// <param name="loggerConfiguration">The logger configuration.</param>
+        /// <param name="database">The MongoDb database where the log collection will live.</param>
+        /// <param name="restrictedToMinimumLevel">The minimum log event level required in order to write an event to the sink.</param>
+        /// <param name="batchPostingLimit">The maximum number of events to post in a single batch.</param>
+        /// <param name="period">The time to wait between checking for event batches.</param>
+        /// <param name="formatProvider">Supplies culture-specific formatting information, or null.</param>
+        /// <returns>Logger configuration, allowing configuration to continue.</returns>
+        /// <exception cref="ArgumentNullException">A required parameter is null.</exception>
+        public static LoggerConfiguration MongoDB(
+            this LoggerSinkConfiguration loggerConfiguration,
+            IMongoDatabase database,
+            LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
+            int batchPostingLimit = MongoDBSink.DefaultBatchPostingLimit,
+            TimeSpan? period = null,
+            IFormatProvider formatProvider = null)
+        {
+            if (loggerConfiguration == null) throw new ArgumentNullException("loggerConfiguration");
+            if (database == null) throw new ArgumentNullException("database");
+
+            var defaultedPeriod = period ?? MongoDBSink.DefaultPeriod;
+            return loggerConfiguration.Sink(
+                new MongoDBSink(
+                    database,
+                    batchPostingLimit,
+                    defaultedPeriod,
+                    formatProvider,
+                    MongoDBSink.DefaultCollectionName,
+                    CollectionOptions.Null),
+                restrictedToMinimumLevel);
+        }
+
+        /// <summary>
         /// Adds a sink that writes log events as documents to a capped collection in a MongoDb database.
         /// </summary>
         /// <param name="loggerConfiguration">The logger configuration.</param>
@@ -123,7 +157,7 @@ namespace Serilog
         /// <exception cref="ArgumentNullException">A required parameter is null.</exception>
         public static LoggerConfiguration MongoDBCapped(
             this LoggerSinkConfiguration loggerConfiguration,
-            MongoDatabase database,
+            IMongoDatabase database,
             LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
             long cappedMaxSizeMb = 50,
             long? cappedMaxDocuments = null,

--- a/src/Serilog.Sinks.MongoDB/Serilog.Sinks.MongoDB.csproj
+++ b/src/Serilog.Sinks.MongoDB/Serilog.Sinks.MongoDB.csproj
@@ -35,19 +35,22 @@
     <DocumentationFile>bin\Release\Serilog.Sinks.MongoDB.XML</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup>
-    <SignAssembly>true</SignAssembly>
+    <SignAssembly>false</SignAssembly>
   </PropertyGroup>
   <PropertyGroup>
     <AssemblyOriginatorKeyFile>..\..\assets\Serilog.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="MongoDB.Bson, Version=1.8.3.9, Culture=neutral, PublicKeyToken=f686731cfb9cc103, processorArchitecture=MSIL">
+    <Reference Include="MongoDB.Bson, Version=2.0.0.577, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\mongocsharpdriver.1.8.3\lib\net35\MongoDB.Bson.dll</HintPath>
+      <HintPath>..\..\packages\MongoDB.Bson.2.0.0-beta1\lib\net45\MongoDB.Bson.dll</HintPath>
     </Reference>
-    <Reference Include="MongoDB.Driver, Version=1.8.3.9, Culture=neutral, PublicKeyToken=f686731cfb9cc103, processorArchitecture=MSIL">
+    <Reference Include="MongoDB.Driver, Version=2.0.0.577, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\mongocsharpdriver.1.8.3\lib\net35\MongoDB.Driver.dll</HintPath>
+      <HintPath>..\..\packages\MongoDB.Driver.2.0.0-beta1\lib\net45\MongoDB.Driver.dll</HintPath>
+    </Reference>
+    <Reference Include="MongoDB.Driver.Core">
+      <HintPath>..\..\packages\MongoDB.Driver.Core.2.0.0-beta1\lib\net45\MongoDB.Driver.Core.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/src/Serilog.Sinks.MongoDB/Serilog.Sinks.MongoDB.nuspec
+++ b/src/Serilog.Sinks.MongoDB/Serilog.Sinks.MongoDB.nuspec
@@ -12,7 +12,7 @@
       <tags>serilog logging mongodb</tags>
       <dependencies>
         <dependency id="Serilog" version="$version$" />
-        <dependency id="mongocsharpdriver" version="1.8.3" />
+        <dependency id="MongoDB.Driver" version="2.0.0-beta1" />
       </dependencies>
     </metadata>
 </package>

--- a/src/Serilog.Sinks.MongoDB/packages.config
+++ b/src/Serilog.Sinks.MongoDB/packages.config
@@ -1,4 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="mongocsharpdriver" version="1.8.3" targetFramework="net45" />
+  <package id="MongoDB.Bson" version="2.0.0-beta1" targetFramework="net45" />
+  <package id="MongoDB.Driver" version="2.0.0-beta1" targetFramework="net45" />
+  <package id="MongoDB.Driver.Core" version="2.0.0-beta1" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
This is the implementation of #364.

It also removes strong naming from the MongoDB sink as MongoDB isn't strongly named any more