### PR TITLE
Wait for Loggly client to submit the log event.

### DIFF
--- a/src/Serilog.Sinks.Loggly/LoggerConfigurationLogglyExtensions.cs
+++ b/src/Serilog.Sinks.Loggly/LoggerConfigurationLogglyExtensions.cs
@@ -30,17 +30,23 @@ namespace Serilog
         /// <param name="loggerConfiguration">The logger configuration.</param>
         /// <param name="restrictedToMinimumLevel">The minimum log event level required in order to write an event to the sink.</param>
         /// <param name="formatProvider">Supplies culture-specific formatting information, or null.</param>
+        /// <param name="batchPostingLimit">The maximum number of events to post in a single batch.</param>
+        /// <param name="period">The time to wait between checking for event batches.</param>
         /// <returns>Logger configuration, allowing configuration to continue.</returns>
         /// <exception cref="ArgumentNullException">A required parameter is null.</exception>
         public static LoggerConfiguration Loggly(
             this LoggerSinkConfiguration loggerConfiguration,
             LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
+            int batchPostingLimit = LogglySink.DefaultBatchPostingLimit,
+            TimeSpan? period = null,
             IFormatProvider formatProvider = null)
         {
             if (loggerConfiguration == null) throw new ArgumentNullException("loggerConfiguration");
 
+            var defaultedPeriod = period ?? LogglySink.DefaultPeriod;
+
             return loggerConfiguration.Sink(
-                new LogglySink(formatProvider),
+                new LogglySink(formatProvider, batchPostingLimit, defaultedPeriod),
                 restrictedToMinimumLevel);
         }
 

--- a/src/Serilog.Sinks.Loggly/Serilog.Sinks.Loggly.csproj
+++ b/src/Serilog.Sinks.Loggly/Serilog.Sinks.Loggly.csproj
@@ -73,6 +73,10 @@
     </None>
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\Serilog.FullNetFx\Serilog.FullNetFx.csproj">
+      <Project>{7A9E1095-167D-402A-B43D-B36B97FF183D}</Project>
+      <Name>Serilog.FullNetFx</Name>
+    </ProjectReference>
     <ProjectReference Include="..\Serilog\Serilog.csproj">
       <Project>{0915DBD9-0F7C-4439-8D9E-74C3D579B219}</Project>
       <Name>Serilog</Name>

--- a/src/Serilog.Sinks.Loggly/Sinks/Loggly/LogglySink.cs
+++ b/src/Serilog.Sinks.Loggly/Sinks/Loggly/LogglySink.cs
@@ -73,7 +73,7 @@ namespace Serilog.Sinks.Loggly
                 logglyEvent.Data.AddIfAbsent("Exception", logEvent.Exception);
             }
 
-            _client.Log(logglyEvent);
+            _client.Log(logglyEvent).Wait();
         }
 
         static SyslogLevel ToSyslogLevel(LogEvent logEvent)


### PR DESCRIPTION
In the current version of loggly-csharp, client.Log returns a Task, so it needs to be awaited or .Wait()ed otherwise the log message will not succeed if the calling thread is aborted quickly.

https://github.com/neutmute/loggly-csharp/commit/e38b247caa5ce7a1a6c43608635fe4e9a82c9dd9