### PR TITLE
Added event sources (potential feature)

### DIFF
--- a/Serilog.sln.DotSettings
+++ b/Serilog.sln.DotSettings
@@ -123,7 +123,8 @@
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_OBJECT_AND_COLLECTION_INITIALIZER_STYLE/@EntryValue">CHOP_ALWAYS</s:String>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/JavaScriptCodeFormatting/ALIGN_MULTIPLE_DECLARATION/@EntryValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/JavaScriptCodeFormatting/JavaScriptFormatOther/ALIGN_MULTIPLE_DECLARATION/@EntryValue">True</s:Boolean>
-	<s:String x:Key="/Default/CodeStyle/CSharpFileLayoutPatterns/Pattern/@EntryValue">&lt;Patterns xmlns="urn:schemas-jetbrains-com:member-reordering-patterns"&gt;&#xD;
+	<s:String x:Key="/Default/CodeStyle/CSharpFileLayoutPatterns/Pattern/@EntryValue">&lt;?xml version="1.0" encoding="utf-16"?&gt;&#xD;
+&lt;Patterns xmlns="urn:schemas-jetbrains-com:member-reordering-patterns"&gt;&#xD;
   &lt;TypePattern DisplayName="COM interfaces or structs"&gt;&#xD;
     &lt;TypePattern.Match&gt;&#xD;
       &lt;Or&gt;&#xD;
@@ -134,77 +135,67 @@
             &lt;HasAttribute Name="System.Runtime.InteropServices.ComImport" /&gt;&#xD;
           &lt;/Or&gt;&#xD;
         &lt;/And&gt;&#xD;
-        &lt;HasAttribute Name="System.Runtime.InteropServices.StructLayoutAttribute" /&gt;&#xD;
+        &lt;Kind Is="Struct" /&gt;&#xD;
       &lt;/Or&gt;&#xD;
     &lt;/TypePattern.Match&gt;&#xD;
   &lt;/TypePattern&gt;&#xD;
-&#xD;
   &lt;TypePattern DisplayName="NUnit Test Fixtures" RemoveRegions="All"&gt;&#xD;
     &lt;TypePattern.Match&gt;&#xD;
       &lt;And&gt;&#xD;
         &lt;Kind Is="Class" /&gt;&#xD;
-        &lt;HasAttribute Name="NUnit.Framework.TestFixtureAttribute" Inherited="true" /&gt;&#xD;
-        &lt;HasAttribute Name="NUnit.Framework.TestCaseFixtureAttribute" Inherited="true" /&gt;&#xD;
+        &lt;HasAttribute Name="NUnit.Framework.TestFixtureAttribute" Inherited="True" /&gt;&#xD;
+        &lt;HasAttribute Name="NUnit.Framework.TestCaseFixtureAttribute" Inherited="True" /&gt;&#xD;
       &lt;/And&gt;&#xD;
     &lt;/TypePattern.Match&gt;&#xD;
-&#xD;
     &lt;Entry DisplayName="Setup/Teardown Methods"&gt;&#xD;
       &lt;Entry.Match&gt;&#xD;
         &lt;And&gt;&#xD;
           &lt;Kind Is="Method" /&gt;&#xD;
           &lt;Or&gt;&#xD;
-            &lt;HasAttribute Name="NUnit.Framework.SetUpAttribute" Inherited="true" /&gt;&#xD;
-            &lt;HasAttribute Name="NUnit.Framework.TearDownAttribute" Inherited="true" /&gt;&#xD;
-            &lt;HasAttribute Name="NUnit.Framework.FixtureSetUpAttribute" Inherited="true" /&gt;&#xD;
-            &lt;HasAttribute Name="NUnit.Framework.FixtureTearDownAttribute" Inherited="true" /&gt;&#xD;
+            &lt;HasAttribute Name="NUnit.Framework.SetUpAttribute" Inherited="True" /&gt;&#xD;
+            &lt;HasAttribute Name="NUnit.Framework.TearDownAttribute" Inherited="True" /&gt;&#xD;
+            &lt;HasAttribute Name="NUnit.Framework.FixtureSetUpAttribute" Inherited="True" /&gt;&#xD;
+            &lt;HasAttribute Name="NUnit.Framework.FixtureTearDownAttribute" Inherited="True" /&gt;&#xD;
           &lt;/Or&gt;&#xD;
         &lt;/And&gt;&#xD;
       &lt;/Entry.Match&gt;&#xD;
     &lt;/Entry&gt;&#xD;
-&#xD;
     &lt;Entry DisplayName="All other members" /&gt;&#xD;
-&#xD;
-    &lt;Entry DisplayName="Test Methods" Priority="100"&gt;&#xD;
+    &lt;Entry Priority="100" DisplayName="Test Methods"&gt;&#xD;
       &lt;Entry.Match&gt;&#xD;
         &lt;And&gt;&#xD;
           &lt;Kind Is="Method" /&gt;&#xD;
-          &lt;HasAttribute Name="NUnit.Framework.TestAttribute" Inherited="false" /&gt;&#xD;
+          &lt;HasAttribute Name="NUnit.Framework.TestAttribute" /&gt;&#xD;
         &lt;/And&gt;&#xD;
       &lt;/Entry.Match&gt;&#xD;
