### PR TITLE
use silent logger when creating a logger and there are no sinks in the configuration

### DIFF
--- a/src/Serilog/LoggerConfiguration.cs
+++ b/src/Serilog/LoggerConfiguration.cs
@@ -130,6 +130,9 @@ namespace Serilog
                     disposable.Dispose();
             };
 
+            if (!_logEventSinks.Any())
+                return new SilentLogger();
+
             var sink = new SafeAggregateSink(_logEventSinks);
             
             if (_filters.Any())

--- a/src/Serilog/LoggerConfiguration.cs
+++ b/src/Serilog/LoggerConfiguration.cs
@@ -124,14 +124,14 @@ namespace Serilog
         /// disposed.</remarks>
         public ILogger CreateLogger()
         {
+            if (!_logEventSinks.Any())
+                return new SilentLogger();
+
             Action dispose = () =>
             {
                 foreach (var disposable in _logEventSinks.OfType<IDisposable>())
                     disposable.Dispose();
             };
-
-            if (!_logEventSinks.Any())
-                return new SilentLogger();
 
             var sink = new SafeAggregateSink(_logEventSinks);
             

--- a/test/Serilog.Tests/Core/LoggerTests.cs
+++ b/test/Serilog.Tests/Core/LoggerTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.IO;
 using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
@@ -17,6 +18,7 @@ namespace Serilog.Tests.Core
             var thrown = false;
 
             var l = new LoggerConfiguration()
+                .WriteTo.TextWriter(new StringWriter())
                 .Enrich.With(new DelegatingEnricher((le, pf) => {
                     thrown = true;
                     throw new Exception("No go, pal."); }))

--- a/test/Serilog.Tests/LoggerConfigurationTests.cs
+++ b/test/Serilog.Tests/LoggerConfigurationTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.IO;
 using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
@@ -148,6 +149,7 @@ namespace Serilog.Tests
             var enrichedPropertySeen = false;
 
             var logger = new LoggerConfiguration()
+                .WriteTo.TextWriter(new StringWriter())
                 .Enrich.With(new DelegatingEnricher((e, f) => e.AddPropertyIfAbsent(property)))
                 .Enrich.With(new DelegatingEnricher((e, f) => enrichedPropertySeen = e.Properties.ContainsKey(property.Name)))
                 .CreateLogger();
@@ -173,6 +175,13 @@ namespace Serilog.Tests
 
             Assert.That(xs, Is.StringContaining("C"));
             Assert.That(xs, Is.Not.StringContaining("D"));
+        }
+
+        [Test]
+        public void AnUnconfiguredLoggerShouldBeTheNullLogger()
+        {
+            var actual = new LoggerConfiguration().CreateLogger();
+            Assert.That(actual.GetType().Name, Is.EqualTo("SilentLogger"));
         }
     }
 }


### PR DESCRIPTION
Fixes #560 

I could not find the `NullLogger` mentioned in the issue, but I figured the `SilentLogger` was the one to use instead.