### PR TITLE
PeriodicBatchingSink hook for processing on ticks even when the batch is empty

### DIFF
--- a/src/Serilog.FullNetFx/Sinks/PeriodicBatching/PeriodicBatchingSink-net40.cs
+++ b/src/Serilog.FullNetFx/Sinks/PeriodicBatching/PeriodicBatchingSink-net40.cs
@@ -132,7 +132,10 @@ namespace Serilog.Sinks.PeriodicBatching
                     }
 
                     if (_waitingBatch.Count == 0)
+                    {
+                        OnEmptyBatch();
                         return;
+                    }
 
                     EmitBatch(_waitingBatch);
                     _waitingBatch.Clear();
@@ -203,6 +206,14 @@ namespace Serilog.Sinks.PeriodicBatching
         protected virtual bool CanInclude(LogEvent evt)
         {
             return true;
+        }
+
+        /// <summary>
+        /// Allows derived sinks to perform periodic work without requiring additional threads
+        /// or timers (thus avoiding additional flush/shut-down complexity).
+        /// </summary>
+        protected virtual void OnEmptyBatch()
+        {
         }
     }
 }

--- a/src/Serilog.FullNetFx/Sinks/PeriodicBatching/PeriodicBatchingSink.cs
+++ b/src/Serilog.FullNetFx/Sinks/PeriodicBatching/PeriodicBatchingSink.cs
@@ -154,7 +154,10 @@ namespace Serilog.Sinks.PeriodicBatching
                     }
 
                     if (_waitingBatch.Count == 0)
+                    {
+                        OnEmptyBatch();
                         return;
+                    }
 
                     EmitBatch(_waitingBatch);
 
@@ -227,6 +230,14 @@ namespace Serilog.Sinks.PeriodicBatching
         protected virtual bool CanInclude(LogEvent evt)
         {
             return true;
+        }
+
+        /// <summary>
+        /// Allows derived sinks to perform periodic work without requiring additional threads
+        /// or timers (thus avoiding additional flush/shut-down complexity).
+        /// </summary>
+        protected virtual void OnEmptyBatch()
+        {            
         }
     }
 }


### PR DESCRIPTION
The Seq sink needs an opportunity to do periodic processing, regardless of whether any events have been emitted (#507). This PR adds `OnEmptyBatch()` to `PeriodicBatchingSink` to enable this to occur on the same timer thread used for batch processing, so that additional dispose/shut-down code isn't required.

I'm not certain whether other sinks can make use of this at present, but the general scenario (_query a remote service for current logging level_) sounds like one that will appear again, especially after #511.