-&#xD;
       &lt;Entry.SortBy&gt;&#xD;
         &lt;Name /&gt;&#xD;
       &lt;/Entry.SortBy&gt;&#xD;
     &lt;/Entry&gt;&#xD;
   &lt;/TypePattern&gt;&#xD;
-&#xD;
   &lt;TypePattern DisplayName="Default Pattern"&gt;&#xD;
-    &lt;Entry DisplayName="Public Delegates" Priority="100"&gt;&#xD;
+    &lt;Entry Priority="100" DisplayName="Public Delegates"&gt;&#xD;
       &lt;Entry.Match&gt;&#xD;
         &lt;And&gt;&#xD;
           &lt;Access Is="Public" /&gt;&#xD;
           &lt;Kind Is="Delegate" /&gt;&#xD;
         &lt;/And&gt;&#xD;
       &lt;/Entry.Match&gt;&#xD;
-&#xD;
       &lt;Entry.SortBy&gt;&#xD;
         &lt;Name /&gt;&#xD;
       &lt;/Entry.SortBy&gt;&#xD;
     &lt;/Entry&gt;&#xD;
-&#xD;
-    &lt;Entry DisplayName="Public Enums" Priority="100"&gt;&#xD;
+    &lt;Entry Priority="100" DisplayName="Public Enums"&gt;&#xD;
       &lt;Entry.Match&gt;&#xD;
         &lt;And&gt;&#xD;
           &lt;Access Is="Public" /&gt;&#xD;
           &lt;Kind Is="Enum" /&gt;&#xD;
         &lt;/And&gt;&#xD;
       &lt;/Entry.Match&gt;&#xD;
-&#xD;
       &lt;Entry.SortBy&gt;&#xD;
         &lt;Name /&gt;&#xD;
       &lt;/Entry.SortBy&gt;&#xD;
     &lt;/Entry&gt;&#xD;
-&#xD;
     &lt;Entry DisplayName="Static Fields and Constants"&gt;&#xD;
       &lt;Entry.Match&gt;&#xD;
         &lt;Or&gt;&#xD;
@@ -215,17 +206,10 @@
           &lt;/And&gt;&#xD;
         &lt;/Or&gt;&#xD;
       &lt;/Entry.Match&gt;&#xD;
-&#xD;
       &lt;Entry.SortBy&gt;&#xD;
-        &lt;Kind&gt;&#xD;
-          &lt;Kind.Order&gt;&#xD;
-            &lt;DeclarationKind&gt;Constant&lt;/DeclarationKind&gt;&#xD;
-            &lt;DeclarationKind&gt;Field&lt;/DeclarationKind&gt;&#xD;
-          &lt;/Kind.Order&gt;&#xD;
-        &lt;/Kind&gt;&#xD;
+        &lt;Kind Order="Constant Field" /&gt;&#xD;
       &lt;/Entry.SortBy&gt;&#xD;
     &lt;/Entry&gt;&#xD;
-&#xD;
     &lt;Entry DisplayName="Fields"&gt;&#xD;
       &lt;Entry.Match&gt;&#xD;
         &lt;And&gt;&#xD;
@@ -235,23 +219,19 @@
           &lt;/Not&gt;&#xD;
         &lt;/And&gt;&#xD;
       &lt;/Entry.Match&gt;&#xD;
-&#xD;
       &lt;Entry.SortBy&gt;&#xD;
         &lt;Readonly /&gt;&#xD;
         &lt;Name /&gt;&#xD;
       &lt;/Entry.SortBy&gt;&#xD;
     &lt;/Entry&gt;&#xD;
-&#xD;
     &lt;Entry DisplayName="Constructors"&gt;&#xD;
       &lt;Entry.Match&gt;&#xD;
         &lt;Kind Is="Constructor" /&gt;&#xD;
       &lt;/Entry.Match&gt;&#xD;
-&#xD;
       &lt;Entry.SortBy&gt;&#xD;
-        &lt;Static/&gt;&#xD;
+        &lt;Static /&gt;&#xD;
       &lt;/Entry.SortBy&gt;&#xD;
     &lt;/Entry&gt;&#xD;
-&#xD;
     &lt;Entry DisplayName="Properties, Indexers"&gt;&#xD;
       &lt;Entry.Match&gt;&#xD;
         &lt;Or&gt;&#xD;
@@ -260,30 +240,25 @@
         &lt;/Or&gt;&#xD;
       &lt;/Entry.Match&gt;&#xD;
     &lt;/Entry&gt;&#xD;
-&#xD;
-    &lt;Entry DisplayName="Interface Implementations" Priority="100"&gt;&#xD;
+    &lt;Entry Priority="100" DisplayName="Interface Implementations"&gt;&#xD;
       &lt;Entry.Match&gt;&#xD;
         &lt;And&gt;&#xD;
           &lt;Kind Is="Member" /&gt;&#xD;
           &lt;ImplementsInterface /&gt;&#xD;
         &lt;/And&gt;&#xD;
       &lt;/Entry.Match&gt;&#xD;
