### PR TITLE
Including logging level in Trace logger

### DIFF
--- a/src/Serilog.FullNetFx/Sinks/DiagnosticTrace/DiagnosticTraceSink.cs
+++ b/src/Serilog.FullNetFx/Sinks/DiagnosticTrace/DiagnosticTraceSink.cs
@@ -36,7 +36,17 @@ namespace Serilog.Sinks.DiagnosticTrace
             if (logEvent == null) throw new ArgumentNullException("logEvent");
             var sr = new StringWriter();
             _textFormatter.Format(logEvent, sr);
-            Trace.WriteLine(sr.ToString().Trim());
+
+            var text = sr.ToString().Trim();
+
+            if (logEvent.Level == LogEventLevel.Error || logEvent.Level == LogEventLevel.Fatal)
+                Trace.TraceError(text);
+            else if (logEvent.Level == LogEventLevel.Warning)
+                Trace.TraceWarning(text);
+            else if (logEvent.Level == LogEventLevel.Information)
+                Trace.TraceInformation(text);
+            else
+                Trace.WriteLine(text);
         }
     }
 }


### PR DESCRIPTION
On Azure, there's a an option to log Trace events to a destination set
on Azure Portal (storage tables or files).    Since Serilog was not
including the event type in the trace log, trace messages generated by
Serilog are not being logged.  There's also a minimum logging level
setting in Azure that uses this event type to choose logging messages to
log.

To get this feature working properly, I updated the Trace sink to
include the event type in the Trace message based on the Serilog
LogEventLevel.