### PR TITLE
Add a `levelSwitch` parameter to all sink configuration methods

### DIFF
--- a/src/Serilog.FullNetFx/LoggerConfigurationFullNetFxExtensions.cs
+++ b/src/Serilog.FullNetFx/LoggerConfigurationFullNetFxExtensions.cs
@@ -13,18 +13,17 @@
 // limitations under the License.
 
 using System;
-using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Threading;
 using Serilog.Configuration;
+using Serilog.Core;
 using Serilog.Debugging;
 using Serilog.Enrichers;
 using Serilog.Events;
 using Serilog.Formatting.Display;
 using Serilog.Formatting.Raw;
 using Serilog.Settings.AppSettings;
-using Serilog.Settings.KeyValuePairs;
 using Serilog.Sinks.DiagnosticTrace;
 using Serilog.Sinks.IOFile;
 using Serilog.Sinks.RollingFile;
@@ -48,7 +47,9 @@ namespace Serilog
         /// </summary>
         /// <param name="sinkConfiguration">Logger sink configuration.</param>
         /// <param name="restrictedToMinimumLevel">The minimum level for
-        /// events passed through the sink.</param>
+        /// events passed through the sink. Ignored when <paramref name="levelSwitch"/> is specified.</param>
+        /// <param name="levelSwitch">A switch allowing the pass-through minimum level
+        /// to be changed at runtime.</param>
         /// <param name="outputTemplate">A message template describing the format used to write to the sink.
         /// the default is "{Timestamp} [{Level}] {Message}{NewLine}{Exception}".</param>
         /// <param name="formatProvider">Supplies culture-specific formatting information, or null.</param>
@@ -57,12 +58,13 @@ namespace Serilog
             this LoggerSinkConfiguration sinkConfiguration,
             LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
             string outputTemplate = DefaultConsoleOutputTemplate,
-            IFormatProvider formatProvider = null)
+            IFormatProvider formatProvider = null,
+            LoggingLevelSwitch levelSwitch = null)
         {
             if (sinkConfiguration == null) throw new ArgumentNullException("sinkConfiguration");
             if (outputTemplate == null) throw new ArgumentNullException("outputTemplate");
             var formatter = new MessageTemplateTextFormatter(outputTemplate, formatProvider);
-            return sinkConfiguration.Sink(new ConsoleSink(formatter), restrictedToMinimumLevel);
+            return sinkConfiguration.Sink(new ConsoleSink(formatter), restrictedToMinimumLevel, levelSwitch);
         }
 
         /// <summary>
@@ -71,7 +73,9 @@ namespace Serilog
         /// </summary>
         /// <param name="sinkConfiguration">Logger sink configuration.</param>
         /// <param name="restrictedToMinimumLevel">The minimum level for
-        /// events passed through the sink.</param>
+        /// events passed through the sink. Ignored when <paramref name="levelSwitch"/> is specified.</param>
+        /// <param name="levelSwitch">A switch allowing the pass-through minimum level
+        /// to be changed at runtime.</param>
         /// <param name="outputTemplate">A message template describing the format used to write to the sink.
         /// the default is "{Timestamp} [{Level}] {Message}{NewLine}{Exception}".</param>
         /// <param name="formatProvider">Supplies culture-specific formatting information, or null.</param>
@@ -80,11 +84,12 @@ namespace Serilog
             this LoggerSinkConfiguration sinkConfiguration,
             LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
             string outputTemplate = DefaultConsoleOutputTemplate,
-            IFormatProvider formatProvider = null)
+            IFormatProvider formatProvider = null,
+            LoggingLevelSwitch levelSwitch = null)
         {
             if (sinkConfiguration == null) throw new ArgumentNullException("sinkConfiguration");
             if (outputTemplate == null) throw new ArgumentNullException("outputTemplate");
-            return sinkConfiguration.Sink(new ColoredConsoleSink(outputTemplate, formatProvider), restrictedToMinimumLevel);
+            return sinkConfiguration.Sink(new ColoredConsoleSink(outputTemplate, formatProvider), restrictedToMinimumLevel, levelSwitch);
         }
 
         /// <summary>