-&#xD;
       &lt;Entry.SortBy&gt;&#xD;
-        &lt;ImplementsInterface Immediate="true" /&gt;&#xD;
+        &lt;ImplementsInterface Immediate="True" /&gt;&#xD;
       &lt;/Entry.SortBy&gt;&#xD;
     &lt;/Entry&gt;&#xD;
-&#xD;
     &lt;Entry DisplayName="All other members" /&gt;&#xD;
-&#xD;
     &lt;Entry DisplayName="Nested Types"&gt;&#xD;
       &lt;Entry.Match&gt;&#xD;
         &lt;Kind Is="Type" /&gt;&#xD;
       &lt;/Entry.Match&gt;&#xD;
     &lt;/Entry&gt;&#xD;
   &lt;/TypePattern&gt;&#xD;
-&lt;/Patterns&gt;&#xD;
-</s:String>
+&lt;/Patterns&gt;</s:String>
 	<s:String x:Key="/Default/CodeStyle/CSharpMemberOrderPattern/CustomPattern/@EntryValue">&lt;?xml version="1.0" encoding="utf-8" ?&gt;&#xD;
 &#xD;
 &lt;!--&#xD;
@@ -548,6 +523,8 @@ II.2.12 &lt;HandlesEvent /&gt;&#xD;
 	<s:String x:Key="/Default/CodeStyle/Naming/VBNaming/PredefinedNamingRules/=TypeParameters/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="T" Suffix="" Style="AaBb" /&gt;</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/VBNaming/PredefinedNamingRules/=TypesAndNamespaces/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpFileLayoutPatternsUpgrade/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EAddAccessorOwnerDeclarationBracesMigration/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EAlwaysTreatStructAsNotReorderableMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateBlankLinesAroundFieldToBlankLinesAroundProperty/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateThisQualifierSettings/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002EJavaScript_002ECodeStyle_002ESettingsUpgrade_002EJsCodeFormatterSettingsUpgrader/@EntryIndexedValue">True</s:Boolean>

--- a/Serilog.sln.DotSettings
+++ b/Serilog.sln.DotSettings
@@ -123,8 +123,7 @@
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_OBJECT_AND_COLLECTION_INITIALIZER_STYLE/@EntryValue">CHOP_ALWAYS</s:String>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/JavaScriptCodeFormatting/ALIGN_MULTIPLE_DECLARATION/@EntryValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/JavaScriptCodeFormatting/JavaScriptFormatOther/ALIGN_MULTIPLE_DECLARATION/@EntryValue">True</s:Boolean>
-	<s:String x:Key="/Default/CodeStyle/CSharpFileLayoutPatterns/Pattern/@EntryValue">&lt;?xml version="1.0" encoding="utf-16"?&gt;&#xD;
-&lt;Patterns xmlns="urn:schemas-jetbrains-com:member-reordering-patterns"&gt;&#xD;
+	<s:String x:Key="/Default/CodeStyle/CSharpFileLayoutPatterns/Pattern/@EntryValue">&lt;Patterns xmlns="urn:schemas-jetbrains-com:member-reordering-patterns"&gt;&#xD;
   &lt;TypePattern DisplayName="COM interfaces or structs"&gt;&#xD;
     &lt;TypePattern.Match&gt;&#xD;
       &lt;Or&gt;&#xD;
@@ -135,67 +134,77 @@
             &lt;HasAttribute Name="System.Runtime.InteropServices.ComImport" /&gt;&#xD;
           &lt;/Or&gt;&#xD;
         &lt;/And&gt;&#xD;
-        &lt;Kind Is="Struct" /&gt;&#xD;
+        &lt;HasAttribute Name="System.Runtime.InteropServices.StructLayoutAttribute" /&gt;&#xD;
       &lt;/Or&gt;&#xD;
     &lt;/TypePattern.Match&gt;&#xD;
   &lt;/TypePattern&gt;&#xD;
+&#xD;
   &lt;TypePattern DisplayName="NUnit Test Fixtures" RemoveRegions="All"&gt;&#xD;
     &lt;TypePattern.Match&gt;&#xD;
       &lt;And&gt;&#xD;
         &lt;Kind Is="Class" /&gt;&#xD;
-        &lt;HasAttribute Name="NUnit.Framework.TestFixtureAttribute" Inherited="True" /&gt;&#xD;
-        &lt;HasAttribute Name="NUnit.Framework.TestCaseFixtureAttribute" Inherited="True" /&gt;&#xD;
+        &lt;HasAttribute Name="NUnit.Framework.TestFixtureAttribute" Inherited="true" /&gt;&#xD;
+        &lt;HasAttribute Name="NUnit.Framework.TestCaseFixtureAttribute" Inherited="true" /&gt;&#xD;
       &lt;/And&gt;&#xD;
     &lt;/TypePattern.Match&gt;&#xD;
+&#xD;
     &lt;Entry DisplayName="Setup/Teardown Methods"&gt;&#xD;
       &lt;Entry.Match&gt;&#xD;
         &lt;And&gt;&#xD;
           &lt;Kind Is="Method" /&gt;&#xD;
           &lt;Or&gt;&#xD;
