### PR TITLE
Newest elmah.io package

### DIFF
--- a/src/Serilog.Sinks.ElmahIO/Serilog.Sinks.ElmahIO.nuspec
+++ b/src/Serilog.Sinks.ElmahIO/Serilog.Sinks.ElmahIO.nuspec
@@ -13,7 +13,7 @@
     <dependencies>
       <dependency id="Serilog" version="$version$" />
       <dependency id="elmah.corelibrary" version="1.2.2" />
-      <dependency id="elmah.io.core" version="1.0.0.38" />
+      <dependency id="elmah.io.core" version="1.0.0.40" />
     </dependencies>
   </metadata>
 </package>


### PR DESCRIPTION
Updated Serilog.Sinks.ElmahIO.nuspec to point to the newest stable package of elmah.io.