### PR TITLE
Add Log overloads that help avoid array and boxing allocations

### DIFF
--- a/src/Serilog/Log.cs
+++ b/src/Serilog/Log.cs
@@ -108,12 +108,117 @@ namespace Serilog
         /// Write a log event with the specified level.
         /// </summary>
         /// <param name="level">The level of the event.</param>
-        /// <param name="messageTemplate"></param>
-        /// <param name="propertyValues"></param>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <param name="propertyValue">Object positionally formatted into the message template.</param>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        public static void Write<T>(LogEventLevel level, string messageTemplate, T propertyValue)
+        {
+            // Avoid the array allocation and any boxing allocations when the level isn't enabled
+            if (Logger.IsEnabled(level))
+            {
+                Logger.Write(level, messageTemplate, new object[] { propertyValue });
+            }
+        }
+
+        /// <summary>
+        /// Write a log event with the specified level.
+        /// </summary>
+        /// <param name="level">The level of the event.</param>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <param name="propertyValue0">Object positionally formatted into the message template.</param>
+        /// <param name="propertyValue1">Object positionally formatted into the message template.</param>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        public static void Write<T0, T1>(LogEventLevel level, string messageTemplate, T0 propertyValue0, T1 propertyValue1)
+        {
+            // Avoid the array allocation and any boxing allocations when the level isn't enabled
+            if (Logger.IsEnabled(level))
+            {
+                Logger.Write(level, messageTemplate, new object[] { propertyValue0, propertyValue1 });
+            }
+        }
+
+        /// <summary>
+        /// Write a log event with the specified level.
+        /// </summary>
+        /// <param name="level">The level of the event.</param>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <param name="propertyValue0">Object positionally formatted into the message template.</param>
+        /// <param name="propertyValue1">Object positionally formatted into the message template.</param>
+        /// <param name="propertyValue2">Object positionally formatted into the message template.</param>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        public static void Write<T0, T1, T2>(LogEventLevel level, string messageTemplate, T0 propertyValue0, T1 propertyValue1, T2 propertyValue2)
+        {
+            // Avoid the array allocation and any boxing allocations when the level isn't enabled
+            if (Logger.IsEnabled(level))
+            {
+                Logger.Write(level, messageTemplate, new object[] { propertyValue0, propertyValue1, propertyValue2 });
+            }
+        }
+
+        /// <summary>
+        /// Write a log event with the specified level.
+        /// </summary>
+        /// <param name="level">The level of the event.</param>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <param name="propertyValues">Objects positionally formatted into the message template.</param>
         [MessageTemplateFormatMethod("messageTemplate")]
         public static void Write(LogEventLevel level, string messageTemplate, params object[] propertyValues)
         {
             Logger.Write(level, messageTemplate, propertyValues);
+        }
+
+        /// <summary>
+        /// Write a log event with the specified level and associated exception.
+        /// </summary>
+        /// <param name="level">The level of the event.</param>
+        /// <param name="exception">Exception related to the event.</param>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <param name="propertyValue">Object positionally formatted into the message template.</param>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        public static void Write<T>(LogEventLevel level, Exception exception, string messageTemplate, T propertyValue)
+        {
+            // Avoid the array allocation and any boxing allocations when the level isn't enabled
+            if (Logger.IsEnabled(level))
+            {
+                Logger.Write(level, exception, messageTemplate, new object[] { propertyValue });
+            }
+        }
+
+        /// <summary>
+        /// Write a log event with the specified level and associated exception.
+        /// </summary>
+        /// <param name="level">The level of the event.</param>
+        /// <param name="exception">Exception related to the event.</param>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <param name="propertyValue0">Object positionally formatted into the message template.</param>
+        /// <param name="propertyValue1">Object positionally formatted into the message template.</param>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        public static void Write<T0, T1>(LogEventLevel level, Exception exception, string messageTemplate, T0 propertyValue0, T1 propertyValue1)
+        {
+            // Avoid the array allocation and any boxing allocations when the level isn't enabled
+            if (Logger.IsEnabled(level))
+            {
+                Logger.Write(level, exception, messageTemplate, new object[] { propertyValue0, propertyValue1 });
+            }
+        }
+
+        /// <summary>
+        /// Write a log event with the specified level and associated exception.
+        /// </summary>
+        /// <param name="level">The level of the event.</param>
+        /// <param name="exception">Exception related to the event.</param>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <param name="propertyValue0">Object positionally formatted into the message template.</param>
+        /// <param name="propertyValue1">Object positionally formatted into the message template.</param>
+        /// <param name="propertyValue2">Object positionally formatted into the message template.</param>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        public static void Write<T0, T1, T2>(LogEventLevel level, Exception exception, string messageTemplate, T0 propertyValue0, T1 propertyValue1, T2 propertyValue2)
+        {
+            // Avoid the array allocation and any boxing allocations when the level isn't enabled
+            if (Logger.IsEnabled(level))
+            {
+                Logger.Write(level, exception, messageTemplate, new object[] { propertyValue0, propertyValue1, propertyValue2 });
+            }
         }
 
         /// <summary>
