### PR TITLE
[Elasticsearch Sink] Log message should be named "message" instead of "r...

### DIFF
--- a/src/Serilog.Sinks.ElasticSearch/Sinks/ElasticSearch/ElasticsearchJsonFormatter-net40.cs
+++ b/src/Serilog.Sinks.ElasticSearch/Sinks/ElasticSearch/ElasticsearchJsonFormatter-net40.cs
@@ -83,7 +83,7 @@ namespace Serilog.Sinks.ElasticSearch
         /// </summary>
         protected override void WriteRenderedMessage(string message, ref string delim, TextWriter output)
         {
-            WriteJsonProperty("renderedMessage", message, ref delim, output);
+            WriteJsonProperty("message", message, ref delim, output);
         }
         
         /// <summary>


### PR DESCRIPTION
...enderedMessage"

This change was made in the other elasticsearch json formatter, but not in the .net 4.0 one. So this should be changed here as well.