### PR TITLE
Add EnvironmentUserNameEnricher + unit test

### DIFF
--- a/src/Serilog.FullNetFx/Enrichers/EnvironmentUserNameEnricher.cs
+++ b/src/Serilog.FullNetFx/Enrichers/EnvironmentUserNameEnricher.cs
@@ -1,0 +1,58 @@
+﻿// Copyright 2013-2015 Serilog Contributors
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using Serilog.Core;
+using Serilog.Events;
+
+namespace Serilog.Enrichers
+{
+    /// <summary>
+    /// Enriches log events with an EnvironmentUserName property containing [<see cref="Environment.UserDomainName"/>\]<see cref="Environment.UserName"/>.
+    /// </summary>
+    public class EnvironmentUserNameEnricher : ILogEventEnricher
+    {
+        LogEventProperty _cachedProperty;
+
+        /// <summary>
+        /// The property name added to enriched log events.
+        /// </summary>
+        public const string EnvironmentUserNamePropertyName = "EnvironmentUserName";
+
+        /// <summary>
+        /// Enrich the log event.
+        /// </summary>
+        /// <param name="logEvent">The log event to enrich.</param>
+        /// <param name="propertyFactory">Factory for creating new properties to add to the event.</param>
+        public void Enrich(LogEvent logEvent, ILogEventPropertyFactory propertyFactory)
+        {
+            _cachedProperty = _cachedProperty ?? propertyFactory.CreateProperty(EnvironmentUserNamePropertyName, GetEnvironmentUserName());
+            logEvent.AddPropertyIfAbsent(_cachedProperty);
+        }
+
+        private static string GetEnvironmentUserName()
+        {
+#if !ASPNETCORE50
+            var userDomainName = Environment.UserDomainName;
+            var userName = Environment.UserName;
+#else
+            var userDomainName = Environment.GetEnvironmentVariable("USERNAME");
+            var userName = Environment.GetEnvironmentVariable("USERDOMAIN");
+#endif
+            return !string.IsNullOrWhiteSpace(userDomainName)
+                ? string.Format(@"{0}\{1}", userDomainName, userName)
+                : userName;
+        }
+    }
+}

--- a/src/Serilog.FullNetFx/LoggerConfigurationFullNetFxExtensions.cs
+++ b/src/Serilog.FullNetFx/LoggerConfigurationFullNetFxExtensions.cs
@@ -259,6 +259,18 @@ namespace Serilog
         }
 
         /// <summary>
+        /// Enriches log events with an EnvironmentUserName property containing [<see cref="Environment.UserDomainName"/>\]<see cref="Environment.UserName"/>.
+        /// </summary>
+        /// <param name="enrichmentConfiguration">Logger enrichment configuration.</param>
+        /// <returns>Configuration object allowing method chaining.</returns>
+        public static LoggerConfiguration WithEnvironmentUserName(
+           this LoggerEnrichmentConfiguration enrichmentConfiguration)
+        {
+            if (enrichmentConfiguration == null) throw new ArgumentNullException("enrichmentConfiguration");
+            return enrichmentConfiguration.With<EnvironmentUserNameEnricher>();
+        }
+
+        /// <summary>
         /// Reads the &lt;appSettings&gt; element of App.config or Web.config, searching for for keys
         /// that look like: <code>serilog:*</code>, which are used to configure
         /// the logger. To add a sink, use a key like <code>serilog:write-to:File.path</code> for

--- a/src/Serilog.FullNetFx/Serilog.FullNetFx.csproj
+++ b/src/Serilog.FullNetFx/Serilog.FullNetFx.csproj
@@ -48,6 +48,7 @@
   <ItemGroup>
     <Compile Include="Context\ImmutableStack.cs" />
     <Compile Include="Enrichers\LogContextEnricher.cs" />
+    <Compile Include="Enrichers\EnvironmentUserNameEnricher.cs" />
     <Compile Include="Enrichers\ProcessIdEnricher.cs" />
     <Compile Include="Enrichers\MachineNameEnricher.cs" />
     <Compile Include="Enrichers\ThreadIdEnricher.cs" />

--- a/test/Serilog.Tests/Enrichers/EnvironmentUserNameEnricherTests.cs
+++ b/test/Serilog.Tests/Enrichers/EnvironmentUserNameEnricherTests.cs
@@ -1,0 +1,25 @@
+﻿using NUnit.Framework;
+using Serilog.Events;
+using Serilog.Tests.Support;
+
+namespace Serilog.Tests.Enrichers
+{
+    [TestFixture]
+    public class EnvironmentUserNameEnricherTests
+    {
+        [Test]
+        public void EnvironmentUserNameEnricherIsApplied()
+        {
+            LogEvent evt = null;
+            var log = new LoggerConfiguration()
+                .Enrich.WithEnvironmentUserName()
+                .WriteTo.Sink(new DelegatingSink(e => evt = e))
+                .CreateLogger();
+
+            log.Information(@"Has an EnvironmentUserName property with [domain\]userName");
+
+            Assert.IsNotNull(evt);
+            Assert.IsNotNullOrEmpty((string)evt.Properties["EnvironmentUserName"].LiteralValue());
+        }
+    }
+}

--- a/test/Serilog.Tests/Serilog.Tests.csproj
+++ b/test/Serilog.Tests/Serilog.Tests.csproj
@@ -84,6 +84,7 @@
     <Compile Include="Core\LoggerTests.cs" />
     <Compile Include="Core\SafeAggregateSinkTests.cs" />
     <Compile Include="Core\MessageTemplateTests.cs" />
+    <Compile Include="Enrichers\EnvironmentUserNameEnricherTests.cs" />
     <Compile Include="Events\DictionaryValueTests.cs" />
     <Compile Include="Events\LogEventPropertyValueTests.cs" />
     <Compile Include="Filters\MatchingTests.cs" />


### PR DESCRIPTION
This PR adds an enricher that is similar to the `MachineNameEnricher`, except that it adds the name of the current user running the application, including the domain name if available.