### PR TITLE
AppSettings: Update the unit test that checks environment variable expansion is supported

### DIFF
--- a/test/Serilog.Tests/Serilog.Tests.csproj
+++ b/test/Serilog.Tests/Serilog.Tests.csproj
@@ -52,6 +52,7 @@
       <HintPath>..\..\packages\NUnit.2.6.3\lib\nunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Configuration" />
     <Reference Include="System.Reactive.Core, Version=2.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\Rx-Core.2.2.1-beta\lib\net45\System.Reactive.Core.dll</HintPath>
@@ -91,6 +92,7 @@
     <Compile Include="LogTests.cs" />
     <Compile Include="Parameters\PropertyValueConverterTests.cs" />
     <Compile Include="Parsing\MessageTemplateParserTests.cs" />
+    <Compile Include="Settings\AppSettingsTests.cs" />
     <Compile Include="Settings\KeyValuePairSettingsTests.cs" />
     <Compile Include="Sinks\IOFile\FileSinkTests.cs" />
     <Compile Include="Sinks\Observable\ObservableSinkTests.cs" />

--- a/test/Serilog.Tests/Settings/AppSettingsTests.cs
+++ b/test/Serilog.Tests/Settings/AppSettingsTests.cs
@@ -1,0 +1,30 @@
+﻿using System.Configuration;
+using NUnit.Framework;
+using Serilog.Events;
+using Serilog.Tests.Support;
+
+namespace Serilog.Extras.AppSettings.Tests
+{
+    [TestFixture]
+    public class AppSettingsTests
+    {
+        [Test]
+        public void EnvironmentVariableExpansionIsApplied()
+        {
+            // Make sure we have the expected key in the App.config
+            Assert.AreEqual("%PATH%", ConfigurationManager.AppSettings["serilog:enrich:with-property:Path"]);
+
+            LogEvent evt = null;
+            var log = new LoggerConfiguration()
+                .ReadFrom.AppSettings() 
+                .WriteTo.Sink(new DelegatingSink(e => evt = e))
+                .CreateLogger();
+
+            log.Information("Has a Path property with value expanded from the environment variable");
+
+            Assert.IsNotNull(evt);
+            Assert.IsNotNullOrEmpty((string)evt.Properties["Path"].LiteralValue());
+            Assert.AreNotEqual("%PATH%", evt.Properties["Path"].LiteralValue());
+        }
+    }
+}

--- a/test/Serilog.Tests/Settings/KeyValuePairSettingsTests.cs
+++ b/test/Serilog.Tests/Settings/KeyValuePairSettingsTests.cs
@@ -94,24 +94,5 @@ namespace Serilog.Extras.AppSettings.Tests
             Assert.IsNotNull(evt);
             Assert.AreEqual("Test", evt.Properties["App"].LiteralValue());
         }
-
-        [Test, Ignore("Requires an App.config file to enable this feature")]
-        public void EnvironmentVariableExpansionIsApplied()
-        {
-            LogEvent evt = null;
-            var log = new LoggerConfiguration()
-                // Only available with ReadFrom.AppSettings()
-                .ReadFrom.KeyValuePairs(new Dictionary<string, string>
-                {
-                    {"enrich:with-property:Path", "%PATH%"}
-                })
-                .WriteTo.Sink(new DelegatingSink(e => evt = e))
-                .CreateLogger();
-
-            log.Information("Has a Path property with value expanded from the environment variable");
-
-            Assert.IsNotNull(evt);
-            Assert.AreNotEqual("%PATH%", evt.Properties["Path"].LiteralValue());
-        }
     }
 }

--- a/test/Serilog.Tests/app.config
+++ b/test/Serilog.Tests/app.config
@@ -1,5 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
+  <appSettings>
+    <add key="serilog:enrich:with-property:Path" value="%PATH%" />
+  </appSettings>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>


### PR DESCRIPTION
The test was being ignored because it required an App.config present with a key, so I made the changes required for the test to run - I have it running locally in TeamCity and it's passing, so I'd expect it to run fine in your CI... We'll see.