@@ -139,9 +244,53 @@ namespace Serilog
         {
             return Logger.IsEnabled(level);
         }
+        /// <summary>
+        /// Write a log event with the <see cref="LogEventLevel.Verbose"/> level.
+        /// </summary>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <param name="propertyValue">Object positionally formatted into the message template.</param>
+        /// <example>
+        /// Log.Verbose("Staring into space, wondering if we're alone.");
+        /// </example>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        public static void Verbose<T>(string messageTemplate, T propertyValue)
+        {
+            Write(LogEventLevel.Verbose, messageTemplate, propertyValue);
+        }
 
         /// <summary>
-        /// Write a log event with the <see cref="LogEventLevel.Verbose"/> level and associated exception.
+        /// Write a log event with the <see cref="LogEventLevel.Verbose"/> level.
+        /// </summary>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <param name="propertyValue0">Object positionally formatted into the message template.</param>
+        /// <param name="propertyValue1">Object positionally formatted into the message template.</param>
+        /// <example>
+        /// Log.Verbose("Staring into space, wondering if we're alone.");
+        /// </example>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        public static void Verbose<T0, T1>(string messageTemplate, T0 propertyValue0, T1 propertyValue1)
+        {
+            Write(LogEventLevel.Verbose, messageTemplate, propertyValue0, propertyValue1);
+        }
+
+        /// <summary>
+        /// Write a log event with the <see cref="LogEventLevel.Verbose"/> level.
+        /// </summary>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <param name="propertyValue0">Object positionally formatted into the message template.</param>
+        /// <param name="propertyValue1">Object positionally formatted into the message template.</param>
+        /// <param name="propertyValue2">Object positionally formatted into the message template.</param>
+        /// <example>
+        /// Log.Verbose("Staring into space, wondering if we're alone.");
+        /// </example>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        public static void Verbose<T0, T1, T2>(string messageTemplate, T0 propertyValue0, T1 propertyValue1, T2 propertyValue2)
+        {
+            Write(LogEventLevel.Verbose, messageTemplate, propertyValue0, propertyValue1, propertyValue2);
+        }
+
+        /// <summary>
+        /// Write a log event with the <see cref="LogEventLevel.Verbose"/> level.
         /// </summary>
         /// <param name="messageTemplate">Message template describing the event.</param>
         /// <param name="propertyValues">Objects positionally formatted into the message template.</param>
@@ -152,6 +301,54 @@ namespace Serilog
         public static void Verbose(string messageTemplate, params object[] propertyValues)
         {
             Logger.Verbose(messageTemplate, propertyValues);
+        }
+
+        /// <summary>
+        /// Write a log event with the <see cref="LogEventLevel.Verbose"/> level and associated exception.
+        /// </summary>
+        /// <param name="exception">Exception related to the event.</param>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <param name="propertyValue">Object positionally formatted into the message template.</param>
+        /// <example>
+        /// Log.Verbose(ex, "Staring into space, wondering where this comet came from.");
+        /// </example>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        public static void Verbose<T>(Exception exception, string messageTemplate, T propertyValue)
+        {
+            Write(LogEventLevel.Verbose, exception, messageTemplate, propertyValue);
+        }
+
+        /// <summary>
+        /// Write a log event with the <see cref="LogEventLevel.Verbose"/> level and associated exception.
+        /// </summary>
+        /// <param name="exception">Exception related to the event.</param>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <param name="propertyValue0">Object positionally formatted into the message template.</param>
+        /// <param name="propertyValue1">Object positionally formatted into the message template.</param>
+        /// <example>
+        /// Log.Verbose(ex, "Staring into space, wondering where this comet came from.");
+        /// </example>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        public static void Verbose<T0, T1>(Exception exception, string messageTemplate, T0 propertyValue0, T1 propertyValue1)
+        {
+            Write(LogEventLevel.Verbose, exception, messageTemplate, propertyValue0, propertyValue1);
+        }
+
+        /// <summary>
+        /// Write a log event with the <see cref="LogEventLevel.Verbose"/> level and associated exception.
+        /// </summary>
+        /// <param name="exception">Exception related to the event.</param>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <param name="propertyValue0">Object positionally formatted into the message template.</param>
+        /// <param name="propertyValue1">Object positionally formatted into the message template.</param>
+        /// <param name="propertyValue2">Object positionally formatted into the message template.</param>
+        /// <example>
+        /// Log.Verbose(ex, "Staring into space, wondering where this comet came from.");
+        /// </example>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        public static void Verbose<T0, T1, T2>(Exception exception, string messageTemplate, T0 propertyValue0, T1 propertyValue1, T2 propertyValue2)
+        {
+            Write(LogEventLevel.Verbose, exception, messageTemplate, propertyValue0, propertyValue1, propertyValue2);
         }
 
         /// <summary>
