### PR TITLE
Continue logging when Exception Rendering fails

### DIFF
--- a/test/Serilog.Tests/Formatting/Display/OutputPropertiesTests.cs
+++ b/test/Serilog.Tests/Formatting/Display/OutputPropertiesTests.cs
@@ -1,0 +1,98 @@
+﻿using System;
+using System.IO;
+using NUnit.Framework;
+using Serilog.Debugging;
+using Serilog.Formatting.Display;
+using Serilog.Tests.Support;
+
+namespace Serilog.Tests.Formatting.Display
+{
+    [TestFixture]
+    public class OutputPropertiesTests
+    {
+        [Test]
+        public void BadExceptionRendersIntoOutput()
+        {
+            const string exceptionMessage = "Test Message";
+            Exception exception = new BadException(exceptionMessage);
+            var evt = DelegatingSink.GetLogEvent(l => l.Error(exception, "Something went wrong"));
+
+            var outputProperties = OutputProperties.GetOutputProperties(evt);
+            Assert.IsTrue(outputProperties.ContainsKey(OutputProperties.ExceptionPropertyName));
+            Assert.That(outputProperties[OutputProperties.ExceptionPropertyName].ToString(), Is.StringContaining(exceptionMessage));
+        }
+
+        [Serial]
+        [Test]
+        public void ExceptionRenderingExceptionLogsToSelfLog()
+        {
+            StringWriter writer = new StringWriter();
+            SelfLog.Out = writer;
+
+            const string exceptionMessage = "Test Message";
+            Exception exception = new BadException(exceptionMessage);
+            var evt = DelegatingSink.GetLogEvent(l => l.Error(exception, "Something went wrong"));
+
+            var outputProperties = OutputProperties.GetOutputProperties(evt);
+            Assert.IsNotEmpty(writer.ToString());
+        }
+
+        [Test]
+        public void NoExceptionRendersEmptyStringForException()
+        {
+            var evt = DelegatingSink.GetLogEvent(l => l.Error("No Exception Logged"));
+
+            var outputProperties = OutputProperties.GetOutputProperties(evt);
+            Assert.IsTrue(outputProperties.ContainsKey(OutputProperties.ExceptionPropertyName));
+            Assert.IsEmpty(outputProperties[OutputProperties.ExceptionPropertyName].ToString());
+        }
+
+        [Test]
+        public void RendersExceptionIntoOutput()
+        {
+            const string exceptionMessage = "Test Message";
+            Exception exception = new Exception(exceptionMessage);
+            var evt = DelegatingSink.GetLogEvent(l => l.Error(exception, "Something went wrong"));
+
+            var outputProperties = OutputProperties.GetOutputProperties(evt);
+            Assert.IsTrue(outputProperties.ContainsKey(OutputProperties.ExceptionPropertyName));
+            Assert.That(outputProperties[OutputProperties.ExceptionPropertyName].ToString(), Is.StringContaining(exceptionMessage));
+        }
+
+        [Test]
+        public void VeryBadExceptionRendersFailureMessageIntoOutput()
+        {
+            const string exceptionMessage = "Test Message";
+            Exception exception = new VeryBadException(exceptionMessage);
+            var evt = DelegatingSink.GetLogEvent(l => l.Error(exception, "Something went wrong"));
+
+            var outputProperties = OutputProperties.GetOutputProperties(evt);
+            Assert.IsTrue(outputProperties.ContainsKey(OutputProperties.ExceptionPropertyName));
+            Assert.That(outputProperties[OutputProperties.ExceptionPropertyName].ToString(), Is.StringContaining(OutputProperties.FailedToRenderExceptionMessage));
+        }
+
+        private class BadException : Exception
+        {
+            public BadException(string message) : base(message)
+            {
+            }
+
+            public override string ToString()
+            {
+                throw new ApplicationException("Bad Exception");
+            }
+        }
+
+        private class VeryBadException : Exception
+        {
+            public VeryBadException(string message) : base(message)
+            {
+            }
+
+            public override string Message
+            {
+                get { throw new ApplicationException("Very Bad Exception"); }
+            }
+        }
+    }
+}

--- a/test/Serilog.Tests/Serilog.Tests-net40.csproj
+++ b/test/Serilog.Tests/Serilog.Tests-net40.csproj
@@ -70,6 +70,7 @@
     <Compile Include="Events\LogEventPropertyValueTests.cs" />
     <Compile Include="Filters\MatchingTests.cs" />
     <Compile Include="Formatting\Display\MessageTemplateTextFormatterTests.cs" />
+    <Compile Include="Formatting\Display\OutputPropertiesTests.cs" />
     <Compile Include="LoggerConfigurationTests.cs" />
     <Compile Include="LogTests.cs" />
     <Compile Include="Parameters\PropertyValueConverterTests.cs" />
@@ -82,6 +83,7 @@
     <Compile Include="Support\DelegatingEnricher.cs" />
     <Compile Include="Support\DelegatingSink.cs" />
     <Compile Include="Support\Extensions.cs" />
+    <Compile Include="Support\SerialAttribute.cs" />
     <Compile Include="Support\Some.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/test/Serilog.Tests/Support/SerialAttribute.cs
+++ b/test/Serilog.Tests/Support/SerialAttribute.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Serilog.Tests.Support
+{
+    /// <summary>
+    /// Decorates a test so that ncrunch won't run it in parallel with anything else
+    /// </summary>
+    public class SerialAttribute : Attribute
+    {
+    }
+}


### PR DESCRIPTION
Under certain circumstances, calling .ToString() on an exception can itself throw an exception.  In this situation, Serilog does not log the message or exception.  This occurrence is logged to SelfLog, but this is still tricky to find.

This PR introduces error handling at the point where the exception is rendered into the output.  If .ToString() fails, then a message combining the exception type and message is used.  If this fails, a constant is used.  Importantly, the log message is still written.

I've added test coverage of this functionality.  The Serial attribute is added for people using ncrunch, as testing SelfLog is not thread-safe.

For information only, the real-world scenario which triggered this is from a program where a dependency had been removed.  I think the library may have also been doing some dynamic loading.  When trying to use the functionality exposed in the library, a FileNotFoundException was generated.  This exception was also generated when trying to view the StackTrace of the exception, which in turn was used by ToString.