-            &lt;HasAttribute Name="NUnit.Framework.SetUpAttribute" Inherited="True" /&gt;&#xD;
-            &lt;HasAttribute Name="NUnit.Framework.TearDownAttribute" Inherited="True" /&gt;&#xD;
-            &lt;HasAttribute Name="NUnit.Framework.FixtureSetUpAttribute" Inherited="True" /&gt;&#xD;
-            &lt;HasAttribute Name="NUnit.Framework.FixtureTearDownAttribute" Inherited="True" /&gt;&#xD;
+            &lt;HasAttribute Name="NUnit.Framework.SetUpAttribute" Inherited="true" /&gt;&#xD;
+            &lt;HasAttribute Name="NUnit.Framework.TearDownAttribute" Inherited="true" /&gt;&#xD;
+            &lt;HasAttribute Name="NUnit.Framework.FixtureSetUpAttribute" Inherited="true" /&gt;&#xD;
+            &lt;HasAttribute Name="NUnit.Framework.FixtureTearDownAttribute" Inherited="true" /&gt;&#xD;
           &lt;/Or&gt;&#xD;
         &lt;/And&gt;&#xD;
       &lt;/Entry.Match&gt;&#xD;
     &lt;/Entry&gt;&#xD;
+&#xD;
     &lt;Entry DisplayName="All other members" /&gt;&#xD;
-    &lt;Entry Priority="100" DisplayName="Test Methods"&gt;&#xD;
+&#xD;
+    &lt;Entry DisplayName="Test Methods" Priority="100"&gt;&#xD;
       &lt;Entry.Match&gt;&#xD;
         &lt;And&gt;&#xD;
           &lt;Kind Is="Method" /&gt;&#xD;
-          &lt;HasAttribute Name="NUnit.Framework.TestAttribute" /&gt;&#xD;
+          &lt;HasAttribute Name="NUnit.Framework.TestAttribute" Inherited="false" /&gt;&#xD;
         &lt;/And&gt;&#xD;
       &lt;/Entry.Match&gt;&#xD;
+&#xD;
       &lt;Entry.SortBy&gt;&#xD;
         &lt;Name /&gt;&#xD;
       &lt;/Entry.SortBy&gt;&#xD;
     &lt;/Entry&gt;&#xD;
   &lt;/TypePattern&gt;&#xD;
+&#xD;
   &lt;TypePattern DisplayName="Default Pattern"&gt;&#xD;
-    &lt;Entry Priority="100" DisplayName="Public Delegates"&gt;&#xD;
+    &lt;Entry DisplayName="Public Delegates" Priority="100"&gt;&#xD;
       &lt;Entry.Match&gt;&#xD;
         &lt;And&gt;&#xD;
           &lt;Access Is="Public" /&gt;&#xD;
           &lt;Kind Is="Delegate" /&gt;&#xD;
         &lt;/And&gt;&#xD;
       &lt;/Entry.Match&gt;&#xD;
+&#xD;
       &lt;Entry.SortBy&gt;&#xD;
         &lt;Name /&gt;&#xD;
       &lt;/Entry.SortBy&gt;&#xD;
     &lt;/Entry&gt;&#xD;
-    &lt;Entry Priority="100" DisplayName="Public Enums"&gt;&#xD;
+&#xD;
+    &lt;Entry DisplayName="Public Enums" Priority="100"&gt;&#xD;
       &lt;Entry.Match&gt;&#xD;
         &lt;And&gt;&#xD;
           &lt;Access Is="Public" /&gt;&#xD;
           &lt;Kind Is="Enum" /&gt;&#xD;
         &lt;/And&gt;&#xD;
       &lt;/Entry.Match&gt;&#xD;
+&#xD;
       &lt;Entry.SortBy&gt;&#xD;
         &lt;Name /&gt;&#xD;
       &lt;/Entry.SortBy&gt;&#xD;
     &lt;/Entry&gt;&#xD;
+&#xD;
     &lt;Entry DisplayName="Static Fields and Constants"&gt;&#xD;
       &lt;Entry.Match&gt;&#xD;
         &lt;Or&gt;&#xD;
@@ -206,10 +215,17 @@
           &lt;/And&gt;&#xD;
         &lt;/Or&gt;&#xD;
       &lt;/Entry.Match&gt;&#xD;
+&#xD;
       &lt;Entry.SortBy&gt;&#xD;
-        &lt;Kind Order="Constant Field" /&gt;&#xD;
+        &lt;Kind&gt;&#xD;
+          &lt;Kind.Order&gt;&#xD;
+            &lt;DeclarationKind&gt;Constant&lt;/DeclarationKind&gt;&#xD;
+            &lt;DeclarationKind&gt;Field&lt;/DeclarationKind&gt;&#xD;
+          &lt;/Kind.Order&gt;&#xD;
+        &lt;/Kind&gt;&#xD;
       &lt;/Entry.SortBy&gt;&#xD;
     &lt;/Entry&gt;&#xD;
+&#xD;
     &lt;Entry DisplayName="Fields"&gt;&#xD;
       &lt;Entry.Match&gt;&#xD;
         &lt;And&gt;&#xD;