@@ -170,7 +367,52 @@ namespace Serilog
         }
 
         /// <summary>
-        /// Write a log event with the <see cref="LogEventLevel.Debug"/> level and associated exception.
+        /// Write a log event with the <see cref="LogEventLevel.Debug"/> level.
+        /// </summary>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <param name="propertyValue">Object positionally formatted into the message template.</param>
+        /// <example>
+        /// Log.Debug("Starting up at {StartedAt}.", DateTime.Now);
+        /// </example>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        public static void Debug<T>(string messageTemplate, T propertyValue)
+        {
+            Write(LogEventLevel.Debug, messageTemplate, propertyValue);
+        }
+
+        /// <summary>
+        /// Write a log event with the <see cref="LogEventLevel.Debug"/> level.
+        /// </summary>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <param name="propertyValue0">Object positionally formatted into the message template.</param>
+        /// <param name="propertyValue1">Object positionally formatted into the message template.</param>
+        /// <example>
+        /// Log.Debug("Starting up at {StartedAt}.", DateTime.Now);
+        /// </example>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        public static void Debug<T0, T1>(string messageTemplate, T0 propertyValue0, T1 propertyValue1)
+        {
+            Write(LogEventLevel.Debug, messageTemplate, propertyValue0, propertyValue1);
+        }
+
+        /// <summary>
+        /// Write a log event with the <see cref="LogEventLevel.Debug"/> level.
+        /// </summary>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <param name="propertyValue0">Object positionally formatted into the message template.</param>
+        /// <param name="propertyValue1">Object positionally formatted into the message template.</param>
+        /// <param name="propertyValue2">Object positionally formatted into the message template.</param>
+        /// <example>
+        /// Log.Debug("Starting up at {StartedAt}.", DateTime.Now);
+        /// </example>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        public static void Debug<T0, T1, T2>(string messageTemplate, T0 propertyValue0, T1 propertyValue1, T2 propertyValue2)
+        {
+            Write(LogEventLevel.Debug, messageTemplate, propertyValue0, propertyValue1, propertyValue2);
+        }
+
+        /// <summary>
+        /// Write a log event with the <see cref="LogEventLevel.Debug"/> level.
         /// </summary>
         /// <param name="messageTemplate">Message template describing the event.</param>
         /// <param name="propertyValues">Objects positionally formatted into the message template.</param>