@@ -112,7 +117,9 @@ namespace Serilog
         /// <param name="sinkConfiguration">Logger sink configuration.</param>
         /// <param name="path">Path to the file.</param>
         /// <param name="restrictedToMinimumLevel">The minimum level for
-        /// events passed through the sink.</param>
+        /// events passed through the sink. Ignored when <paramref name="levelSwitch"/> is specified.</param>
+        /// <param name="levelSwitch">A switch allowing the pass-through minimum level
+        /// to be changed at runtime.</param>
         /// <param name="formatProvider">Supplies culture-specific formatting information, or null.</param>
         /// <param name="outputTemplate">A message template describing the format used to write to the sink.
         /// the default is "{Timestamp} [{Level}] {Message}{NewLine}{Exception}".</param>
@@ -126,7 +133,8 @@ namespace Serilog
             LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
             string outputTemplate = DefaultOutputTemplate,
             IFormatProvider formatProvider = null,
-            long? fileSizeLimitBytes = DefaultFileSizeLimitBytes)
+            long? fileSizeLimitBytes = DefaultFileSizeLimitBytes,
+            LoggingLevelSwitch levelSwitch = null)
         {
             if (sinkConfiguration == null) throw new ArgumentNullException("sinkConfiguration");
             if (outputTemplate == null) throw new ArgumentNullException("outputTemplate");
@@ -147,7 +155,7 @@ namespace Serilog
                 return sinkConfiguration.Sink(new NullSink());
             }
 
-            return sinkConfiguration.Sink(sink, restrictedToMinimumLevel);
+            return sinkConfiguration.Sink(sink, restrictedToMinimumLevel, levelSwitch);
         }
 
         /// <summary>
@@ -160,7 +168,9 @@ namespace Serilog
         /// with {Date} in the place of the file date. E.g. "Logs\myapp-{Date}.log" will result in log
         /// files such as "Logs\myapp-2013-10-20.log", "Logs\myapp-2013-10-21.log" and so on.</param>
         /// <param name="restrictedToMinimumLevel">The minimum level for
-        /// events passed through the sink.</param>
+        /// events passed through the sink. Ignored when <paramref name="levelSwitch"/> is specified.</param>
+        /// <param name="levelSwitch">A switch allowing the pass-through minimum level
+        /// to be changed at runtime.</param>
         /// <param name="outputTemplate">A message template describing the format used to write to the sink.
         /// the default is "{Timestamp} [{Level}] {Message}{NewLine}{Exception}".</param>
         /// <param name="formatProvider">Supplies culture-specific formatting information, or null.</param>
@@ -177,13 +187,14 @@ namespace Serilog
             string outputTemplate = DefaultOutputTemplate,
             IFormatProvider formatProvider = null,
             long? fileSizeLimitBytes = DefaultFileSizeLimitBytes,
-            int? retainedFileCountLimit = DefaultRetainedFileCountLimit)
+            int? retainedFileCountLimit = DefaultRetainedFileCountLimit,
+            LoggingLevelSwitch levelSwitch = null)
         {
             if (sinkConfiguration == null) throw new ArgumentNullException("sinkConfiguration");
             if (outputTemplate == null) throw new ArgumentNullException("outputTemplate");
             var formatter = new MessageTemplateTextFormatter(outputTemplate, formatProvider);
             var sink = new RollingFileSink(pathFormat, formatter, fileSizeLimitBytes, retainedFileCountLimit);
-            return sinkConfiguration.Sink(sink, restrictedToMinimumLevel);
+            return sinkConfiguration.Sink(sink, restrictedToMinimumLevel, levelSwitch);
         }
 
         /// <summary>
@@ -191,7 +202,9 @@ namespace Serilog
         /// </summary>
         /// <param name="sinkConfiguration">Logger sink configuration.</param>
         /// <param name="restrictedToMinimumLevel">The minimum level for
-        /// events passed through the sink.</param>
+        /// events passed through the sink. Ignored when <paramref name="levelSwitch"/> is specified.</param>
+        /// <param name="levelSwitch">A switch allowing the pass-through minimum level
+        /// to be changed at runtime.</param>
         /// <param name="outputTemplate">A message template describing the format used to write to the sink.
         /// the default is "{Timestamp} [{Level}] {Message}{NewLine}{Exception}".</param>
         /// <param name="formatProvider">Supplies culture-specific formatting information, or null.</param>
