### PR TITLE
Corrects a minor spelling mistake in the description of the MSOwin nuget package

### DIFF
--- a/src/Serilog.Extras.MSOwin/Serilog.Extras.MSOwin.nuspec
+++ b/src/Serilog.Extras.MSOwin/Serilog.Extras.MSOwin.nuspec
@@ -4,7 +4,7 @@
     <id>Serilog.Extras.MSOwin</id>
     <version>$version$</version>
     <authors>Serilog Contributors</authors>
-    <description>Provides request correlation middelware and integration with Microsoft.Owin logging.</description>
+    <description>Provides request correlation middleware and integration with Microsoft.Owin logging.</description>
     <language>en-US</language>
     <projectUrl>http://serilog.net</projectUrl>
     <licenseUrl>http://www.apache.org/licenses/LICENSE-2.0</licenseUrl>


### PR DESCRIPTION
Corrects a minor spelling mistake in the description of the MSOwin nuget package.

I probably would have just ignored this since it is minor were it not for the fact this is the description that gets published on nuget.org and appears in package search results.