@@ -181,6 +423,54 @@ namespace Serilog
         public static void Debug(string messageTemplate, params object[] propertyValues)
         {
             Logger.Debug(messageTemplate, propertyValues);
+        }
+
+        /// <summary>
+        /// Write a log event with the <see cref="LogEventLevel.Debug"/> level and associated exception.
+        /// </summary>
+        /// <param name="exception">Exception related to the event.</param>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <param name="propertyValue">Object positionally formatted into the message template.</param>
+        /// <example>
+        /// Log.Debug(ex, "Swallowing a mundane exception.");
+        /// </example>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        public static void Debug<T>(Exception exception, string messageTemplate, T propertyValue)
+        {
+            Write(LogEventLevel.Debug, exception, messageTemplate, propertyValue);
+        }
+
+        /// <summary>
+        /// Write a log event with the <see cref="LogEventLevel.Debug"/> level and associated exception.
+        /// </summary>
+        /// <param name="exception">Exception related to the event.</param>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <param name="propertyValue0">Object positionally formatted into the message template.</param>
+        /// <param name="propertyValue1">Object positionally formatted into the message template.</param>
+        /// <example>
+        /// Log.Debug(ex, "Swallowing a mundane exception.");
+        /// </example>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        public static void Debug<T0, T1>(Exception exception, string messageTemplate, T0 propertyValue0, T1 propertyValue1)
+        {
+            Write(LogEventLevel.Debug, exception, messageTemplate, propertyValue0, propertyValue1);
+        }
+
+        /// <summary>
+        /// Write a log event with the <see cref="LogEventLevel.Debug"/> level and associated exception.
+        /// </summary>
+        /// <param name="exception">Exception related to the event.</param>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <param name="propertyValue0">Object positionally formatted into the message template.</param>
+        /// <param name="propertyValue1">Object positionally formatted into the message template.</param>
+        /// <param name="propertyValue2">Object positionally formatted into the message template.</param>
+        /// <example>
+        /// Log.Debug(ex, "Swallowing a mundane exception.");
+        /// </example>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        public static void Debug<T0, T1, T2>(Exception exception, string messageTemplate, T0 propertyValue0, T1 propertyValue1, T2 propertyValue2)
+        {
+            Write(LogEventLevel.Debug, exception, messageTemplate, propertyValue0, propertyValue1, propertyValue2);
         }
 
         /// <summary>
@@ -199,7 +489,52 @@ namespace Serilog
         }
 
         /// <summary>
-        /// Write a log event with the <see cref="LogEventLevel.Information"/> level and associated exception.
+        /// Write a log event with the <see cref="LogEventLevel.Information"/> level.
+        /// </summary>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <param name="propertyValue">Object positionally formatted into the message template.</param>
+        /// <example>
+        /// Log.Information("Processed {RecordCount} records in {TimeMS}.", records.Length, sw.ElapsedMilliseconds);
+        /// </example>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        public static void Information<T>(string messageTemplate, T propertyValue)
+        {
+            Write(LogEventLevel.Information, messageTemplate, propertyValue);
+        }
+
+        /// <summary>
+        /// Write a log event with the <see cref="LogEventLevel.Information"/> level.
+        /// </summary>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <param name="propertyValue0">Object positionally formatted into the message template.</param>
+        /// <param name="propertyValue1">Object positionally formatted into the message template.</param>
+        /// <example>
+        /// Log.Information("Processed {RecordCount} records in {TimeMS}.", records.Length, sw.ElapsedMilliseconds);
+        /// </example>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        public static void Information<T0, T1>(string messageTemplate, T0 propertyValue0, T1 propertyValue1)
+        {
+            Write(LogEventLevel.Information, messageTemplate, propertyValue0, propertyValue1);
+        }
+
+        /// <summary>
+        /// Write a log event with the <see cref="LogEventLevel.Information"/> level.
+        /// </summary>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <param name="propertyValue0">Object positionally formatted into the message template.</param>
+        /// <param name="propertyValue1">Object positionally formatted into the message template.</param>
+        /// <param name="propertyValue2">Object positionally formatted into the message template.</param>
+        /// <example>
+        /// Log.Information("Processed {RecordCount} records in {TimeMS}.", records.Length, sw.ElapsedMilliseconds);
+        /// </example>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        public static void Information<T0, T1, T2>(string messageTemplate, T0 propertyValue0, T1 propertyValue1, T2 propertyValue2)
+        {
+            Write(LogEventLevel.Information, messageTemplate, propertyValue0, propertyValue1, propertyValue2);
+        }
+
+        /// <summary>
+        /// Write a log event with the <see cref="LogEventLevel.Information"/> level.
         /// </summary>
         /// <param name="messageTemplate">Message template describing the event.</param>
         /// <param name="propertyValues">Objects positionally formatted into the message template.</param>
