### PR TITLE
Added Write overload with timestamp to ILogger

### DIFF
--- a/src/Serilog/Core/Pipeline/Logger.cs
+++ b/src/Serilog/Core/Pipeline/Logger.cs
@@ -123,6 +123,12 @@ namespace Serilog.Core.Pipeline
         [MessageTemplateFormatMethod("messageTemplate")]
         public void Write(LogEventLevel level, Exception exception, string messageTemplate, params object[] propertyValues)
         {
+            Write(DateTimeOffset.Now, level, exception, messageTemplate, propertyValues);
+        }
+
+        [MessageTemplateFormatMethod("messageTemplate")]
+        public void Write(DateTimeOffset timestamp, LogEventLevel level, Exception exception, string messageTemplate, params object[] propertyValues)
+        {
             if (messageTemplate == null) return;
             if (!IsEnabled(level)) return;
 
@@ -131,13 +137,11 @@ namespace Serilog.Core.Pipeline
                 propertyValues.GetType() != typeof(object[]))
                 propertyValues = new object[] { propertyValues };
 
-            var now = DateTimeOffset.Now;
-
             MessageTemplate parsedTemplate;
             IEnumerable<LogEventProperty> properties;
             _messageTemplateProcessor.Process(messageTemplate, propertyValues, out parsedTemplate, out properties);
 
-            var logEvent = new LogEvent(now, level, exception, parsedTemplate, properties);
+            var logEvent = new LogEvent(timestamp, level, exception, parsedTemplate, properties);
             Dispatch(logEvent);
         }
 

--- a/src/Serilog/Core/Pipeline/SilentLogger.cs
+++ b/src/Serilog/Core/Pipeline/SilentLogger.cs
@@ -54,6 +54,11 @@ namespace Serilog.Core.Pipeline
         {
         }
 
+        [MessageTemplateFormatMethod("messageTemplate")]
+        public void Write(DateTimeOffset timestamp, LogEventLevel level, Exception exception, string messageTemplate, params object[] propertyValues)
+        {
+        }
+
         public bool IsEnabled(LogEventLevel level)
         {
             return false;

--- a/src/Serilog/ILogger.cs
+++ b/src/Serilog/ILogger.cs
@@ -91,6 +91,17 @@ namespace Serilog
         void Write(LogEventLevel level, Exception exception, string messageTemplate, params object[] propertyValues);
 
         /// <summary>
+        /// Write a log event with the specified level and associated exception.
+        /// </summary>
+        /// <param name="timestamp">Timestamp for the log event.</param>
+        /// <param name="level">The level of the event.</param>
+        /// <param name="exception">Exception related to the event.</param>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <param name="propertyValues">Objects positionally formatted into the message template.</param>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        void Write(DateTimeOffset timestamp, LogEventLevel level, Exception exception, string messageTemplate, params object[] propertyValues);
+
+        /// <summary>
         /// Determine if events at the specified level will be passed through
         /// to the log sinks.
         /// </summary>


### PR DESCRIPTION
This verload is useful for preserving timestamps when merging logs from another source into Serilog sinks.