### PR TITLE
LoggerConfiguration.CreateLogger() now throws if called more than once

### DIFF
--- a/src/Serilog/LoggerConfiguration.cs
+++ b/src/Serilog/LoggerConfiguration.cs
@@ -38,6 +38,7 @@ namespace Serilog
         LogEventLevel _minimumLevel = LogEventLevel.Information;
         LoggingLevelSwitch _levelSwitch;
         int _maximumDestructuringDepth = 10;
+        bool _loggerCreated;
 
         /// <summary>
         /// Configures the sinks that log events will be emitted to.
@@ -124,6 +125,10 @@ namespace Serilog
         /// disposed.</remarks>
         public ILogger CreateLogger()
         {
+            if (_loggerCreated)
+                throw new InvalidOperationException($"CreateLogger was previously called and can only be called once.");
+            _loggerCreated = true;
+
             if (!_logEventSinks.Any())
                 return new SilentLogger();
 

--- a/test/Serilog.Tests/LoggerConfigurationTests.cs
+++ b/test/Serilog.Tests/LoggerConfigurationTests.cs
@@ -26,6 +26,14 @@ namespace Serilog.Tests
         }
 
         [Test]
+        public void CreateLoggerThrowsIfCalledMoreThanOnce()
+        {
+            var loggerConfiguration = new LoggerConfiguration();
+            loggerConfiguration.CreateLogger();
+            Assert.Throws<InvalidOperationException>(() => loggerConfiguration.CreateLogger());
+        }
+
+        [Test]
         public void DisposableSinksAreDisposedAlongWithRootLogger()
         {
             var sink = new DisposableSink();


### PR DESCRIPTION
Might be the smallest PR I've ever written. Resolves #561.