@@ -210,6 +545,54 @@ namespace Serilog
         public static void Information(string messageTemplate, params object[] propertyValues)
         {
             Logger.Information(messageTemplate, propertyValues);
+        }
+
+        /// <summary>
+        /// Write a log event with the <see cref="LogEventLevel.Information"/> level and associated exception.
+        /// </summary>
+        /// <param name="exception">Exception related to the event.</param>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <param name="propertyValue">Object positionally formatted into the message template.</param>
+        /// <example>
+        /// Log.Information(ex, "Processed {RecordCount} records in {TimeMS}.", records.Length, sw.ElapsedMilliseconds);
+        /// </example>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        public static void Information<T>(Exception exception, string messageTemplate, T propertyValue)
+        {
+            Write(LogEventLevel.Information, exception, messageTemplate, propertyValue);
+        }
+
+        /// <summary>
+        /// Write a log event with the <see cref="LogEventLevel.Information"/> level and associated exception.
+        /// </summary>
+        /// <param name="exception">Exception related to the event.</param>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <param name="propertyValue0">Object positionally formatted into the message template.</param>
+        /// <param name="propertyValue1">Object positionally formatted into the message template.</param>
+        /// <example>
+        /// Log.Information(ex, "Processed {RecordCount} records in {TimeMS}.", records.Length, sw.ElapsedMilliseconds);
+        /// </example>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        public static void Information<T0, T1>(Exception exception, string messageTemplate, T0 propertyValue0, T1 propertyValue1)
+        {
+            Write(LogEventLevel.Information, exception, messageTemplate, propertyValue0, propertyValue1);
+        }
+
+        /// <summary>
+        /// Write a log event with the <see cref="LogEventLevel.Information"/> level and associated exception.
+        /// </summary>
+        /// <param name="exception">Exception related to the event.</param>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <param name="propertyValue0">Object positionally formatted into the message template.</param>
+        /// <param name="propertyValue1">Object positionally formatted into the message template.</param>
+        /// <param name="propertyValue2">Object positionally formatted into the message template.</param>
+        /// <example>
+        /// Log.Information(ex, "Processed {RecordCount} records in {TimeMS}.", records.Length, sw.ElapsedMilliseconds);
+        /// </example>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        public static void Information<T0, T1, T2>(Exception exception, string messageTemplate, T0 propertyValue0, T1 propertyValue1, T2 propertyValue2)
+        {
+            Write(LogEventLevel.Information, exception, messageTemplate, propertyValue0, propertyValue1, propertyValue2);
         }
 
         /// <summary>
@@ -228,7 +611,52 @@ namespace Serilog
         }
 
         /// <summary>
-        /// Write a log event with the <see cref="LogEventLevel.Warning"/> level and associated exception.
+        /// Write a log event with the <see cref="LogEventLevel.Warning"/> level.
+        /// </summary>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <param name="propertyValue">Object positionally formatted into the message template.</param>
+        /// <example>
+        /// Log.Warning("Skipped {SkipCount} records.", skippedRecords.Length);
+        /// </example>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        public static void Warning<T>(string messageTemplate, T propertyValue)
+        {
+            Write(LogEventLevel.Warning, messageTemplate, propertyValue);
+        }
+
+        /// <summary>
+        /// Write a log event with the <see cref="LogEventLevel.Warning"/> level.
+        /// </summary>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <param name="propertyValue0">Object positionally formatted into the message template.</param>
+        /// <param name="propertyValue1">Object positionally formatted into the message template.</param>
+        /// <example>
+        /// Log.Warning("Skipped {SkipCount} records.", skippedRecords.Length);
+        /// </example>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        public static void Warning<T0, T1>(string messageTemplate, T0 propertyValue0, T1 propertyValue1)
+        {
+            Write(LogEventLevel.Warning, messageTemplate, propertyValue0, propertyValue1);
+        }
+
+        /// <summary>
+        /// Write a log event with the <see cref="LogEventLevel.Warning"/> level.
+        /// </summary>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <param name="propertyValue0">Object positionally formatted into the message template.</param>
+        /// <param name="propertyValue1">Object positionally formatted into the message template.</param>
+        /// <param name="propertyValue2">Object positionally formatted into the message template.</param>
+        /// <example>
+        /// Log.Warning("Skipped {SkipCount} records.", skippedRecords.Length);
+        /// </example>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        public static void Warning<T0, T1, T2>(string messageTemplate, T0 propertyValue0, T1 propertyValue1, T2 propertyValue2)
+        {
+            Write(LogEventLevel.Warning, messageTemplate, propertyValue0, propertyValue1, propertyValue2);
+        }
+
+        /// <summary>
+        /// Write a log event with the <see cref="LogEventLevel.Warning"/> level.
         /// </summary>
         /// <param name="messageTemplate">Message template describing the event.</param>
         /// <param name="propertyValues">Objects positionally formatted into the message template.</param>
