### PR TITLE
Expose AppSettings configuration

### DIFF
--- a/src/Serilog.FullNetFx/LoggerConfigurationFullNetFxExtensions.cs
+++ b/src/Serilog.FullNetFx/LoggerConfigurationFullNetFxExtensions.cs
@@ -24,7 +24,6 @@ using Serilog.Events;
 using Serilog.Formatting.Display;
 using Serilog.Formatting.Raw;
 using Serilog.Settings.AppSettings;
-using Serilog.Settings.KeyValuePairs;
 using Serilog.Sinks.DiagnosticTrace;
 using Serilog.Sinks.IOFile;
 using Serilog.Sinks.RollingFile;
@@ -266,13 +265,14 @@ namespace Serilog
         /// containing sinks, use <code>serilog:using</code>. To set the level use 
         /// <code>serilog:minimum-level</code>.
         /// </summary>
-        /// <param name="settingConfiguration">Logger setting configuration</param>
+        /// <param name="settingConfiguration">Logger setting configuration.</param>
+        /// <param name="exposeSettings">Action allowing changes to the Serilog settings read from the App.config.</param>
         /// <returns>An object allowing configuration to continue.</returns>
         public static LoggerConfiguration AppSettings(
-            this LoggerSettingsConfiguration settingConfiguration)
+            this LoggerSettingsConfiguration settingConfiguration, Action<Dictionary<string, string>> exposeSettings = null)
         {
             if (settingConfiguration == null) throw new ArgumentNullException("settingConfiguration");
-            return settingConfiguration.Settings(new AppSettingsSettings());
+            return settingConfiguration.Settings(new AppSettingsSettings(exposeSettings));
         }
     }
 }

--- a/test/Serilog.Tests/Serilog.Tests.csproj
+++ b/test/Serilog.Tests/Serilog.Tests.csproj
@@ -52,6 +52,7 @@
       <HintPath>..\..\packages\NUnit.2.6.3\lib\nunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Configuration" />
     <Reference Include="System.Reactive.Core, Version=2.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\Rx-Core.2.2.1-beta\lib\net45\System.Reactive.Core.dll</HintPath>
@@ -91,6 +92,7 @@
     <Compile Include="LogTests.cs" />
     <Compile Include="Parameters\PropertyValueConverterTests.cs" />
     <Compile Include="Parsing\MessageTemplateParserTests.cs" />
+    <Compile Include="Settings\AppSettingsTests.cs" />
     <Compile Include="Settings\KeyValuePairSettingsTests.cs" />
     <Compile Include="Sinks\IOFile\FileSinkTests.cs" />
     <Compile Include="Sinks\Observable\ObservableSinkTests.cs" />

--- a/test/Serilog.Tests/Settings/AppSettingsTests.cs
+++ b/test/Serilog.Tests/Settings/AppSettingsTests.cs
@@ -1,0 +1,30 @@
+﻿using System.Configuration;
+using NUnit.Framework;
+using Serilog.Events;
+using Serilog.Tests.Support;
+
+namespace Serilog.Extras.AppSettings.Tests
+{
+    [TestFixture]
+    public class AppSettingsTests
+    {
+        [Test]
+        public void EnvironmentVariableExpansionIsApplied()
+        {
+            // Make sure we have the expected key in the App.config
+            Assert.AreEqual("%PATH%", ConfigurationManager.AppSettings["serilog:enrich:with-property:Path"]);
+
+            LogEvent evt = null;
+            var log = new LoggerConfiguration()
+                .ReadFrom.AppSettings() 
+                .WriteTo.Sink(new DelegatingSink(e => evt = e))
+                .CreateLogger();
+
+            log.Information("Has a Path property with value expanded from the environment variable");
+
+            Assert.IsNotNull(evt);
+            Assert.IsNotNullOrEmpty((string)evt.Properties["Path"].LiteralValue());
+            Assert.AreNotEqual("%PATH%", evt.Properties["Path"].LiteralValue());
+        }
+    }
+}

--- a/test/Serilog.Tests/Settings/AppSettingsTests.cs
+++ b/test/Serilog.Tests/Settings/AppSettingsTests.cs
@@ -26,5 +26,40 @@ namespace Serilog.Extras.AppSettings.Tests
             Assert.IsNotNullOrEmpty((string)evt.Properties["Path"].LiteralValue());
             Assert.AreNotEqual("%PATH%", evt.Properties["Path"].LiteralValue());
         }
