### PR TITLE
Fixes support for using multiple CounterMeasure

### DIFF
--- a/Serilog.sln
+++ b/Serilog.sln
@@ -102,6 +102,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Serilog.Sinks.AzureDocument
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Serilog.MsTests", "test\Serilog.MsTests\Serilog.MsTests.csproj", "{7FC9FC46-5014-4461-A448-815E6CCE21E5}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Serilog.Extras.Timing.Tests", "test\Serilog.Extras.Timing.Tests\Serilog.Extras.Timing.Tests.csproj", "{27951D39-9610-4646-A804-13E8325128E4}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -280,6 +282,10 @@ Global
 		{7FC9FC46-5014-4461-A448-815E6CCE21E5}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{7FC9FC46-5014-4461-A448-815E6CCE21E5}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7FC9FC46-5014-4461-A448-815E6CCE21E5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{27951D39-9610-4646-A804-13E8325128E4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{27951D39-9610-4646-A804-13E8325128E4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{27951D39-9610-4646-A804-13E8325128E4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{27951D39-9610-4646-A804-13E8325128E4}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -328,5 +334,6 @@ Global
 		{088A4030-7C7A-4434-964A-8E9E42DB17F0} = {037440DE-440B-4129-9F7A-09B42D00397E}
 		{C1875BEA-4509-4E04-AB8F-C2F8169BF001} = {037440DE-440B-4129-9F7A-09B42D00397E}
 		{7FC9FC46-5014-4461-A448-815E6CCE21E5} = {0D135C0C-A60B-454A-A2F4-CD74A30E04B0}
+		{27951D39-9610-4646-A804-13E8325128E4} = {0D135C0C-A60B-454A-A2F4-CD74A30E04B0}
 	EndGlobalSection
 EndGlobal

--- a/packages/repositories.config
+++ b/packages/repositories.config
@@ -31,4 +31,5 @@
   <repository path="..\test\Serilog.Sinks.Elasticsearch.Tests\packages.config" />
   <repository path="..\test\Serilog.Sinks.RavenDB.Tests\packages.config" />
   <repository path="..\test\Serilog.Tests\packages.config" />
+  <repository path="..\test\Serilog.Extras.Timing.Tests\packages.config" />
 </repositories>

--- a/src/Serilog.Extras.Timing/Extras/Timing/CounterMeasure.cs
+++ b/src/Serilog.Extras.Timing/Extras/Timing/CounterMeasure.cs
@@ -24,7 +24,7 @@ namespace Serilog.Extras.Timing
         readonly LogEventLevel _level;
         readonly string _template;
         readonly bool _directWrite;
-        static AtomicLong _value;
+        readonly AtomicLong _value;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="CounterMeasure"/> class.

--- a/test/Serilog.Extras.Timing.Tests/CounterMeasureTests.cs
+++ b/test/Serilog.Extras.Timing.Tests/CounterMeasureTests.cs
@@ -1,0 +1,47 @@
+﻿using System.Linq;
+using NUnit.Framework;
+using Serilog.Events;
+using Serilog.Tests.Support;
+using System.Collections.Generic;
+
+
+namespace Serilog.Extras.Timing.Tests
+{
+    [TestFixture]
+    public class CounterMeasureTests
+    {
+        [Test]
+        public void CountersIncrementSeperately()
+        {
+            var events = new List<LogEvent>();
+
+            var log = new LoggerConfiguration()               
+                .WriteTo.Sink(new DelegatingSink(e => events.Add(e)))
+                .CreateLogger();
+
+            var counter1 = log.CountOperation("TestCounter1", directWrite: false);
+            var counter2 = log.CountOperation("TestCounter2", directWrite: false);
+
+            // increment counter1 5 times
+            for (int i = 0; i < 5; i++ )
+            {
+                counter1.Increment();
+            }
+
+            // increment counter2 10 times
+            for (int i = 0; i < 10; i++)
+            {
+                counter2.Increment();
+            }
+
+            counter1.Write();
+            counter2.Write();
+
+            var counter1Literal = (long)events[0].Properties["CounterValue"].LiteralValue();
+            var counter2Literal = (long)events[1].Properties["CounterValue"].LiteralValue();
+
+            Assert.AreEqual(5, counter1Literal);
+            Assert.AreEqual(10, counter2Literal);           
+        }
+    }
+}

--- a/test/Serilog.Extras.Timing.Tests/Properties/AssemblyInfo.cs
+++ b/test/Serilog.Extras.Timing.Tests/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Serilog.Extras.Timing.Tests")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Serilog.Extras.Timing.Tests")]
+[assembly: AssemblyCopyright("Copyright ©  2015")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("212f76e5-baea-4413-b39b-3db0c95a1133")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/test/Serilog.Extras.Timing.Tests/Serilog.Extras.Timing.Tests.csproj
+++ b/test/Serilog.Extras.Timing.Tests/Serilog.Extras.Timing.Tests.csproj
@@ -1,0 +1,99 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{27951D39-9610-4646-A804-13E8325128E4}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Serilog.Extras.Timing.Tests</RootNamespace>
+    <AssemblyName>Serilog.Extras.Timing.Tests</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
+    <IsCodedUITest>False</IsCodedUITest>
+    <TestProjectType>UnitTest</TestProjectType>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="nunit.framework">
+      <HintPath>..\packages\NUnit.2.6.3\lib\nunit.framework.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+  </ItemGroup>
+  <Choose>
+    <When Condition="('$(VisualStudioVersion)' == '10.0' or '$(VisualStudioVersion)' == '') and '$(TargetFrameworkVersion)' == 'v3.5'">
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+      </ItemGroup>
+    </When>
+    <Otherwise />
+  </Choose>
+  <ItemGroup>
+    <Compile Include="CounterMeasureTests.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Serilog.Extras.Timing\Serilog.Extras.Timing.csproj">
+      <Project>{264c91af-6631-4e04-a2ac-e32e88055228}</Project>
+      <Name>Serilog.Extras.Timing</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\src\Serilog\Serilog.csproj">
+      <Project>{0915dbd9-0f7c-4439-8d9e-74c3d579b219}</Project>
+      <Name>Serilog</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\Serilog.Tests\Serilog.Tests.csproj">
+      <Project>{d5648551-d19d-41e3-9fc1-e74b111eef41}</Project>
+      <Name>Serilog.Tests</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Choose>
+    <When Condition="'$(VisualStudioVersion)' == '10.0' And '$(IsCodedUITest)' == 'True'">
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.CodedUITestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITest.Common, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITest.Extension, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITesting, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/test/Serilog.Extras.Timing.Tests/packages.config
+++ b/test/Serilog.Extras.Timing.Tests/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="NUnit" version="2.6.3" targetFramework="net45" />
+</packages>


### PR DESCRIPTION
Using Serilog.Extras.Timing to create two counters they both share a value which is incremented together.

Code:
```csharp
var bookCounter = logger.CountOperation("books", "created books", false, LogEventLevel.Debug);
var authorCounter = logger.CountOperation("authors", "created authors", false, LogEventLevel.Debug);

bookCounter.Write();
authorCounter.Increment();
bookCounter.Write();
```

Output:

```
2015-02-09 22:07:56 [Debug] "books" count = 0 created books
2015-02-09 22:08:13 [Debug] "books" count = 1 created books
```

The fix is a one liner removing the static property on CounterMeasure _value

In the second commit I created a test project for Serilog.Extras.Timing with a test covering this case.