@@ -239,6 +667,54 @@ namespace Serilog
         public static void Warning(string messageTemplate, params object[] propertyValues)
         {
             Logger.Warning(messageTemplate, propertyValues);
+        }
+
+        /// <summary>
+        /// Write a log event with the <see cref="LogEventLevel.Warning"/> level and associated exception.
+        /// </summary>
+        /// <param name="exception">Exception related to the event.</param>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <param name="propertyValue">Object positionally formatted into the message template.</param>
+        /// <example>
+        /// Log.Warning(ex, "Skipped {SkipCount} records.", skippedRecords.Length);
+        /// </example>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        public static void Warning<T>(Exception exception, string messageTemplate, T propertyValue)
+        {
+            Write(LogEventLevel.Warning, exception, messageTemplate, propertyValue);
+        }
+
+        /// <summary>
+        /// Write a log event with the <see cref="LogEventLevel.Warning"/> level and associated exception.
+        /// </summary>
+        /// <param name="exception">Exception related to the event.</param>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <param name="propertyValue0">Object positionally formatted into the message template.</param>
+        /// <param name="propertyValue1">Object positionally formatted into the message template.</param>
+        /// <example>
+        /// Log.Warning(ex, "Skipped {SkipCount} records.", skippedRecords.Length);
+        /// </example>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        public static void Warning<T0, T1>(Exception exception, string messageTemplate, T0 propertyValue0, T1 propertyValue1)
+        {
+            Write(LogEventLevel.Warning, exception, messageTemplate, propertyValue0, propertyValue1);
+        }
+
+        /// <summary>
+        /// Write a log event with the <see cref="LogEventLevel.Warning"/> level and associated exception.
+        /// </summary>
+        /// <param name="exception">Exception related to the event.</param>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <param name="propertyValue0">Object positionally formatted into the message template.</param>
+        /// <param name="propertyValue1">Object positionally formatted into the message template.</param>
+        /// <param name="propertyValue2">Object positionally formatted into the message template.</param>
+        /// <example>
+        /// Log.Warning(ex, "Skipped {SkipCount} records.", skippedRecords.Length);
+        /// </example>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        public static void Warning<T0, T1, T2>(Exception exception, string messageTemplate, T0 propertyValue0, T1 propertyValue1, T2 propertyValue2)
+        {
+            Write(LogEventLevel.Warning, exception, messageTemplate, propertyValue0, propertyValue1, propertyValue2);
         }
 
         /// <summary>
@@ -257,7 +733,52 @@ namespace Serilog
         }
 
         /// <summary>
-        /// Write a log event with the <see cref="LogEventLevel.Error"/> level and associated exception.
+        /// Write a log event with the <see cref="LogEventLevel.Error"/> level.
+        /// </summary>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <param name="propertyValue">Object positionally formatted into the message template.</param>
+        /// <example>
+        /// Log.Error("Failed {ErrorCount} records.", brokenRecords.Length);
+        /// </example>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        public static void Error<T>(string messageTemplate, T propertyValue)
+        {
+            Write(LogEventLevel.Error, messageTemplate, propertyValue);
+        }
+
+        /// <summary>
+        /// Write a log event with the <see cref="LogEventLevel.Error"/> level.
+        /// </summary>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <param name="propertyValue0">Object positionally formatted into the message template.</param>
+        /// <param name="propertyValue1">Object positionally formatted into the message template.</param>
+        /// <example>
+        /// Log.Error("Failed {ErrorCount} records.", brokenRecords.Length);
+        /// </example>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        public static void Error<T0, T1>(string messageTemplate, T0 propertyValue0, T1 propertyValue1)
+        {
+            Write(LogEventLevel.Error, messageTemplate, propertyValue0, propertyValue1);
+        }
+
+        /// <summary>
+        /// Write a log event with the <see cref="LogEventLevel.Error"/> level.
+        /// </summary>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <param name="propertyValue0">Object positionally formatted into the message template.</param>
+        /// <param name="propertyValue1">Object positionally formatted into the message template.</param>
+        /// <param name="propertyValue2">Object positionally formatted into the message template.</param>
+        /// <example>
+        /// Log.Error("Failed {ErrorCount} records.", brokenRecords.Length);
+        /// </example>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        public static void Error<T0, T1, T2>(string messageTemplate, T0 propertyValue0, T1 propertyValue1, T2 propertyValue2)
+        {
+            Write(LogEventLevel.Error, messageTemplate, propertyValue0, propertyValue1, propertyValue2);
+        }
+
+        /// <summary>
+        /// Write a log event with the <see cref="LogEventLevel.Error"/> level.
         /// </summary>
         /// <param name="messageTemplate">Message template describing the event.</param>
         /// <param name="propertyValues">Objects positionally formatted into the message template.</param>
