### PR TITLE
More pliable LoggerConfiguration

### DIFF
--- a/src/Serilog/LoggerConfiguration.cs
+++ b/src/Serilog/LoggerConfiguration.cs
@@ -140,6 +140,56 @@ namespace Serilog
         }
 
         /// <summary>
+        /// Resets the configuration object to its original default state.
+        /// </summary>
+        public LoggerConfiguration Reset()
+        {
+            ClearSinks();
+            ClearEnrichers();
+            ClearFilters();
+            ClearDestructureConfig();
+            _minimumLevel = LogEventLevel.Information;
+            return this;
+        }
+
+        /// <summary>
+        /// Removes all configured sinks.
+        /// </summary>
+        public LoggerConfiguration ClearSinks()
+        {
+            _logEventSinks.Clear();
+            return this;
+        }
+
+        /// <summary>
+        /// Removes all configured enrichers.
+        /// </summary>
+        public LoggerConfiguration ClearEnrichers()
+        {
+            _enrichers.Clear();
+            return this;
+        }
+
+        /// <summary>
+        /// Removes all configured filters.
+        /// </summary>
+        public LoggerConfiguration ClearFilters()
+        {
+            _filters.Clear();
+            return this;
+        }
+
+        /// <summary>
+        /// Removes all configured destructuring customizations.
+        /// </summary>
+        public LoggerConfiguration ClearDestructureConfig()
+        {
+            _additionalScalarTypes.Clear();
+            _additionalDestructuringPolicies.Clear();
+            return this;
+        }
+
+        /// <summary>
         /// Create a logger using the configured sinks, enrichers and minimum level.
         /// </summary>
         /// <returns>The logger.</returns>

--- a/src/Serilog/LoggerConfiguration.cs
+++ b/src/Serilog/LoggerConfiguration.cs
@@ -29,14 +29,38 @@ namespace Serilog
     /// </summary>
     public class LoggerConfiguration
     {
-        readonly List<ILogEventSink> _logEventSinks = new List<ILogEventSink>();
-        readonly List<ILogEventEnricher> _enrichers = new List<ILogEventEnricher>(); 
-        readonly List<ILogEventFilter> _filters = new List<ILogEventFilter>();
-        readonly List<Type> _additionalScalarTypes = new List<Type>();
-        readonly List<IDestructuringPolicy> _additionalDestructuringPolicies = new List<IDestructuringPolicy>();
-        
-        LogEventLevel _minimumLevel = LogEventLevel.Information;
+        /// <summary>
+        /// The sinks that log events will be emitted to.
+        /// </summary>
+        protected readonly List<ILogEventSink> _logEventSinks = new List<ILogEventSink>();
+
+        /// <summary>
+        /// Enrichers of <see cref="LogEvent"/>s.
+        /// </summary>
+        protected readonly List<ILogEventEnricher> _enrichers = new List<ILogEventEnricher>();
+
+        /// <summary>
+        /// Global filters of <see cref="LogEvent"/>s.
+        /// </summary>
+        protected readonly List<ILogEventFilter> _filters = new List<ILogEventFilter>();
+
+        /// <summary>
+        /// Types to be destructed as scalar values.
+        /// </summary>
+        protected readonly List<Type> _additionalScalarTypes = new List<Type>();
+
+        /// <summary>
+        /// Policies for destructuring certain objects.
+        /// </summary>
+        protected readonly List<IDestructuringPolicy> _additionalDestructuringPolicies = new List<IDestructuringPolicy>();
+
+        /// <summary>
+        /// Minimum logging level.
+        /// </summary>
+        protected LogEventLevel _minimumLevel = LogEventLevel.Information;
+
         LoggingLevelSwitch _levelSwitch;
+
         int _maximumDestructuringDepth = 10;
 
         /// <summary>


### PR DESCRIPTION
In trying to add some fluent builder patterns on top of LoggerConfiguration I have come across the limitation that sinks and filters etc cannot be removed from the configuration object once they have been added.  Is there a fundamental reason why this would be a bad thing to do?

Assuming an answer of 'no', this branch contains 2 commits; 

- the first is a simple one to change the collections inside LoggerConfiguration to be protected rather than private.  This would allow specializations of LoggerConfiguration to add the features they want.

- the second are some simple methods that my current use case would find useful - to reset the configuration object to an empty state, or to empty the individual collections.

The first commit is very harmless at least, and would open it up for many customizations.