### PR TITLE
Attempt to fix intermittent hang during CoreCLR test runs

### DIFF
--- a/src/Serilog/Sinks/PeriodicBatching/PortableTimer.cs
+++ b/src/Serilog/Sinks/PeriodicBatching/PortableTimer.cs
@@ -65,7 +65,8 @@ namespace Serilog.Sinks.PeriodicBatching
 
             try
             {
-                await Task.Delay(interval, _cancel.Token).ConfigureAwait(false);
+                if (interval > TimeSpan.Zero)
+                    await Task.Delay(interval, _cancel.Token).ConfigureAwait(false);
 
                 _state = PortableTimerState.Active;
 


### PR DESCRIPTION
`Task.Wait()` in this instance may cause marshalling back onto the originating synchronisation context, leading to a deadlock. If this successfully resolves the intermittent test failure we should consider moving this change back to 1.5 as well.

See also: http://stackoverflow.com/questions/28305968/use-task-run-in-synchronous-method-to-avoid-deadlock-waiting-on-async-method

CC @merbla @khellang 