### PR TITLE
Revert the default destructuring depth back to 10

### DIFF
--- a/src/Serilog/LoggerConfiguration.cs
+++ b/src/Serilog/LoggerConfiguration.cs
@@ -37,7 +37,7 @@ namespace Serilog
         
         LogEventLevel _minimumLevel = LogEventLevel.Information;
         LoggingLevelSwitch _levelSwitch;
-        int _maximumDestructuringDepth = 5;
+        int _maximumDestructuringDepth = 10;
 
         /// <summary>
         /// Configures the sinks that log events will be emitted to.


### PR DESCRIPTION
In an [earlier change](https://github.com/serilog/serilog/commit/980de25bfa82619ddf77280741b84fdb7eac2fce) we trimmed the default maximum destructuring depth from 10 to 5, to be more defensive around over-serialization. Experience is showing 5 is too shallow; it's easy to hit it with a collection of objects that each have a collection property containing an object with a collection.

Even small trees/linked lists hit 5 before getting off the ground :-)

I think although the sentiment was good, we just traded one trap (big events) for another trap (surprising nulls in serialized data).

I'm still not sure 10 is the right number, if there's such thing as a "right" number, but it seems it was a better default and there's not much data to go on. //cc @serilog/core