@@ -219,19 +235,23 @@
           &lt;/Not&gt;&#xD;
         &lt;/And&gt;&#xD;
       &lt;/Entry.Match&gt;&#xD;
+&#xD;
       &lt;Entry.SortBy&gt;&#xD;
         &lt;Readonly /&gt;&#xD;
         &lt;Name /&gt;&#xD;
       &lt;/Entry.SortBy&gt;&#xD;
     &lt;/Entry&gt;&#xD;
+&#xD;
     &lt;Entry DisplayName="Constructors"&gt;&#xD;
       &lt;Entry.Match&gt;&#xD;
         &lt;Kind Is="Constructor" /&gt;&#xD;
       &lt;/Entry.Match&gt;&#xD;
+&#xD;
       &lt;Entry.SortBy&gt;&#xD;
-        &lt;Static /&gt;&#xD;
+        &lt;Static/&gt;&#xD;
       &lt;/Entry.SortBy&gt;&#xD;
     &lt;/Entry&gt;&#xD;
+&#xD;
     &lt;Entry DisplayName="Properties, Indexers"&gt;&#xD;
       &lt;Entry.Match&gt;&#xD;
         &lt;Or&gt;&#xD;
@@ -240,25 +260,30 @@
         &lt;/Or&gt;&#xD;
       &lt;/Entry.Match&gt;&#xD;
     &lt;/Entry&gt;&#xD;
-    &lt;Entry Priority="100" DisplayName="Interface Implementations"&gt;&#xD;
+&#xD;
+    &lt;Entry DisplayName="Interface Implementations" Priority="100"&gt;&#xD;
       &lt;Entry.Match&gt;&#xD;
         &lt;And&gt;&#xD;
           &lt;Kind Is="Member" /&gt;&#xD;
           &lt;ImplementsInterface /&gt;&#xD;
         &lt;/And&gt;&#xD;
       &lt;/Entry.Match&gt;&#xD;
+&#xD;
       &lt;Entry.SortBy&gt;&#xD;
-        &lt;ImplementsInterface Immediate="True" /&gt;&#xD;
+        &lt;ImplementsInterface Immediate="true" /&gt;&#xD;
       &lt;/Entry.SortBy&gt;&#xD;
     &lt;/Entry&gt;&#xD;
+&#xD;
     &lt;Entry DisplayName="All other members" /&gt;&#xD;
+&#xD;
     &lt;Entry DisplayName="Nested Types"&gt;&#xD;
       &lt;Entry.Match&gt;&#xD;
         &lt;Kind Is="Type" /&gt;&#xD;
       &lt;/Entry.Match&gt;&#xD;
     &lt;/Entry&gt;&#xD;
   &lt;/TypePattern&gt;&#xD;
-&lt;/Patterns&gt;</s:String>
+&lt;/Patterns&gt;&#xD;
+</s:String>
 	<s:String x:Key="/Default/CodeStyle/CSharpMemberOrderPattern/CustomPattern/@EntryValue">&lt;?xml version="1.0" encoding="utf-8" ?&gt;&#xD;
 &#xD;
 &lt;!--&#xD;
@@ -523,8 +548,6 @@ II.2.12 &lt;HandlesEvent /&gt;&#xD;
 	<s:String x:Key="/Default/CodeStyle/Naming/VBNaming/PredefinedNamingRules/=TypeParameters/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="T" Suffix="" Style="AaBb" /&gt;</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/VBNaming/PredefinedNamingRules/=TypesAndNamespaces/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpFileLayoutPatternsUpgrade/@EntryIndexedValue">True</s:Boolean>
-	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EAddAccessorOwnerDeclarationBracesMigration/@EntryIndexedValue">True</s:Boolean>
-	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EAlwaysTreatStructAsNotReorderableMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateBlankLinesAroundFieldToBlankLinesAroundProperty/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateThisQualifierSettings/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002EJavaScript_002ECodeStyle_002ESettingsUpgrade_002EJsCodeFormatterSettingsUpgrader/@EntryIndexedValue">True</s:Boolean>

--- a/src/Serilog/Serilog-net40.csproj
+++ b/src/Serilog/Serilog-net40.csproj
@@ -117,6 +117,7 @@
     <Compile Include="Settings\KeyValuePairs\TypeExtensions-40.cs" />
     <Compile Include="Sinks\IOTextWriter\TextWriterSink.cs" />
     <Compile Include="Sinks\Observable\ObservableSink-net40.cs" />
+    <Compile Include="Sources\EventSource.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\..\assets\Serilog.snk">

--- a/src/Serilog/Serilog.csproj
+++ b/src/Serilog/Serilog.csproj
@@ -123,6 +123,7 @@
     <Compile Include="Settings\KeyValuePairs\KeyValuePairSettings.cs" />
     <Compile Include="Sinks\IOTextWriter\TextWriterSink.cs" />
     <Compile Include="Sinks\Observable\ObservableSink.cs" />
+    <Compile Include="Sources\EventSource.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\..\assets\Serilog.snk">