+
+        [Test]
+        public void ChangesToSettingsReadFromAppConfigFileAreApplied()
+        {
+            const string appTitleKey = "serilog:enrich:with-property:AppTitle";
+            const string appTitleValue = "Serilog.Tests";
+
+            const string appDescriptionKey = "serilog:enrich:with-property:AppDescription";
+            const string appDescriptionValue = "Tests for Serilog";
+
+            const string appCopyrightKey = "serilog:enrich:with-property:AppCopyright";
+            const string appCopyrightValue = "Serilog Contributors 2015";
+
+            // Make sure we have the expected keys in the App.config
+            Assert.AreEqual(appTitleValue, ConfigurationManager.AppSettings[appTitleKey]);
+            Assert.AreEqual(appDescriptionValue, ConfigurationManager.AppSettings[appDescriptionKey]);
+            Assert.IsNull(ConfigurationManager.AppSettings[appCopyrightKey]);
+
+            LogEvent evt = null;
+            var log = new LoggerConfiguration()
+                .ReadFrom.AppSettings(settings =>
+                {
+                    settings.Remove(appDescriptionKey);
+                    settings.Add(appCopyrightKey, appCopyrightValue);
+                })
+                .WriteTo.Sink(new DelegatingSink(e => evt = e))
+                .CreateLogger();
+
+            log.Information("Has AppTitle and AppCopyright property, but no AppDescription");
+
+            Assert.IsNotNull(evt);
+            Assert.AreEqual(appTitleValue, evt.Properties["AppTitle"].LiteralValue());
+            Assert.AreEqual(appCopyrightValue, evt.Properties["AppCopyright"].LiteralValue());
+            Assert.IsFalse(evt.Properties.ContainsKey("AppDescription"));
+        }
     }
 }

--- a/test/Serilog.Tests/Settings/KeyValuePairSettingsTests.cs
+++ b/test/Serilog.Tests/Settings/KeyValuePairSettingsTests.cs
@@ -94,24 +94,5 @@ namespace Serilog.Extras.AppSettings.Tests
             Assert.IsNotNull(evt);
             Assert.AreEqual("Test", evt.Properties["App"].LiteralValue());
         }
-
-        [Test, Ignore("Requires an App.config file to enable this feature")]
-        public void EnvironmentVariableExpansionIsApplied()
-        {
-            LogEvent evt = null;
-            var log = new LoggerConfiguration()
-                // Only available with ReadFrom.AppSettings()
-                .ReadFrom.KeyValuePairs(new Dictionary<string, string>
-                {
-                    {"enrich:with-property:Path", "%PATH%"}
-                })
-                .WriteTo.Sink(new DelegatingSink(e => evt = e))
-                .CreateLogger();
-
-            log.Information("Has a Path property with value expanded from the environment variable");
-
-            Assert.IsNotNull(evt);
-            Assert.AreNotEqual("%PATH%", evt.Properties["Path"].LiteralValue());
-        }
     }
 }

--- a/test/Serilog.Tests/app.config
+++ b/test/Serilog.Tests/app.config
@@ -1,5 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
+  <appSettings>
+    <add key="serilog:enrich:with-property:Path" value="%PATH%" />
+  </appSettings>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>

--- a/test/Serilog.Tests/app.config
+++ b/test/Serilog.Tests/app.config
@@ -2,6 +2,8 @@
 <configuration>
   <appSettings>
     <add key="serilog:enrich:with-property:Path" value="%PATH%" />
+    <add key="serilog:enrich:with-property:AppTitle" value="Serilog.Tests" />
+    <add key="serilog:enrich:with-property:AppDescription" value="Tests for Serilog" />
   </appSettings>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">


### PR DESCRIPTION
I try to keep my Serilog settings in the App.config as much as possible as it facilitates deployment a lot (i.e. transforms by environment via Octopus), however, I have scenarios where I need to tweak some properties of specific sinks dynamically via code, so I thought I'd expose the properties somehow to have the ability to get into the pipeline and change the dictionary before it gets consumed by the different sinks.

For example, imagine I have the following setting in my App.config:
```
<add key="serilog:write-to:RollingFile.pathFormat" value="C:\logs\myapp-{SomeTag}-{Date}.log" />
```

And I'd like `{SomeTag}` to be replaced by something that is obtained at runtime, at the start of the app, when I'm configuring Serilog.

With this PR, I'm exposing the settings read from the App.config to the developer, so we can have a chance to modify the settings dictionary before Serilog processes it.

```
var log = new LoggerConfiguration()
    .ReadFrom.AppSettings(settings =>
    {
        // Modify the dictionary to do replaces and/or add items and/or remove items etc.
    })
    .CreateLogger();
```

ps: This builds uppon PR #463