### PR TITLE
Support IEnumerable<Uri> in AppSettingsReader

### DIFF
--- a/src/Serilog.Extras.AppSettings/Extras/AppSettings/PrefixedAppSettingsReader.cs
+++ b/src/Serilog.Extras.AppSettings/Extras/AppSettings/PrefixedAppSettingsReader.cs
@@ -134,7 +134,8 @@ namespace Serilog.Extras.AppSettings
             var extendedTypeConversions = new Dictionary<Type, Func<string, object>>
             {
                 { typeof(Uri), s => new Uri(s) },
-                { typeof(TimeSpan), s => TimeSpan.Parse(s) }
+                { typeof(TimeSpan), s => TimeSpan.Parse(s) },
+                { typeof(IEnumerable<Uri>), s => s.Split(new [] { ' ' }, StringSplitOptions.RemoveEmptyEntries).Select(u => new Uri(u)) }
             };
 
             var convertor = extendedTypeConversions

--- a/test/Serilog.Extras.AppSettings.Tests/PrefixedAppSettingsReaderTests.cs
+++ b/test/Serilog.Extras.AppSettings.Tests/PrefixedAppSettingsReaderTests.cs
@@ -1,4 +1,8 @@
-﻿using System.Collections.Specialized;
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.Linq;
 using NUnit.Framework;
 using Serilog.Events;
 using Serilog.Tests.Support;
@@ -75,5 +79,31 @@ namespace Serilog.Extras.AppSettings.Tests
             Assert.IsNotNull(evt);
             Assert.AreNotEqual("%PATH%", evt.Properties["Path"].LiteralValue());
         }
-    }
+
+		[Test]
+	    public void SingleUriConvertsToUri()
+	    {
+			var result = (Uri)PrefixedAppSettingsReader.ConvertToType("http://localhost:9200/", typeof(Uri));
+			Assert.AreEqual(result.AbsoluteUri, "http://localhost:9200/");
+	    }
+
+		[Test]
+		public void MultipleUriConvertsToEnumerableUri()
+		{
+			var resultEnumerable = (IEnumerable<Uri>)PrefixedAppSettingsReader.ConvertToType("http://localhost:9200/ http://localhost:9201/", typeof(IEnumerable<Uri>));
+			
+			Assert.IsNotNull(resultEnumerable);
+			Assert.IsInstanceOf(typeof(IEnumerable<Uri>), resultEnumerable);
+			
+			var result = resultEnumerable as IList<Uri> ?? resultEnumerable.ToList();
+			
+			Assert.AreEqual(result.Count(), 2);
+
+			Assert.IsInstanceOf(typeof(Uri), result[0]);
+			Assert.AreEqual(result[0].AbsoluteUri, "http://localhost:9200/");
+			
+			Assert.IsInstanceOf(typeof(Uri), result[1]);
+			Assert.AreEqual(result[1].AbsoluteUri, "http://localhost:9201/");
+		}
+	}
 }


### PR DESCRIPTION
This change adds support for IEnumerable<Uri> in the AppSettingsReader, allowing multiple Uri settings separated by a space.  We are using app settings with Elasticsearch and need to specify multiple nodes in the setting.  Please let me know if there is anything else I need to do.