### PR TITLE
ReadFrom.AppSettings() that takes key value pair collection

### DIFF
--- a/src/Serilog.FullNetFx/LoggerConfigurationFullNetFxExtensions.cs
+++ b/src/Serilog.FullNetFx/LoggerConfigurationFullNetFxExtensions.cs
@@ -24,7 +24,6 @@ using Serilog.Events;
 using Serilog.Formatting.Display;
 using Serilog.Formatting.Raw;
 using Serilog.Settings.AppSettings;
-using Serilog.Settings.KeyValuePairs;
 using Serilog.Sinks.DiagnosticTrace;
 using Serilog.Sinks.IOFile;
 using Serilog.Sinks.RollingFile;
@@ -273,6 +272,25 @@ namespace Serilog
         {
             if (settingConfiguration == null) throw new ArgumentNullException("settingConfiguration");
             return settingConfiguration.Settings(new AppSettingsSettings());
+        }
+
+        /// <summary>
+        /// Reads the application settings name value collection, searching for for keys
+        /// that look like: <code>serilog:*</code>, which are used to configure
+        /// the logger. To add a sink, use a key like <code>serilog:write-to:File.path</code> for
+        /// each parameter to the sink's configuration method. To add an additional assembly
+        /// containing sinks, use <code>serilog:using</code>. To set the level use 
+        /// <code>serilog:minimum-level</code>.
+        /// </summary>
+        /// <param name="settingConfiguration">Logger setting configuration</param>
+        /// <param name="settings">Application settings name value collection</param>
+        /// <returns>An object allowing configuration to continue.</returns>
+        public static LoggerConfiguration AppSettings(
+            this LoggerSettingsConfiguration settingConfiguration, Dictionary<string, string> settings)
+        {
+            if (settingConfiguration == null) throw new ArgumentNullException("settingConfiguration");
+            if (settings == null) throw new ArgumentNullException("settings");
+            return settingConfiguration.Settings(new AppSettingsSettings(settings));
         }
     }
 }

--- a/test/Serilog.Tests/Settings/AppSettingsTests.cs
+++ b/test/Serilog.Tests/Settings/AppSettingsTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Configuration;
+using System.Linq;
 using NUnit.Framework;
 using Serilog.Events;
 using Serilog.Tests.Support;
@@ -9,7 +10,7 @@ namespace Serilog.Extras.AppSettings.Tests
     public class AppSettingsTests
     {
         [Test]
-        public void EnvironmentVariableExpansionIsApplied()
+        public void EnvironmentVariableExpansionIsAppliedUsingAppSettings()
         {
             // Make sure we have the expected key in the App.config
             Assert.AreEqual("%PATH%", ConfigurationManager.AppSettings["serilog:enrich:with-property:Path"]);
@@ -17,6 +18,28 @@ namespace Serilog.Extras.AppSettings.Tests
             LogEvent evt = null;
             var log = new LoggerConfiguration()
                 .ReadFrom.AppSettings() 
+                .WriteTo.Sink(new DelegatingSink(e => evt = e))
+                .CreateLogger();
+
+            log.Information("Has a Path property with value expanded from the environment variable");
+
+            Assert.IsNotNull(evt);
+            Assert.IsNotNullOrEmpty((string)evt.Properties["Path"].LiteralValue());
+            Assert.AreNotEqual("%PATH%", evt.Properties["Path"].LiteralValue());
+        }
+
+        [Test]
+        public void EnvironmentVariableExpansionIsAppliedUsingKeyValuePairs()
+        {
+            var appSettings = ConfigurationManager.AppSettings.AllKeys
+                .ToDictionary(k => k, k => ConfigurationManager.AppSettings[k]);
+
+            // Make sure we have the expected key in the App.config
+            Assert.AreEqual("%PATH%", appSettings["serilog:enrich:with-property:Path"]);
+
+            LogEvent evt = null;
+            var log = new LoggerConfiguration()
+                .ReadFrom.AppSettings(appSettings)
                 .WriteTo.Sink(new DelegatingSink(e => evt = e))
                 .CreateLogger();
 


### PR DESCRIPTION
Fixes serilog/serilog#536 - Allow ReadFrom.AppSettings to receive a list of key value pairs and process them like any other App.config appSetting.