@@ -200,12 +213,13 @@ namespace Serilog
             this LoggerSinkConfiguration sinkConfiguration,
             LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
             string outputTemplate = DefaultOutputTemplate,
-            IFormatProvider formatProvider = null)
+            IFormatProvider formatProvider = null,
+            LoggingLevelSwitch levelSwitch = null)
         {
             if (sinkConfiguration == null) throw new ArgumentNullException("sinkConfiguration");
             if (outputTemplate == null) throw new ArgumentNullException("outputTemplate");
             var formatter = new MessageTemplateTextFormatter(outputTemplate, formatProvider);
-            return sinkConfiguration.Sink(new DiagnosticTraceSink(formatter), restrictedToMinimumLevel);
+            return sinkConfiguration.Sink(new DiagnosticTraceSink(formatter), restrictedToMinimumLevel, levelSwitch);
         }
 
         /// <summary>

--- a/src/Serilog/Configuration/LoggerSinkConfiguration.cs
+++ b/src/Serilog/Configuration/LoggerSinkConfiguration.cs
@@ -16,6 +16,7 @@ using System;
 using System.IO;
 using Serilog.Core;
 using Serilog.Core.Sinks;
+using Serilog.Debugging;
 using Serilog.Events;
 using Serilog.Formatting.Display;
 using Serilog.Sinks.IOTextWriter;
@@ -46,15 +47,27 @@ namespace Serilog.Configuration
         /// </summary>
         /// <param name="logEventSink">The sink.</param>
         /// <param name="restrictedToMinimumLevel">The minimum level for
-        /// events passed through the sink.</param>
+        /// events passed through the sink. Ignored when <paramref name="levelSwitch"/> is specified.</param>
+        /// <param name="levelSwitch">A switch allowing the pass-through minimum level
+        /// to be changed at runtime.</param>
         /// <returns>Configuration object allowing method chaining.</returns>
         public LoggerConfiguration Sink(
             ILogEventSink logEventSink,
-            LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum)
+            LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
+            LoggingLevelSwitch levelSwitch = null)
         {
             var sink = logEventSink;
-            if (restrictedToMinimumLevel > LevelAlias.Minimum)
-                sink = new RestrictedSink(sink, restrictedToMinimumLevel);
+            if (levelSwitch != null)
+            {
+                if (restrictedToMinimumLevel != LevelAlias.Minimum)
+                    SelfLog.WriteLine("Sink {0} was configured with both a level switch and minimum level '{1}'; the minimum level will be ignored and the switch level used", sink, restrictedToMinimumLevel);
+
+                sink = new RestrictedSink(sink, levelSwitch);
+            }
+            else if (restrictedToMinimumLevel > LevelAlias.Minimum)
+            {
+                sink = new RestrictedSink(sink, new LoggingLevelSwitch(restrictedToMinimumLevel));
+            }
 
             _addSink(sink);
             return _loggerConfiguration;
@@ -65,12 +78,16 @@ namespace Serilog.Configuration
         /// </summary>
         /// <typeparam name="TSink">The sink.</typeparam>
         /// <param name="restrictedToMinimumLevel">The minimum level for
-        /// events passed through the sink.</param>
+        /// events passed through the sink. Ignored when <paramref name="levelSwitch"/> is specified.</param>
+        /// <param name="levelSwitch">A switch allowing the pass-through minimum level
+        /// to be changed at runtime.</param>
         /// <returns>Configuration object allowing method chaining.</returns>
-        public LoggerConfiguration Sink<TSink>(LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum)
+        public LoggerConfiguration Sink<TSink>(
+            LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
+            LoggingLevelSwitch levelSwitch = null)
             where TSink : ILogEventSink, new()
         {
-            return Sink(new TSink(), restrictedToMinimumLevel);
+            return Sink(new TSink(), restrictedToMinimumLevel, levelSwitch);
         }
 
         /// <summary>
@@ -79,7 +96,9 @@ namespace Serilog.Configuration
         /// <param name="textWriter">The text writer to write log events to.</param>
         /// <param name="outputTemplate">Message template describing the output format.</param>
         /// <param name="restrictedToMinimumLevel">The minimum level for
-        /// events passed through the sink.</param>
+        /// events passed through the sink. Ignored when <paramref name="levelSwitch"/> is specified.</param>
+        /// <param name="levelSwitch">A switch allowing the pass-through minimum level
+        /// to be changed at runtime.</param>
         /// <returns>Configuration object allowing method chaining.</returns>
         /// <param name="formatProvider">Supplies culture-specific formatting information, or null.</param>
         /// <exception cref="ArgumentNullException"></exception>
@@ -87,14 +106,15 @@ namespace Serilog.Configuration
             TextWriter textWriter,
             LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
             string outputTemplate = DefaultOutputTemplate,
-            IFormatProvider formatProvider = null)
+            IFormatProvider formatProvider = null,
+            LoggingLevelSwitch levelSwitch = null)
         {
             if (textWriter == null) throw new ArgumentNullException("textWriter");
             if (outputTemplate == null) throw new ArgumentNullException("outputTemplate");
 
             var formatter = new MessageTemplateTextFormatter(outputTemplate, formatProvider);
             var sink = new TextWriterSink(textWriter, formatter);
-            return Sink(sink, restrictedToMinimumLevel);
+            return Sink(sink, restrictedToMinimumLevel, levelSwitch);
         }
 
         /// <summary>