--- a/src/Serilog/Sources/EventSource.cs
+++ b/src/Serilog/Sources/EventSource.cs
@@ -1,0 +1,340 @@
+﻿using System;
+using System.Collections.Generic;
+using Serilog.Core;
+using Serilog.Events;
+
+namespace Serilog.Sources
+{
+
+	/// <summary>
+	///		Provides the ability to create semantic and strongly typed logging sources
+	/// </summary>
+	public abstract class EventSource : ILogger
+	{
+
+		private readonly ILogger _sourceLogger;
+
+		/// <summary>
+		///		Creates a new <see cref="EventSource"/>
+		/// </summary>
+		protected EventSource()
+			: this(new LoggerConfiguration())
+		{
+			
+		}
+
+		/// <summary>
+		///		Creates a new <see cref="EventSource"/> using an existing <see cref="LoggerConfiguration"/>
+		/// </summary>
+		protected EventSource(LoggerConfiguration configuration)
+		{
+			if(configuration == null)
+				throw new ArgumentNullException("configuration");
+			OnBuildUp(configuration);
+
+			_sourceLogger = configuration.CreateLogger();
+		}
+
+		/// <summary>
+		/// Create a logger that enriches log events via the provided enrichers.
+		/// </summary>
+		/// <param name="enrichers">Enrichers that apply in the context.</param>
+		/// <returns>A logger that will enrich log events as specified.</returns>
+		public ILogger ForContext(IEnumerable<ILogEventEnricher> enrichers)
+		{
+			return _sourceLogger != null ? _sourceLogger.ForContext(enrichers) : this;
+		}
+
+		/// <summary>
+		/// Create a logger that enriches log events with the specified property.
+		/// </summary>
+		/// <returns>A logger that will enrich log events as specified.</returns>
+		public ILogger ForContext(string propertyName, object value, bool destructureObjects = false)
+		{
+			return _sourceLogger != null ? _sourceLogger.ForContext(propertyName, value, destructureObjects) : this;
+		}
+
+		/// <summary>
+		/// Create a logger that marks log events as being from the specified
+		/// source type.
+		/// </summary>
+		/// <typeparam name="TSource">Type generating log messages in the context.</typeparam>
+		/// <returns>A logger that will enrich log events as specified.</returns>
+		public ILogger ForContext<TSource>()
+		{
+			return _sourceLogger != null ? _sourceLogger.ForContext<TSource>() : this;
+		}
+
+		/// <summary>
+		/// Create a logger that marks log events as being from the specified
+		/// source type.
+		/// </summary>
+		/// <param name="source">Type generating log messages in the context.</param>
+		/// <returns>A logger that will enrich log events as specified.</returns>
+		public ILogger ForContext(Type source)
+		{
+			return _sourceLogger != null ? _sourceLogger.ForContext(source) : this;
+		}
+
+		/// <summary>
+		/// Write an event to the log.
+		/// </summary>
+		/// <param name="logEvent">The event to write.</param>
+		public void Write(LogEvent logEvent)
+		{
+			if(_sourceLogger == null)
+				return;
+
+			_sourceLogger.Write(logEvent);
+		}
+
+		/// <summary>
+		/// Write a log event with the specified level.
+		/// </summary>
+		/// <param name="level">The level of the event.</param>
+		/// <param name="messageTemplate"></param>
+		/// <param name="propertyValues"></param>
+		public void Write(LogEventLevel level, string messageTemplate, params object[] propertyValues)
+		{
+			if (_sourceLogger == null)
+				return;
+
+			_sourceLogger.Write(level, messageTemplate, propertyValues);
+		}
+
+		/// <summary>
+		/// Write a log event with the specified level and associated exception.
+		/// </summary>
+		/// <param name="level">The level of the event.</param>
+		/// <param name="exception">Exception related to the event.</param>
+		/// <param name="messageTemplate">Message template describing the event.</param>
+		/// <param name="propertyValues">Objects positionally formatted into the message template.</param>
+		public void Write(LogEventLevel level, Exception exception, string messageTemplate, params object[] propertyValues)
+		{
+			if (_sourceLogger == null)
+				return;
+
+			_sourceLogger.Write(level, exception, messageTemplate, propertyValues);
+		}
+
+		/// <summary>
+		/// Determine if events at the specified level will be passed through
+		/// to the log sinks.
+		/// </summary>
+		/// <param name="level">Level to check.</param>
+		/// <returns>True if the level is enabled; otherwise, false.</returns>
+		public bool IsEnabled(LogEventLevel level)
+		{
+			return _sourceLogger != null && _sourceLogger.IsEnabled(level);
+		}
+
+		/// <summary>
+		/// Write a log event with the <see cref="LogEventLevel.Verbose"/> level and associated exception.
+		/// </summary>
+		/// <param name="messageTemplate">Message template describing the event.</param>
+		/// <param name="propertyValues">Objects positionally formatted into the message template.</param>
+		/// <example>
+		/// Log.Verbose("Staring into space, wondering if we're alone.");
+		/// </example>
+		public void Verbose(string messageTemplate, params object[] propertyValues)
+		{
+			if (_sourceLogger == null)
+				return;
+
+			_sourceLogger.Verbose(messageTemplate, propertyValues);
+		}
+
+		/// <summary>
+		/// Write a log event with the <see cref="LogEventLevel.Verbose"/> level and associated exception.
+		/// </summary>
+		/// <param name="exception">Exception related to the event.</param>
+		/// <param name="messageTemplate">Message template describing the event.</param>
+		/// <param name="propertyValues">Objects positionally formatted into the message template.</param>
+		/// <example>
+		/// Log.Verbose(ex, "Staring into space, wondering where this comet came from.");
+		/// </example>
+		public void Verbose(Exception exception, string messageTemplate, params object[] propertyValues)
+		{
+			if (_sourceLogger == null)
+				return;
+
+			_sourceLogger.Verbose(exception, messageTemplate, propertyValues);
+		}
+
+		/// <summary>
+		/// Write a log event with the <see cref="LogEventLevel.Debug"/> level and associated exception.
+		/// </summary>
+		/// <param name="messageTemplate">Message template describing the event.</param>
+		/// <param name="propertyValues">Objects positionally formatted into the message template.</param>
+		/// <example>
+		/// Log.Debug("Starting up at {StartedAt}.", DateTime.Now);
+		/// </example>
+		public void Debug(string messageTemplate, params object[] propertyValues)
+		{
+			if (_sourceLogger == null)
+				return;
+
+			_sourceLogger.Debug(messageTemplate, propertyValues);
+		}
+
+		/// <summary>
+		/// Write a log event with the <see cref="LogEventLevel.Debug"/> level and associated exception.
+		/// </summary>
+		/// <param name="exception">Exception related to the event.</param>
+		/// <param name="messageTemplate">Message template describing the event.</param>
+		/// <param name="propertyValues">Objects positionally formatted into the message template.</param>
+		/// <example>
+		/// Log.Debug(ex, "Swallowing a mundane exception.");
+		/// </example>
+		public void Debug(Exception exception, string messageTemplate, params object[] propertyValues)
+		{
+			if (_sourceLogger == null)
+				return;
+
+			_sourceLogger.Debug(exception, messageTemplate, propertyValues);
+		}
+
+		/// <summary>
+		/// Write a log event with the <see cref="LogEventLevel.Information"/> level and associated exception.
+		/// </summary>
+		/// <param name="messageTemplate">Message template describing the event.</param>
+		/// <param name="propertyValues">Objects positionally formatted into the message template.</param>
+		/// <example>
+		/// Log.Information("Processed {RecordCount} records in {TimeMS}.", records.Length, sw.ElapsedMilliseconds);
+		/// </example>
+		public void Information(string messageTemplate, params object[] propertyValues)
+		{
+			if (_sourceLogger == null)
+				return;
+
+			_sourceLogger.Information(messageTemplate, propertyValues);
+		}
+
+		/// <summary>
+		/// Write a log event with the <see cref="LogEventLevel.Information"/> level and associated exception.
+		/// </summary>
+		/// <param name="exception">Exception related to the event.</param>
+		/// <param name="messageTemplate">Message template describing the event.</param>
+		/// <param name="propertyValues">Objects positionally formatted into the message template.</param>
+		/// <example>
+		/// Log.Information(ex, "Processed {RecordCount} records in {TimeMS}.", records.Length, sw.ElapsedMilliseconds);
+		/// </example>
+		public void Information(Exception exception, string messageTemplate, params object[] propertyValues)
+		{
+			if (_sourceLogger == null)
+				return;
+
+			_sourceLogger.Information(exception, messageTemplate, propertyValues);
+		}
+
+		/// <summary>
+		/// Write a log event with the <see cref="LogEventLevel.Warning"/> level and associated exception.
+		/// </summary>
+		/// <param name="messageTemplate">Message template describing the event.</param>
+		/// <param name="propertyValues">Objects positionally formatted into the message template.</param>
+		/// <example>
+		/// Log.Warning("Skipped {SkipCount} records.", skippedRecords.Length);
+		/// </example>
+		public void Warning(string messageTemplate, params object[] propertyValues)
+		{
+			if (_sourceLogger == null)
+				return;
+
+			_sourceLogger.Warning(messageTemplate, propertyValues);
+		}
+
+		/// <summary>
+		/// Write a log event with the <see cref="LogEventLevel.Warning"/> level and associated exception.
+		/// </summary>
+		/// <param name="exception">Exception related to the event.</param>
+		/// <param name="messageTemplate">Message template describing the event.</param>
+		/// <param name="propertyValues">Objects positionally formatted into the message template.</param>
+		/// <example>
+		/// Log.Warning(ex, "Skipped {SkipCount} records.", skippedRecords.Length);
+		/// </example>
+		public void Warning(Exception exception, string messageTemplate, params object[] propertyValues)
+		{
+			if (_sourceLogger == null)
+				return;
+
+			_sourceLogger.Warning(exception, messageTemplate, propertyValues);
+		}
+
+		/// <summary>
+		/// Write a log event with the <see cref="LogEventLevel.Error"/> level and associated exception.
+		/// </summary>
+		/// <param name="messageTemplate">Message template describing the event.</param>
+		/// <param name="propertyValues">Objects positionally formatted into the message template.</param>
+		/// <example>
+		/// Log.Error("Failed {ErrorCount} records.", brokenRecords.Length);
+		/// </example>
+		public void Error(string messageTemplate, params object[] propertyValues)
+		{
+			if (_sourceLogger == null)
+				return;
+
+			_sourceLogger.Error(messageTemplate, propertyValues);
+		}
+
+		/// <summary>
+		/// Write a log event with the <see cref="LogEventLevel.Error"/> level and associated exception.
+		/// </summary>
+		/// <param name="exception">Exception related to the event.</param>
+		/// <param name="messageTemplate">Message template describing the event.</param>
+		/// <param name="propertyValues">Objects positionally formatted into the message template.</param>
+		/// <example>
+		/// Log.Error(ex, "Failed {ErrorCount} records.", brokenRecords.Length);
+		/// </example>
+		public void Error(Exception exception, string messageTemplate, params object[] propertyValues)
+		{
+			if (_sourceLogger == null)
+				return;
+
+			_sourceLogger.Error(exception, messageTemplate, propertyValues);
+		}
+
+		/// <summary>
+		/// Write a log event with the <see cref="LogEventLevel.Fatal"/> level and associated exception.
+		/// </summary>
+		/// <param name="messageTemplate">Message template describing the event.</param>
+		/// <param name="propertyValues">Objects positionally formatted into the message template.</param>
+		/// <example>
+		/// Log.Fatal("Process terminating.");
+		/// </example>
+		public void Fatal(string messageTemplate, params object[] propertyValues)
+		{
+			if (_sourceLogger == null)
+				return;
+
+			_sourceLogger.Fatal(messageTemplate, propertyValues);
+		}
+
+		/// <summary>
+		/// Write a log event with the <see cref="LogEventLevel.Fatal"/> level and associated exception.
+		/// </summary>
+		/// <param name="exception">Exception related to the event.</param>
+		/// <param name="messageTemplate">Message template describing the event.</param>
+		/// <param name="propertyValues">Objects positionally formatted into the message template.</param>
+		/// <example>
+		/// Log.Fatal(ex, "Process terminating.");
+		/// </example>
+		public void Fatal(Exception exception, string messageTemplate, params object[] propertyValues)
+		{
+			if (_sourceLogger == null)
+				return;
+
+			_sourceLogger.Fatal(exception, messageTemplate, propertyValues);
+		}
+
+		/// <summary>
+		///		This method is called when initializing the <see cref="EventSource"/> and allows
+		///		to override the default logger configuration in order to provide custom
+		///		filters, sinks and enrichers for the event source
+		/// </summary>
+		protected virtual void OnBuildUp(LoggerConfiguration configuration)
+		{
+			
+		}
+
+	}
+}

