### PR TITLE
Provides a System.Diagnostics.TraceListener implementation that outputs to Serilog

### DIFF
--- a/Serilog.sln
+++ b/Serilog.sln
@@ -108,6 +108,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Serilog.Sinks.AzureDocument
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Serilog.MsTests", "test\Serilog.MsTests\Serilog.MsTests.csproj", "{7FC9FC46-5014-4461-A448-815E6CCE21E5}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Serilog.Extras.TraceListener", "src\Serilog.Extras.TraceListener\Serilog.Extras.TraceListener.csproj", "{956ED9D7-DC59-4A46-AC32-A255AEAD383B}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Serilog.Extras.TraceListener.Tests", "test\Serilog.Extras.TraceListener.Tests\Serilog.Extras.TraceListener.Tests.csproj", "{FEC03AF0-D6C1-4987-8938-C142D93362D7}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -296,6 +300,14 @@ Global
 		{7FC9FC46-5014-4461-A448-815E6CCE21E5}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{7FC9FC46-5014-4461-A448-815E6CCE21E5}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7FC9FC46-5014-4461-A448-815E6CCE21E5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{956ED9D7-DC59-4A46-AC32-A255AEAD383B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{956ED9D7-DC59-4A46-AC32-A255AEAD383B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{956ED9D7-DC59-4A46-AC32-A255AEAD383B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{956ED9D7-DC59-4A46-AC32-A255AEAD383B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FEC03AF0-D6C1-4987-8938-C142D93362D7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FEC03AF0-D6C1-4987-8938-C142D93362D7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FEC03AF0-D6C1-4987-8938-C142D93362D7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FEC03AF0-D6C1-4987-8938-C142D93362D7}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -347,5 +359,7 @@ Global
 		{7E96D14B-2224-4EB9-B26B-6306D225024F} = {037440DE-440B-4129-9F7A-09B42D00397E}
 		{C1875BEA-4509-4E04-AB8F-C2F8169BF001} = {037440DE-440B-4129-9F7A-09B42D00397E}
 		{7FC9FC46-5014-4461-A448-815E6CCE21E5} = {0D135C0C-A60B-454A-A2F4-CD74A30E04B0}
+		{956ED9D7-DC59-4A46-AC32-A255AEAD383B} = {037440DE-440B-4129-9F7A-09B42D00397E}
+		{FEC03AF0-D6C1-4987-8938-C142D93362D7} = {0D135C0C-A60B-454A-A2F4-CD74A30E04B0}
 	EndGlobalSection
 EndGlobal

--- a/packages/repositories.config
+++ b/packages/repositories.config
@@ -27,6 +27,7 @@
   <repository path="..\test\Serilog.Extras.Attributed.Tests\packages.config" />
   <repository path="..\test\Serilog.Extras.DestructureByIgnoring.Tests\packages.config" />
   <repository path="..\test\Serilog.Extras.MSOwin.Tests\packages.config" />
+  <repository path="..\test\Serilog.Extras.TraceListener.Tests\packages.config" />
   <repository path="..\test\Serilog.Sinks.AzureTableStorageWithProperties.Tests\packages.config" />
   <repository path="..\test\Serilog.Sinks.Elasticsearch.Tests\packages.config" />
   <repository path="..\test\Serilog.Sinks.RavenDB.Tests\packages.config" />

--- a/src/Serilog.Extras.TraceListener/App.config
+++ b/src/Serilog.Extras.TraceListener/App.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+    <startup> 
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
+    </startup>
+</configuration>

--- a/src/Serilog.Extras.TraceListener/App.config
+++ b/src/Serilog.Extras.TraceListener/App.config
@@ -1,6 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
-<configuration>
-    <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
-    </startup>
-</configuration>

--- a/src/Serilog.Extras.TraceListener/Extras/TraceListener/SerilogTraceListener.cs
+++ b/src/Serilog.Extras.TraceListener/Extras/TraceListener/SerilogTraceListener.cs
@@ -1,0 +1,195 @@
+﻿// Copyright 2015 Serilog Contributors
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using Serilog.Core.Pipeline;
+using Serilog.Events;
+
+namespace Serilog.Extras.TraceListener
+{
+    /// <summary>
+    ///     TraceListener implementation that directs all output to Serilog.
+    /// </summary>
+    public class SerilogTraceListener : System.Diagnostics.TraceListener
+    {
+        const LogEventLevel FailLevel = LogEventLevel.Fatal;
+        const string MessageMessageTemplate = "{TraceMessage:l}";
+        const string FailMessageTemplate = "Fail: " + MessageMessageTemplate;
+        const LogEventLevel DefaultLogLevel = LogEventLevel.Debug;
+        ILogger logger;
+
+        /// <summary>
+        ///     Creates a SerilogTraceListener that uses the logger from `Serilog.Log`
+        /// </summary>
+        /// <remarks>
+        ///     This is needed because TraceListeners are often configured through XML
+        ///     where there would be no opportunity for constructor injection
+        /// </remarks>
+        public SerilogTraceListener() : this(Log.Logger)
+        {
+        }
+
+        /// <summary>
+        ///     Creates a SerilogTraceListener that uses the specified logger
+        /// </summary>
+        public SerilogTraceListener(ILogger logger)
+        {
+            this.logger = logger.ForContext<SerilogTraceListener>();
+        }
+
+        public override bool IsThreadSafe
+        {
+            get { return true; }
+        }
+
+        public override void Write(string message)
+        {
+            logger.Write(DefaultLogLevel, MessageMessageTemplate, message);
+        }
+
+        public override void Write(string message, string category)
+        {
+            logger.Write(DefaultLogLevel, "{Category:l}: " + MessageMessageTemplate, category, message);
+        }
+
+        public override void WriteLine(string message)
+        {
+            Write(message);
+        }
+
+        public override void WriteLine(string message, string category)
+        {
+            Write(message, category);
+        }
+
+        public override void Fail(string message)
+        {
+            logger.Write(FailLevel, FailMessageTemplate, message);
+        }
+
+        public override void Fail(string message, string detailMessage)
+        {
+            logger.Write(FailLevel, FailMessageTemplate + " {FailDetails:l}", message, detailMessage);
+        }
+
+        public override void Close()
+        {
+            logger = new SilentLogger();
+            base.Close();
+        }
+
+        public override void TraceData(TraceEventCache eventCache, string source, TraceEventType eventType, int id, object data)
+        {
+            WriteEvent(eventCache, source, eventType, id, data: data);
+        }
+
+        public override void TraceData(TraceEventCache eventCache, string source, TraceEventType eventType, int id, params object[] data)
+        {
+            WriteEvent(eventCache, source, eventType, id, data: data);
+        }
+
+        public override void TraceTransfer(TraceEventCache eventCache, string source, int id, string message, Guid relatedActivityId)
+        {
+            const TraceEventType eventType = TraceEventType.Transfer;
+            WriteEvent(eventCache, source, eventType, id, message, relatedActivityId);
+        }
+
+        public override void TraceEvent(TraceEventCache eventCache, string source, TraceEventType eventType, int id)
+        {
+            WriteEvent(eventCache, source, eventType, id);
+        }
+
+        public override void TraceEvent(TraceEventCache eventCache, string source, TraceEventType eventType, int id, string message)
+        {
+            WriteEvent(eventCache, source, eventType, id, message);
+        }
+
+        public override void TraceEvent(TraceEventCache eventCache, string source, TraceEventType eventType, int id, string format, params object[] args)
+        {
+            WriteEvent(eventCache, source, eventType, id, string.Format(CultureInfo.InvariantCulture, format, args));
+        }
+
+        void WriteEvent(TraceEventCache eventCache, string source, TraceEventType eventType, int id, string message = null, Guid? relatedActivityId = null, object data = null)
+        {
+            IList<object> propertyValues = new List<object>
+            {
+                source,
+                eventType,
+                id
+            };
+
+            var template = new StringBuilder("{TraceSource:l} {TraceEventType}: {TraceEventId}");
+
+            if (message != null)
+            {
+                template.AppendLine(" :");
+                template.Append(MessageMessageTemplate);
+
+                propertyValues.Add(message);
+            }
+
+            if (data != null)
+            {
+                template.AppendLine(" :");
+                template.Append("{TraceData:l}");
+                propertyValues.Add(data);
+            }
+
+            if (relatedActivityId.HasValue)
+            {
+                template.Append(", relatedActivityId={RelatedActivityId}");
+                propertyValues.Add(relatedActivityId);
+            }
+
+            LogEventLevel level = ToLogEventLevel(eventType);
+            logger.Write(level, template.ToString(), propertyValues.ToArray());
+        }
+
+        internal static LogEventLevel ToLogEventLevel(TraceEventType eventType)
+        {
+            switch (eventType)
+            {
+                case TraceEventType.Critical:
+                {
+                    return LogEventLevel.Fatal;
+                }
+                case TraceEventType.Error:
+                {
+                    return LogEventLevel.Error;
+                }
+                case TraceEventType.Information:
+                {
+                    return LogEventLevel.Information;
+                }
+                case TraceEventType.Warning:
+                {
+                    return LogEventLevel.Warning;
+                }
+                case TraceEventType.Verbose:
+                {
+                    return LogEventLevel.Verbose;
+                }
+                default:
+                {
+                    return LogEventLevel.Debug;
+                }
+            }
+        }
+    }
+}

--- a/src/Serilog.Extras.TraceListener/Properties/AssemblyInfo.cs
+++ b/src/Serilog.Extras.TraceListener/Properties/AssemblyInfo.cs
@@ -5,4 +5,8 @@ using System.Runtime.CompilerServices;
 [assembly: AssemblyDescription("Serilog logging support capturing trace logging done through Systems.Diagnostics")]
 [assembly: AssemblyCopyright("Copyright © Serilog Contributors 2015")]
 
-[assembly: InternalsVisibleTo("Serilog.Extras.TraceListener.Tests") ]
+[assembly: InternalsVisibleTo("Serilog.Extras.TraceListener.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100fb8d13fd344a1c" +
+                                                       "6fe0fe83ef33c1080bf30690765bc6eb0df26ebfdf8f21670c64265b30db09f73a0dea5b3db4c9" +
+                                                       "d18dbf6d5a25af5ce9016f281014d79dc3b4201ac646c451830fc7e61a2dfd633d34c39f87b818" +
+                                                       "94191652df5ac63cc40c77f3542f702bda692e6e8a9158353df189007a49da0f3cfd55eb250066" +
+                                                       "b19485ec") ]

--- a/src/Serilog.Extras.TraceListener/Properties/AssemblyInfo.cs
+++ b/src/Serilog.Extras.TraceListener/Properties/AssemblyInfo.cs
@@ -1,0 +1,8 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+
+[assembly: AssemblyTitle("Serilog.Extras.TraceListener")]
+[assembly: AssemblyDescription("Serilog logging support capturing trace logging done through Systems.Diagnostics")]
+[assembly: AssemblyCopyright("Copyright © Serilog Contributors 2015")]
+
+[assembly: InternalsVisibleTo("Serilog.Extras.TraceListener.Tests") ]

--- a/src/Serilog.Extras.TraceListener/Serilog.Extras.TraceListener.csproj
+++ b/src/Serilog.Extras.TraceListener/Serilog.Extras.TraceListener.csproj
@@ -1,0 +1,68 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{956ED9D7-DC59-4A46-AC32-A255AEAD383B}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Serilog</RootNamespace>
+    <AssemblyName>Serilog.Extras.TraceListener</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup>
+    <StartupObject />
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\..\assets\CommonAssemblyInfo.cs">
+      <Link>Properties\CommonAssemblyInfo.cs</Link>
+    </Compile>
+    <Compile Include="..\..\src\Serilog\Core\Pipeline\SilentLogger.cs">
+      <Link>Core\Pipeline\SilentLogger.cs</Link>
+    </Compile>
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Extras\TraceListener\SerilogTraceListener.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Serilog\Serilog.csproj">
+      <Project>{0915dbd9-0f7c-4439-8d9e-74c3d579b219}</Project>
+      <Name>Serilog</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/src/Serilog.Extras.TraceListener/Serilog.Extras.TraceListener.csproj
+++ b/src/Serilog.Extras.TraceListener/Serilog.Extras.TraceListener.csproj
@@ -58,7 +58,7 @@
     <None Include="..\..\assets\Serilog.snk">
       <Link>Serilog.snk</Link>
     </None>
-    <None Include="App.config" />
+    <None Include="Serilog.Extras.TraceListener.nuspec" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Serilog\Serilog.csproj">

--- a/src/Serilog.Extras.TraceListener/Serilog.Extras.TraceListener.csproj
+++ b/src/Serilog.Extras.TraceListener/Serilog.Extras.TraceListener.csproj
@@ -34,6 +34,12 @@
   <PropertyGroup>
     <StartupObject />
   </PropertyGroup>
+  <PropertyGroup>
+    <SignAssembly>true</SignAssembly>
+  </PropertyGroup>
+  <PropertyGroup>
+    <AssemblyOriginatorKeyFile>..\..\assets\Serilog.snk</AssemblyOriginatorKeyFile>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -49,6 +55,9 @@
     <Compile Include="Extras\TraceListener\SerilogTraceListener.cs" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="..\..\assets\Serilog.snk">
+      <Link>Serilog.snk</Link>
+    </None>
     <None Include="App.config" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Serilog.Extras.TraceListener/Serilog.Extras.TraceListener.nuspec
+++ b/src/Serilog.Extras.TraceListener/Serilog.Extras.TraceListener.nuspec
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+  <metadata>
+    <id>Serilog.Extras.TraceListener</id>
+    <version>$version$</version>
+    <authors>Serilog Contributors</authors>
+    <description>Provides a System.Diagnostics.TraceListener implementation that outputs to Serilog.</description>
+    <language>en-US</language>
+    <projectUrl>http://serilog.net</projectUrl>
+    <licenseUrl>http://www.apache.org/licenses/LICENSE-2.0</licenseUrl>
+    <iconUrl>http://serilog.net/images/serilog-nuget.png</iconUrl>
+    <tags>serilog logging diagnostics tracing TraceListener</tags>
+    <dependencies>
+      <dependency id="Serilog" version="$version$" />
+    </dependencies>
+  </metadata>
+</package>

--- a/test/Serilog.Extras.TraceListener.Tests/Extras/TraceListener/SerilogTraceListenerSeverityConversionTests.cs
+++ b/test/Serilog.Extras.TraceListener.Tests/Extras/TraceListener/SerilogTraceListenerSeverityConversionTests.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using NUnit.Framework;
+
+namespace Serilog.Extras.TraceListener.Tests
+{
+    [TestFixture]
+    public class SerilogTraceListenerSeverityConversionTests
+    {
+        static IEnumerable<TraceEventType> allTraceEventTypes = Enum.GetValues(typeof(TraceEventType)).Cast<TraceEventType>();
+
+        [Test]
+        public void CanConvertAnyTraceEventType([ValueSource("allTraceEventTypes")] TraceEventType sourceType)
+        {
+            TestDelegate act = () => SerilogTraceListener.ToLogEventLevel(sourceType);
+
+            Assert.DoesNotThrow(act);
+        }
+    }
+}

--- a/test/Serilog.Extras.TraceListener.Tests/Extras/TraceListener/SerilogTraceListenerTests.cs
+++ b/test/Serilog.Extras.TraceListener.Tests/Extras/TraceListener/SerilogTraceListenerTests.cs
@@ -1,0 +1,278 @@
+﻿using System;
+using System.Diagnostics;
+using NUnit.Framework;
+using Serilog.Events;
+using Serilog.Tests.Support;
+
+namespace Serilog.Extras.TraceListener.Tests
+{
+    [TestFixture]
+    public class SerilogTraceListenerTests
+    {
+        const TraceEventType WarningEventType = TraceEventType.Warning;
+        readonly string _category = Some.String("category");
+        readonly int _id = Some.Int();
+        readonly string _message = Some.String("message");
+        readonly string _source = Some.String("source");
+        readonly TraceEventCache _traceEventCache = new TraceEventCache();
+
+        SerilogTraceListener _traceListener;
+        LogEvent _loggedEvent;
+
+        [SetUp]
+        public void SetUp()
+        {
+            var delegatingSink = new DelegatingSink(evt => { _loggedEvent = evt; });
+            var logger = new LoggerConfiguration().MinimumLevel.Verbose().WriteTo.Sink(delegatingSink).CreateLogger();
+
+            _loggedEvent = null;
+            _traceListener = new SerilogTraceListener(logger);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            _traceListener.Dispose();
+        }
+
+        [Test]
+        public void CapturesWrite()
+        {
+            _traceListener.Write(_message);
+
+            LogEventAssert.HasMessage(_message, _loggedEvent);
+            LogEventAssert.HasLevel(LogEventLevel.Debug, _loggedEvent);
+            LogEventAssert.HasPropertyValue(typeof(SerilogTraceListener).ToString(), "SourceContext", _loggedEvent);
+        }
+
+        [Test]
+        public void CapturesWriteWithCategory()
+        {
+            _traceListener.Write(_message, _category);
+
+            LogEventAssert.HasMessage(string.Format("{0}: {1}", _category, _message), _loggedEvent);
+            LogEventAssert.HasLevel(LogEventLevel.Debug, _loggedEvent);
+            LogEventAssert.HasPropertyValue(_category, "Category", _loggedEvent);
+        }
+
+        [Test]
+        public void CapturesWriteOfObjectUsingToString()
+        {
+            var writtenObject = Tuple.Create(Some.String());
+            _traceListener.Write(writtenObject);
+
+            LogEventAssert.HasMessage(writtenObject.ToString(), _loggedEvent);
+            LogEventAssert.HasLevel(LogEventLevel.Debug, _loggedEvent);
+        }
+
+        [Test]
+        public void CapturesWriteOfObjectUsingToStringWithCategory()
+        {
+            var writtenObject = Tuple.Create(Some.String());
+            _traceListener.Write(writtenObject, _category);
+
+            LogEventAssert.HasMessage(string.Format("{0}: {1}", _category, writtenObject), _loggedEvent);
+            LogEventAssert.HasLevel(LogEventLevel.Debug, _loggedEvent);
+            LogEventAssert.HasPropertyValue(_category, "Category", _loggedEvent);
+        }
+
+        [Test]
+        public void CapturesWriteLine()
+        {
+            _traceListener.WriteLine(_message);
+
+            LogEventAssert.HasMessage(_message, _loggedEvent);
+            LogEventAssert.HasLevel(LogEventLevel.Debug, _loggedEvent);
+        }
+
+        [Test]
+        public void CapturesWriteLineWithCategory()
+        {
+            _traceListener.WriteLine(_message, _category);
+
+            LogEventAssert.HasMessage(string.Format("{0}: {1}", _category, _message), _loggedEvent);
+            LogEventAssert.HasLevel(LogEventLevel.Debug, _loggedEvent);
+            LogEventAssert.HasPropertyValue(_category, "Category", _loggedEvent);
+        }
+
+        [Test]
+        public void CapturesWriteLineOfObjectUsingToString()
+        {
+            var writtenObject = Tuple.Create(Some.String());
+            _traceListener.WriteLine(writtenObject);
+
+            LogEventAssert.HasMessage(writtenObject.ToString(), _loggedEvent);
+            LogEventAssert.HasLevel(LogEventLevel.Debug, _loggedEvent);
+        }
+
+        [Test]
+        public void CapturesWriteLineOfObjectUsingToStringWithCategory()
+        {
+            var writtenObject = Tuple.Create(Some.String());
+            _traceListener.WriteLine(writtenObject, _category);
+
+            LogEventAssert.HasMessage(string.Format("{0}: {1}", _category, writtenObject), _loggedEvent);
+            LogEventAssert.HasLevel(LogEventLevel.Debug, _loggedEvent);
+            LogEventAssert.HasPropertyValue(_category, "Category", _loggedEvent);
+        }
+
+        [Test]
+        public void CapturesFail()
+        {
+            _traceListener.Fail(_message);
+
+            LogEventAssert.HasMessage("Fail: " + _message, _loggedEvent);
+            LogEventAssert.HasLevel(LogEventLevel.Fatal, _loggedEvent);
+        }
+
+        [Test]
+        public void CapturesFailWithDetailedDescription()
+        {
+            var detailMessage = Some.String();
+
+            _traceListener.Fail(_message, detailMessage);
+
+            LogEventAssert.HasMessage(string.Format("Fail: {0} {1}", _message, detailMessage), _loggedEvent);
+            LogEventAssert.HasLevel(LogEventLevel.Fatal, _loggedEvent);
+            LogEventAssert.HasPropertyValue(detailMessage, "FailDetails", _loggedEvent);
+        }
+
+        [Test]
+        public void StopsCapturingAfterCloseIsCalled()
+        {
+            _traceListener.Close();
+
+            _traceListener.Write(_message);
+
+            Assert.That(_loggedEvent, Is.Null);
+        }
+
+        [Test]
+        public void CapturesTraceEvent()
+        {
+            _traceListener.TraceEvent(_traceEventCache, _source, WarningEventType, _id);
+
+            LogEventAssert.HasMessage(string.Format("{0} {1}: {2}", _source, WarningEventType, _id), _loggedEvent);
+
+            LogEventAssert.HasLevel(LogEventLevel.Warning, _loggedEvent);
+
+            LogEventAssert.HasPropertyValue(_id, "TraceEventId", _loggedEvent);
+            LogEventAssert.HasPropertyValue(_source, "TraceSource", _loggedEvent);
+            LogEventAssert.HasPropertyValue(WarningEventType, "TraceEventType", _loggedEvent);
+        }
+
+        [Test]
+        public void CapturesTraceEventWithMessage()
+        {
+            _traceListener.TraceEvent(_traceEventCache, _source, WarningEventType, _id, _message);
+
+            LogEventAssert.HasMessage(
+                string.Format("{0} {1}: {2} :" + Environment.NewLine + "{3}", _source, WarningEventType, _id, _message),
+                _loggedEvent);
+
+            LogEventAssert.HasLevel(LogEventLevel.Warning, _loggedEvent);
+
+            LogEventAssert.HasPropertyValue(_id, "TraceEventId", _loggedEvent);
+            LogEventAssert.HasPropertyValue(_source, "TraceSource", _loggedEvent);
+            LogEventAssert.HasPropertyValue(WarningEventType, "TraceEventType", _loggedEvent);
+        }
+
+        [Test]
+        public void CapturesTraceEventWithFormatMessage()
+        {
+            const string format = "{0}-{1}-{2}";
+            var args = new object[]
+            {
+                Some.String(),
+                Some.String(),
+                Some.String()
+            };
+
+            _traceListener.TraceEvent(_traceEventCache, _source, WarningEventType, _id, format, args);
+
+            LogEventAssert.HasMessage(
+                string.Format("{0} {1}: {2} :" + Environment.NewLine + "{3}", _source, WarningEventType, _id, string.Format(format, args)),
+                _loggedEvent);
+
+            LogEventAssert.HasLevel(LogEventLevel.Warning, _loggedEvent);
+
+            LogEventAssert.HasPropertyValue(_id, "TraceEventId", _loggedEvent);
+            LogEventAssert.HasPropertyValue(_source, "TraceSource", _loggedEvent);
+            LogEventAssert.HasPropertyValue(WarningEventType, "TraceEventType", _loggedEvent);
+        }
+
+        [Test]
+        public void CapturesTraceTransfer()
+        {
+            var relatedActivityId = Some.Guid();
+
+            _traceListener.TraceTransfer(_traceEventCache, _source, _id, _message, relatedActivityId);
+
+            LogEventAssert.HasMessage(
+                string.Format("{0} Transfer: {1} :" + Environment.NewLine + "{2}, relatedActivityId={3}", _source, _id, _message, relatedActivityId),
+                _loggedEvent);
+
+            LogEventAssert.HasLevel(LogEventLevel.Debug, _loggedEvent);
+
+            LogEventAssert.HasPropertyValue(_id, "TraceEventId", _loggedEvent);
+            LogEventAssert.HasPropertyValue(_source, "TraceSource", _loggedEvent);
+            LogEventAssert.HasPropertyValue(relatedActivityId, "RelatedActivityId", _loggedEvent);
+        }
+
+        [Test]
+        public void CapturesTraceData()
+        {
+            var data = new
+            {
+                Info = Some.String()
+            };
+
+            _traceListener.TraceData(_traceEventCache, _source, WarningEventType, _id, data);
+
+            LogEventAssert.HasMessage(
+                string.Format("{0} {1}: {2} :" + Environment.NewLine + "{3}", _source, WarningEventType, _id, data),
+                _loggedEvent);
+
+            LogEventAssert.HasLevel(LogEventLevel.Warning, _loggedEvent);
+
+            LogEventAssert.HasPropertyValue(_id, "TraceEventId", _loggedEvent);
+            LogEventAssert.HasPropertyValue(_source, "TraceSource", _loggedEvent);
+            LogEventAssert.HasPropertyValue(data.ToString(), "TraceData", _loggedEvent);
+        }
+
+        [Test]
+        public void CapturesTraceDataWithMultipleData()
+        {
+            var data1 = new
+            {
+                Info = Some.String()
+            };
+            var data2 = new
+            {
+                Info = Some.String()
+            };
+            var data3 = new
+            {
+                Info = Some.Int()
+            };
+
+            _traceListener.TraceData(_traceEventCache, _source, WarningEventType, _id, data1, data2, data3);
+
+            // The square-brackets ('[' ,']') are because of serilog behavior and are not how the stock TraceListener would behave.
+            LogEventAssert.HasMessage(
+                string.Format("{0} {1}: {2} :" + Environment.NewLine + "[{3}]", _source, WarningEventType, _id, string.Join(", ", data1, data2, data3)),
+                _loggedEvent);
+
+            LogEventAssert.HasLevel(LogEventLevel.Warning, _loggedEvent);
+
+            LogEventAssert.HasPropertyValue(_id, "TraceEventId", _loggedEvent);
+            LogEventAssert.HasPropertyValue(_source, "TraceSource", _loggedEvent);
+            LogEventAssert.HasPropertyValueSequenceValue(new object[]
+            {
+                data1,
+                data2,
+                data3
+            }, "TraceData", _loggedEvent);
+        }
+    }
+}

--- a/test/Serilog.Extras.TraceListener.Tests/Serilog.Extras.TraceListener.Tests.csproj
+++ b/test/Serilog.Extras.TraceListener.Tests/Serilog.Extras.TraceListener.Tests.csproj
@@ -1,0 +1,72 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{FEC03AF0-D6C1-4987-8938-C142D93362D7}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Serilog</RootNamespace>
+    <AssemblyName>Serilog.Extras.TraceListener.Tests</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="nunit.framework">
+      <HintPath>..\..\packages\NUnit.2.6.3\lib\nunit.framework.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Extras\TraceListener\SerilogTraceListenerSeverityConversionTests.cs" />
+    <Compile Include="Extras\TraceListener\SerilogTraceListenerTests.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Serilog.Extras.TraceListener\Serilog.Extras.TraceListener.csproj">
+      <Project>{956ED9D7-DC59-4A46-AC32-A255AEAD383B}</Project>
+      <Name>Serilog.Extras.TraceListener</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\src\Serilog.FullNetFx\Serilog.FullNetFx.csproj">
+      <Project>{7A9E1095-167D-402A-B43D-B36B97FF183D}</Project>
+      <Name>Serilog.FullNetFx</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\src\Serilog\Serilog.csproj">
+      <Project>{0915DBD9-0F7C-4439-8D9E-74C3D579B219}</Project>
+      <Name>Serilog</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\Serilog.Tests\Serilog.Tests.csproj">
+      <Project>{D5648551-D19D-41E3-9FC1-E74B111EEF41}</Project>
+      <Name>Serilog.Tests</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/test/Serilog.Extras.TraceListener.Tests/Serilog.Extras.TraceListener.Tests.csproj
+++ b/test/Serilog.Extras.TraceListener.Tests/Serilog.Extras.TraceListener.Tests.csproj
@@ -29,6 +29,12 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
+  <PropertyGroup>
+    <SignAssembly>true</SignAssembly>
+  </PropertyGroup>
+  <PropertyGroup>
+    <AssemblyOriginatorKeyFile>..\..\assets\Serilog.snk</AssemblyOriginatorKeyFile>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="nunit.framework">
       <HintPath>..\..\packages\NUnit.2.6.3\lib\nunit.framework.dll</HintPath>
@@ -41,6 +47,9 @@
     <Compile Include="Extras\TraceListener\SerilogTraceListenerTests.cs" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="..\..\assets\Serilog.snk">
+      <Link>Serilog.snk</Link>
+    </None>
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>

--- a/test/Serilog.Extras.TraceListener.Tests/packages.config
+++ b/test/Serilog.Extras.TraceListener.Tests/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="NUnit" version="2.6.3" targetFramework="net45" />
+</packages>

--- a/test/Serilog.Tests/Serilog.Tests.csproj
+++ b/test/Serilog.Tests/Serilog.Tests.csproj
@@ -100,7 +100,9 @@
     <Compile Include="Sinks\TextWriter\TextWriterSinkTests.cs" />
     <Compile Include="Support\DelegatingEnricher.cs" />
     <Compile Include="Support\DelegatingSink.cs" />
+    <Compile Include="Support\DictionaryContainsKeyConstraint.cs" />
     <Compile Include="Support\Extensions.cs" />
+    <Compile Include="Support\LogEventAssert.cs" />
     <Compile Include="Support\Some.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/test/Serilog.Tests/Support/DictionaryContainsKeyConstraint.cs
+++ b/test/Serilog.Tests/Support/DictionaryContainsKeyConstraint.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Collections;
+using NUnit.Framework.Constraints;
+
+namespace Serilog.Tests.Support
+{
+    /// <summary>
+    /// Helper class with properties and methods that supply
+    ///             a number of constraints used in Asserts.
+    /// </summary>
+    public static class ContainsEx
+    {
+        public static DictionaryContainsKeyConstraint Key(object key )
+        {
+            return new DictionaryContainsKeyConstraint(key);
+        }
+    }
+
+    /// <remarks>Backport from NUnit 3.0</remarks>
+    public class DictionaryContainsKeyConstraint : CollectionContainsConstraint
+    {
+        object expected;
+
+        /// <summary>
+        ///     Construct a DictionaryContainsKeyConstraint
+        /// </summary>
+        /// <param name="expected"></param>
+        public DictionaryContainsKeyConstraint(object expected)
+            : base(expected)
+        {
+            this.expected = expected;
+            DisplayName = "ContainsKey";
+        }
+
+        public override void WriteDescriptionTo(MessageWriter writer)
+        {
+            writer.WritePredicate("dictionary containing key ");
+            writer.WriteExpectedValue(expected);
+        }
+
+        /// <summary>
+        ///     Test whether the expected key is contained in the dictionary
+        /// </summary>
+        // ReSharper disable once ParameterHidesMember
+        protected override bool doMatch(IEnumerable actual)
+        {
+            IDictionary dictionary = actual as IDictionary;
+
+            if (dictionary == null)
+                throw new ArgumentException("The actual value must be an IDictionary", "actual");
+
+            return base.doMatch(dictionary.Keys);
+        }
+    }
+}

--- a/test/Serilog.Tests/Support/LogEventAssert.cs
+++ b/test/Serilog.Tests/Support/LogEventAssert.cs
@@ -1,0 +1,51 @@
+using System.Linq;
+using NUnit.Framework;
+using Serilog.Events;
+
+namespace Serilog.Tests.Support
+{
+    /// <summary>
+    ///     The LogEventAssert class contains a collection of static methods that
+    ///     implement assertions againt Serilog.Events.LogEvent
+    /// </summary>
+    public static class LogEventAssert
+    {
+        public static void HasLevel(LogEventLevel level, LogEvent logEvent)
+        {
+            Assert.That(logEvent.Level, Is.EqualTo(level), "A log level different from the expected was found.");
+        }
+
+        public static void HasMessage(string message, LogEvent logEvent)
+        {
+            Assert.That(logEvent.RenderMessage(), Is.EqualTo(message), "The rendered message was not as expected.");
+        }
+
+        public static void HasProperty(string propertyName, LogEvent logEvent)
+        {
+            Assert.That(logEvent.Properties, ContainsEx.Key(propertyName), "Exected property was not found.");
+        }
+
+        public static void DoesNotHaveProperty(string propertyName, LogEvent logEvent)
+        {
+            Assert.That(logEvent.Properties.ContainsKey(propertyName), Is.False, "Found property {0} when it should not have been found", propertyName);
+        }
+
+        public static void HasPropertyValue(object propertyValue, string propertyName, LogEvent logEvent)
+        {
+            HasProperty(propertyName, logEvent);
+
+            LogEventPropertyValue value = logEvent.Properties[propertyName];
+            Assert.That(value.LiteralValue(), Is.EqualTo(propertyValue), "The property value was not as expected");
+        }
+
+        public static void HasPropertyValueSequenceValue(object[] propertyValue, string propertyName, LogEvent logEvent)
+        {
+            HasProperty(propertyName, logEvent);
+
+            LogEventPropertyValue value = logEvent.Properties[propertyName];
+            var sequence = ((SequenceValue) value).Elements.Select(pv => pv.LiteralValue());
+
+            Assert.That(sequence, Is.EquivalentTo(propertyValue.Select(_ => _.ToString())), "The property value was not as expected");
+        }
+    }
+}

--- a/test/Serilog.Tests/Support/Some.cs
+++ b/test/Serilog.Tests/Support/Some.cs
@@ -7,7 +7,7 @@ using Serilog.Parsing;
 
 namespace Serilog.Tests.Support
 {
-    static class Some
+    public static class Some
     {
         static int Counter;
 
@@ -24,6 +24,11 @@ namespace Serilog.Tests.Support
         public static string String(string tag = null)
         {
             return (tag ?? "") + "__" + Int();
+        }
+
+        public static Guid Guid()
+        {
+            return System.Guid.NewGuid();
         }
 
         public static TimeSpan TimeSpan()
@@ -54,7 +59,7 @@ namespace Serilog.Tests.Support
 
         public static string NonexistentTempFilePath()
         {
-            return Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".txt");
+            return Path.Combine(Path.GetTempPath(), Guid() + ".txt");
         }
 
         public static string TempFilePath()
@@ -64,7 +69,7 @@ namespace Serilog.Tests.Support
 
         public static string TempFolderPath()
         {
-            var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            var dir = Path.Combine(Path.GetTempPath(), Guid().ToString());
             Directory.CreateDirectory(dir);
             return dir;
         }


### PR DESCRIPTION
Provides a [`System.Diagnostics.TraceListener`](https://msdn.microsoft.com/en-us/library/system.diagnostics.tracelistener%28v=vs.110%29.aspx) implementation that outputs to Serilog.  As far as existing Serilog functionality this is probably most similar to `Serilog.Extras.MSOwin.LoggerFactory`

This came about because, near as I could tell, WCF only logs to Microsoft's tracing infrastructure so if you want consolidated logging `TraceListener` is the only extension point.

This does not respect the `TraceListener.Filter` member, I am not sure if contractually it needs to.  I noted that [NLog's TraceListener](https://github.com/NLog/NLog/blob/00d53bc3b234917517e2fdc1735f8b4af2d5d8aa/src/NLog/NLogTraceListener.cs) also does respect `Filter` so it seems there is some precedent for this.

I have never authored a .nuspec; nor, to be honest, am I especially familiar with either Serilog or System.Diagnostics, so I mostly just tried to follow conventions and hopefully did all right.
___
To Do
- [x] Reduce string concatenation