@@ -105,16 +125,19 @@ namespace Serilog.Configuration
         /// </summary>
         /// <param name="configureLogger">An action that configures the sub-logger.</param>
         /// <param name="restrictedToMinimumLevel">The minimum level for
-        /// events passed through the sink.</param>
+        /// events passed through the sink. Ignored when <paramref name="levelSwitch"/> is specified.</param>
+        /// <param name="levelSwitch">A switch allowing the pass-through minimum level
+        /// to be changed at runtime.</param>
         /// <returns>Configuration object allowing method chaining.</returns>
         public LoggerConfiguration Logger(
             Action<LoggerConfiguration> configureLogger,
-            LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum)
+            LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
+            LoggingLevelSwitch levelSwitch = null)
         {
             if (configureLogger == null) throw new ArgumentNullException("configureLogger");
             var lc = new LoggerConfiguration();
             configureLogger(lc);
-            return Sink(new CopyingSink((ILogEventSink)lc.CreateLogger()), restrictedToMinimumLevel);
+            return Sink(new CopyingSink((ILogEventSink)lc.CreateLogger()), restrictedToMinimumLevel, levelSwitch);
         }
 
         /// <summary>
@@ -123,16 +146,19 @@ namespace Serilog.Configuration
         /// <param name="configureObservers">An action that provides an observable
         /// to which observers can subscribe.</param>
         /// <param name="restrictedToMinimumLevel">The minimum level for
-        /// events passed through the sink.</param>
+        /// events passed through the sink. Ignored when <paramref name="levelSwitch"/> is specified.</param>
+        /// <param name="levelSwitch">A switch allowing the pass-through minimum level
+        /// to be changed at runtime.</param>
         /// <returns>Configuration object allowing method chaining.</returns>
         public LoggerConfiguration Observers(
             Action<IObservable<LogEvent>> configureObservers,
-            LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum)
+            LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
+            LoggingLevelSwitch levelSwitch = null)
         {
             if (configureObservers == null) throw new ArgumentNullException("configureObservers");
             var observable = new ObservableSink();
             configureObservers(observable);
-            return Sink(observable, restrictedToMinimumLevel);
+            return Sink(observable, restrictedToMinimumLevel, levelSwitch);
         }
     }
 }

--- a/src/Serilog/Configuration/LoggerSinkConfiguration.cs
+++ b/src/Serilog/Configuration/LoggerSinkConfiguration.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using System;
+using System.ComponentModel;
 using System.IO;
 using Serilog.Core;
 using Serilog.Core.Sinks;
@@ -47,6 +48,24 @@ namespace Serilog.Configuration
         /// </summary>
         /// <param name="logEventSink">The sink.</param>
         /// <param name="restrictedToMinimumLevel">The minimum level for