@@ -268,6 +789,54 @@ namespace Serilog
         public static void Error(string messageTemplate, params object[] propertyValues)
         {
             Logger.Error(messageTemplate, propertyValues);
+        }
+
+        /// <summary>
+        /// Write a log event with the <see cref="LogEventLevel.Error"/> level and associated exception.
+        /// </summary>
+        /// <param name="exception">Exception related to the event.</param>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <param name="propertyValue">Object positionally formatted into the message template.</param>
+        /// <example>
+        /// Log.Error(ex, "Failed {ErrorCount} records.", brokenRecords.Length);
+        /// </example>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        public static void Error<T>(Exception exception, string messageTemplate, T propertyValue)
+        {
+            Write(LogEventLevel.Error, exception, messageTemplate, propertyValue);
+        }
+
+        /// <summary>
+        /// Write a log event with the <see cref="LogEventLevel.Error"/> level and associated exception.
+        /// </summary>
+        /// <param name="exception">Exception related to the event.</param>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <param name="propertyValue0">Object positionally formatted into the message template.</param>
+        /// <param name="propertyValue1">Object positionally formatted into the message template.</param>
+        /// <example>
+        /// Log.Error(ex, "Failed {ErrorCount} records.", brokenRecords.Length);
+        /// </example>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        public static void Error<T0, T1>(Exception exception, string messageTemplate, T0 propertyValue0, T1 propertyValue1)
+        {
+            Write(LogEventLevel.Error, exception, messageTemplate, propertyValue0, propertyValue1);
+        }
+
+        /// <summary>
+        /// Write a log event with the <see cref="LogEventLevel.Error"/> level and associated exception.
+        /// </summary>
+        /// <param name="exception">Exception related to the event.</param>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <param name="propertyValue0">Object positionally formatted into the message template.</param>
+        /// <param name="propertyValue1">Object positionally formatted into the message template.</param>
+        /// <param name="propertyValue2">Object positionally formatted into the message template.</param>
+        /// <example>
+        /// Log.Error(ex, "Failed {ErrorCount} records.", brokenRecords.Length);
+        /// </example>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        public static void Error<T0, T1, T2>(Exception exception, string messageTemplate, T0 propertyValue0, T1 propertyValue1, T2 propertyValue2)
+        {
+            Write(LogEventLevel.Error, exception, messageTemplate, propertyValue0, propertyValue1, propertyValue2);
         }
 
         /// <summary>
@@ -286,7 +855,52 @@ namespace Serilog
         }
 
         /// <summary>
-        /// Write a log event with the <see cref="LogEventLevel.Fatal"/> level and associated exception.
+        /// Write a log event with the <see cref="LogEventLevel.Fatal"/> level.
+        /// </summary>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <param name="propertyValue">Object positionally formatted into the message template.</param>
+        /// <example>
+        /// Log.Fatal("Process terminating.");
+        /// </example>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        public static void Fatal<T>(string messageTemplate, T propertyValue)
+        {
+            Write(LogEventLevel.Fatal, messageTemplate, propertyValue);
+        }
+
+        /// <summary>
+        /// Write a log event with the <see cref="LogEventLevel.Fatal"/> level.
+        /// </summary>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <param name="propertyValue0">Object positionally formatted into the message template.</param>
+        /// <param name="propertyValue1">Object positionally formatted into the message template.</param>
+        /// <example>
+        /// Log.Fatal("Process terminating.");
+        /// </example>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        public static void Fatal<T0, T1>(string messageTemplate, T0 propertyValue0, T1 propertyValue1)
+        {
+            Write(LogEventLevel.Fatal, messageTemplate, propertyValue0, propertyValue1);
+        }
+
+        /// <summary>
+        /// Write a log event with the <see cref="LogEventLevel.Fatal"/> level.
+        /// </summary>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <param name="propertyValue0">Object positionally formatted into the message template.</param>
+        /// <param name="propertyValue1">Object positionally formatted into the message template.</param>
+        /// <param name="propertyValue2">Object positionally formatted into the message template.</param>
+        /// <example>
+        /// Log.Fatal("Process terminating.");
+        /// </example>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        public static void Fatal<T0, T1, T2>(string messageTemplate, T0 propertyValue0, T1 propertyValue1, T2 propertyValue2)
+        {
+            Write(LogEventLevel.Fatal, messageTemplate, propertyValue0, propertyValue1, propertyValue2);
+        }
+
+        /// <summary>
+        /// Write a log event with the <see cref="LogEventLevel.Fatal"/> level.
         /// </summary>
         /// <param name="messageTemplate">Message template describing the event.</param>
         /// <param name="propertyValues">Objects positionally formatted into the message template.</param>