--- a/test/Serilog.Tests/Serilog.Tests-net40.csproj
+++ b/test/Serilog.Tests/Serilog.Tests-net40.csproj
@@ -79,6 +79,7 @@
     <Compile Include="Sinks\RollingFile\RollingFileSinkTests.cs" />
     <Compile Include="Sinks\RollingFile\TemplatedPathRollerTests.cs" />
     <Compile Include="Sinks\TextWriter\TextWriterSinkTests.cs" />
+    <Compile Include="Sources\EventSourceTests.cs" />
     <Compile Include="Support\CollectingSink.cs" />
     <Compile Include="Support\DelegatingEnricher.cs" />
     <Compile Include="Support\DelegatingSink.cs" />

--- a/test/Serilog.Tests/Serilog.Tests.csproj
+++ b/test/Serilog.Tests/Serilog.Tests.csproj
@@ -101,6 +101,7 @@
     <Compile Include="Sinks\RollingFile\RollingFileSinkTests.cs" />
     <Compile Include="Sinks\RollingFile\TemplatedPathRollerTests.cs" />
     <Compile Include="Sinks\TextWriter\TextWriterSinkTests.cs" />
+    <Compile Include="Sources\EventSourceTests.cs" />
     <Compile Include="Support\CollectingSink.cs" />
     <Compile Include="Support\DelegatingEnricher.cs" />
     <Compile Include="Support\DelegatingSink.cs" />

--- a/test/Serilog.Tests/Sources/EventSourceTests.cs
+++ b/test/Serilog.Tests/Sources/EventSourceTests.cs
@@ -1,0 +1,16 @@
+﻿using NUnit.Framework;
+
+namespace Serilog.Tests.Sources
+{
+
+	[TestFixture]
+	public class EventSourceTests
+	{
+
+		// no meaningful tests yet. Potential test fixtures valid for an
+		// logging event source are already convered by logger tests
+		// since the event source is currently just an adapter :)
+
+	}
+
+}


### PR DESCRIPTION
One of the big 'strenghts' of semantic/structured logging frameworks such as SLAB is the ability to create predefined event sources for the different business units or stages of an application. With event sources, log outputs can easily be unified by providing strongly typed log invocation methods rather than ambigious log messages written under the developers current discretion. The current PR contains event sources implemented as simple adapters for an underlying logging instance (since this is just a concept). They could easily be extended to true semantic sources like in SLAB :smiley:

Would this be an useful feature for Serilog?