+        /// events passed through the sink.</param>
+        /// <returns>Configuration object allowing method chaining.</returns>
+        /// <remarks>Provided for binary compatibility for earlier versions,
+        /// should be removed in 2.0. Not marked obsolete because warnings
+        /// would be syntactically annoying to avoid.</remarks>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public LoggerConfiguration Sink(
+            ILogEventSink logEventSink,
+            LogEventLevel restrictedToMinimumLevel)
+        {
+            return Sink(logEventSink, restrictedToMinimumLevel, null);
+        }
+
+        /// <summary>
+        /// Write log events to the specified <see cref="ILogEventSink"/>.
+        /// </summary>
+        /// <param name="logEventSink">The sink.</param>
+        /// <param name="restrictedToMinimumLevel">The minimum level for
         /// events passed through the sink. Ignored when <paramref name="levelSwitch"/> is specified.</param>
         /// <param name="levelSwitch">A switch allowing the pass-through minimum level
         /// to be changed at runtime.</param>
@@ -54,6 +73,7 @@ namespace Serilog.Configuration
         public LoggerConfiguration Sink(
             ILogEventSink logEventSink,
             LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
+            // ReSharper disable once MethodOverloadWithOptionalParameter
             LoggingLevelSwitch levelSwitch = null)
         {
             var sink = logEventSink;

--- a/src/Serilog/Core/Sinks/RestrictedSink.cs
+++ b/src/Serilog/Core/Sinks/RestrictedSink.cs
@@ -20,20 +20,21 @@ namespace Serilog.Core.Sinks
     class RestrictedSink : ILogEventSink
     {
         readonly ILogEventSink _sink;
-        readonly LogEventLevel _restrictedMinimumLevel;
+        readonly LoggingLevelSwitch _levelSwitch;
 
-        public RestrictedSink(ILogEventSink sink, LogEventLevel restrictedMinimumLevel)
+        public RestrictedSink(ILogEventSink sink, LoggingLevelSwitch levelSwitch)
         {
             if (sink == null) throw new ArgumentNullException("sink");
+            if (levelSwitch == null) throw new ArgumentNullException("levelSwitch");
             _sink = sink;
-            _restrictedMinimumLevel = restrictedMinimumLevel;
+            _levelSwitch = levelSwitch;
         }
 
         public void Emit(LogEvent logEvent)
         {
             if (logEvent == null) throw new ArgumentNullException("logEvent");
 
-            if (logEvent.Level < _restrictedMinimumLevel)
+            if ((int)logEvent.Level < (int)_levelSwitch.MinimumLevel)
                 return;
 
             _sink.Emit(logEvent);

--- a/test/Serilog.Tests/Serilog.Tests.csproj
+++ b/test/Serilog.Tests/Serilog.Tests.csproj
@@ -101,6 +101,7 @@
     <Compile Include="Sinks\RollingFile\RollingFileSinkTests.cs" />
     <Compile Include="Sinks\RollingFile\TemplatedPathRollerTests.cs" />
     <Compile Include="Sinks\TextWriter\TextWriterSinkTests.cs" />
+    <Compile Include="Support\CollectingSink.cs" />
     <Compile Include="Support\DelegatingEnricher.cs" />
     <Compile Include="Support\DelegatingSink.cs" />
     <Compile Include="Support\Extensions.cs" />

--- a/test/Serilog.Tests/Support/CollectingSink.cs
+++ b/test/Serilog.Tests/Support/CollectingSink.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using Serilog.Core;
+using Serilog.Events;
+
+namespace Serilog.Tests.Support
+{
+    public class CollectingSink : ILogEventSink
+    {
+        readonly List<LogEvent> _received = new List<LogEvent>();
+
+        public void Emit(LogEvent logEvent)
+        {
+            if (logEvent == null) throw new ArgumentNullException("logEvent");
+            _received.Add(logEvent);
+        }
+
+        public List<LogEvent> Received { get { return _received; } } 
+    }
+}


### PR DESCRIPTION
An implementation for #505. Supports configuration like:

```csharp
var fileLevel = new LoggingLevelSwitch(LogEventLevel.Warning);

var log = new LoggerConfiguration()
  .WriteTo.File("...", levelSwitch: fileLevel)
  .CreateLogger();

// Later...
fileLevel.MinimumLevel = LogEventLevel.Debug;

log.Information("This will be written to the file");
```

This is a **binary breaking change** for user code that calls sink configuration methods, but not for third-party sink assemblies. I don't think it justifies a "2.0" version bump, but open to ideas.