@@ -297,6 +911,54 @@ namespace Serilog
         public static void Fatal(string messageTemplate, params object[] propertyValues)
         {
             Logger.Fatal(messageTemplate, propertyValues);
+        }
+
+        /// <summary>
+        /// Write a log event with the <see cref="LogEventLevel.Fatal"/> level and associated exception.
+        /// </summary>
+        /// <param name="exception">Exception related to the event.</param>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <param name="propertyValue">Object positionally formatted into the message template.</param>
+        /// <example>
+        /// Log.Fatal(ex, "Process terminating.");
+        /// </example>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        public static void Fatal<T>(Exception exception, string messageTemplate, T propertyValue)
+        {
+            Write(LogEventLevel.Fatal, exception, messageTemplate, propertyValue);
+        }
+
+        /// <summary>
+        /// Write a log event with the <see cref="LogEventLevel.Fatal"/> level and associated exception.
+        /// </summary>
+        /// <param name="exception">Exception related to the event.</param>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <param name="propertyValue0">Object positionally formatted into the message template.</param>
+        /// <param name="propertyValue1">Object positionally formatted into the message template.</param>
+        /// <example>
+        /// Log.Fatal(ex, "Process terminating.");
+        /// </example>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        public static void Fatal<T0, T1>(Exception exception, string messageTemplate, T0 propertyValue0, T1 propertyValue1)
+        {
+            Write(LogEventLevel.Fatal, exception, messageTemplate, propertyValue0, propertyValue1);
+        }
+
+        /// <summary>
+        /// Write a log event with the <see cref="LogEventLevel.Fatal"/> level and associated exception.
+        /// </summary>
+        /// <param name="exception">Exception related to the event.</param>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <param name="propertyValue0">Object positionally formatted into the message template.</param>
+        /// <param name="propertyValue1">Object positionally formatted into the message template.</param>
+        /// <param name="propertyValue2">Object positionally formatted into the message template.</param>
+        /// <example>
+        /// Log.Fatal(ex, "Process terminating.");
+        /// </example>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        public static void Fatal<T0, T1, T2>(Exception exception, string messageTemplate, T0 propertyValue0, T1 propertyValue1, T2 propertyValue2)
+        {
+            Write(LogEventLevel.Fatal, exception, messageTemplate, propertyValue0, propertyValue1, propertyValue2);
         }
 
         /// <summary>


### PR DESCRIPTION
This PR is the first part of #479 for Serilog 1.5.

Are you OK with the type parameter and parameter naming?

 1. I considered `TPropertyValue` but chose the shorter `T` to align with [`Action<T>`](https://msdn.microsoft.com/en-us/library/018hxwa8(v=vs.110).aspx)/[`Func<T, TResult>`](https://msdn.microsoft.com/en-us/library/bb549151(v=vs.110).aspx).
 2. For the index suffix on the type parameter and parameter names, I debated whether to start with `0` or `1` and went with `0` to align with the parameter names of [`String.Format`](https://msdn.microsoft.com/en-us/library/d9t40k6d(v=vs.110).aspx)'s overloads and because the `messageTemplate` supports specifying numeric property names that start at zero.
 3. For the overload that just has a single `propertyValue` parameter, I left the index off of the type parameter and parameter names, to align with [`Action<T>`](https://msdn.microsoft.com/en-us/library/018hxwa8(v=vs.110).aspx)/[`Func<T, TResult>`](https://msdn.microsoft.com/en-us/library/bb549151(v=vs.110).aspx), though, this is in conflict with [`String.Format`](https://msdn.microsoft.com/en-us/library/fht0f5be(v=vs.110).aspx), which keeps the `0` suffix on the parameter name for the single parameter case.

I don't have a strong preference either way on these.

Let me know if you'd like me to make any changes.