### PR TITLE
Replaced Profile259 with dotnet5.1

### DIFF
--- a/src/Serilog/Context/ImmutableStack.cs
+++ b/src/Serilog/Context/ImmutableStack.cs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if !PROFILE259 && !DOTNET5_4
+#if LOGCONTEXT
 using System;
 using System.Collections.Generic;
 using System.Runtime.Serialization;

--- a/src/Serilog/Context/LogContext.cs
+++ b/src/Serilog/Context/LogContext.cs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if !PROFILE259 && !DOTNET5_4
+#if LOGCONTEXT
 using System;
 using System.Runtime.Remoting.Messaging;
 using Serilog.Core;

--- a/src/Serilog/Enrichers/EnvironmentUserNameEnricher.cs
+++ b/src/Serilog/Enrichers/EnvironmentUserNameEnricher.cs
@@ -1,18 +1,18 @@
 ﻿// Copyright 2013-2015 Serilog Contributors
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if !PROFILE259
+#if !DOTNET5_1
 
 using System;
 using Serilog.Core;

--- a/src/Serilog/Enrichers/LogContextEnricher.cs
+++ b/src/Serilog/Enrichers/LogContextEnricher.cs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if !PROFILE259 && !DOTNET5_4
+#if LOGCONTEXT
 using Serilog.Context;
 using Serilog.Core;
 using Serilog.Events;

--- a/src/Serilog/Enrichers/MachineNameEnricher.cs
+++ b/src/Serilog/Enrichers/MachineNameEnricher.cs
@@ -1,22 +1,23 @@
 ﻿// Copyright 2013-2015 Serilog Contributors
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#if !DOTNET5_1
+
 using System;
 using Serilog.Core;
 using Serilog.Events;
 
-#if !PROFILE259
 namespace Serilog.Enrichers
 {
     /// <summary>

--- a/src/Serilog/Enrichers/ProcessIdEnricher.cs
+++ b/src/Serilog/Enrichers/ProcessIdEnricher.cs
@@ -12,10 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#if PROCESS
+
 using Serilog.Core;
 using Serilog.Events;
 
-#if !PROFILE259
 namespace Serilog.Enrichers
 {
     /// <summary>

--- a/src/Serilog/Enrichers/ThreadIdEnricher.cs
+++ b/src/Serilog/Enrichers/ThreadIdEnricher.cs
@@ -16,7 +16,6 @@ using System.Threading;
 using Serilog.Core;
 using Serilog.Events;
 
-#if !PROFILE259
 namespace Serilog.Enrichers
 {
     /// <summary>
@@ -40,4 +39,3 @@ namespace Serilog.Enrichers
         }
     }
 }
-#endif

--- a/src/Serilog/LoggerConfigurationFullNetFxExtensions.cs
+++ b/src/Serilog/LoggerConfigurationFullNetFxExtensions.cs
@@ -1,22 +1,19 @@
 ﻿// Copyright 2013-2015 Serilog Contributors
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if !PROFILE259
 using System;
 using System.ComponentModel;
-using System.Diagnostics;
-using System.Threading;
 using Serilog.Configuration;
 using Serilog.Core;
 using Serilog.Debugging;
@@ -25,18 +22,25 @@ using Serilog.Events;
 using Serilog.Formatting.Display;
 using Serilog.Formatting.Raw;
 using Serilog.Sinks.DiagnosticTrace;
-using Serilog.Sinks.IOFile;
-using Serilog.Sinks.RollingFile;
 using Serilog.Sinks.SystemConsole;
 
-#if !DOTNET5_4
+#if PROCESS
+using System.Diagnostics;
+#endif
+
+#if FILE_IO
+using Serilog.Sinks.IOFile;
+using Serilog.Sinks.RollingFile;
+#endif
+
+#if APPSETTINGS
 using Serilog.Settings.AppSettings;
 #endif
 
 namespace Serilog
 {
     /// <summary>
-    /// Extends <see cref="LoggerConfiguration"/> to add Full .NET Framework 
+    /// Extends <see cref="LoggerConfiguration"/> to add Full .NET Framework
     /// capabilities.
     /// </summary>
     public static class LoggerConfigurationFullNetFxExtensions
@@ -96,6 +100,7 @@ namespace Serilog
             return sinkConfiguration.Sink(new ColoredConsoleSink(outputTemplate, formatProvider), restrictedToMinimumLevel, levelSwitch);
         }
 
+#if FILE_IO
         /// <summary>
         /// Write log events in a simple text dump format to the specified file.
         /// </summary>
@@ -143,7 +148,7 @@ namespace Serilog
             if (sinkConfiguration == null) throw new ArgumentNullException(nameof(sinkConfiguration));
             if (outputTemplate == null) throw new ArgumentNullException(nameof(outputTemplate));
             var formatter = new MessageTemplateTextFormatter(outputTemplate, formatProvider);
-            
+
             FileSink sink;
             try
             {
@@ -200,6 +205,7 @@ namespace Serilog
             var sink = new RollingFileSink(pathFormat, formatter, fileSizeLimitBytes, retainedFileCountLimit);
             return sinkConfiguration.Sink(sink, restrictedToMinimumLevel, levelSwitch);
         }
+#endif
 
         /// <summary>
         /// Write log events to the <see cref="System.Diagnostics.Trace"/>.
@@ -226,7 +232,7 @@ namespace Serilog
             return sinkConfiguration.Sink(new DiagnosticTraceSink(formatter), restrictedToMinimumLevel, levelSwitch);
         }
 
-#if !DOTNET5_4
+#if LOGCONTEXT
         /// <summary>
         /// Enrich log events with properties from <see cref="Context.LogContext"/>.
         /// </summary>
@@ -254,6 +260,7 @@ namespace Serilog
             return enrichmentConfiguration.With<ThreadIdEnricher>();
         }
 
+#if PROCESS
         /// <summary>
         /// Enrich log events with a ProcessId property containing the current <see cref="Process.Id"/>.
         /// </summary>
@@ -265,7 +272,9 @@ namespace Serilog
             if (enrichmentConfiguration == null) throw new ArgumentNullException(nameof(enrichmentConfiguration));
             return enrichmentConfiguration.With<ProcessIdEnricher>();
         }
+#endif
 
+#if !DOTNET5_1
         /// <summary>
         /// Enrich log events with a MachineName property containing the current <see cref="Environment.MachineName"/>.
         /// </summary>
@@ -289,14 +298,15 @@ namespace Serilog
             if (enrichmentConfiguration == null) throw new ArgumentNullException(nameof(enrichmentConfiguration));
             return enrichmentConfiguration.With<EnvironmentUserNameEnricher>();
         }
+#endif
 
-#if !DOTNET5_4
+#if APPSETTINGS
         /// <summary>
         /// Reads the &lt;appSettings&gt; element of App.config or Web.config, searching for for keys
         /// that look like: <code>serilog:*</code>, which are used to configure
         /// the logger. To add a sink, use a key like <code>serilog:write-to:File.path</code> for
         /// each parameter to the sink's configuration method. To add an additional assembly
-        /// containing sinks, use <code>serilog:using</code>. To set the level use 
+        /// containing sinks, use <code>serilog:using</code>. To set the level use
         /// <code>serilog:minimum-level</code>.
         /// </summary>
         /// <param name="settingConfiguration">Logger setting configuration.</param>
@@ -320,4 +330,3 @@ namespace Serilog
 #endif
     }
 }
-#endif

--- a/src/Serilog/Properties/InternalsVisibleTo.cs
+++ b/src/Serilog/Properties/InternalsVisibleTo.cs
@@ -1,6 +1,6 @@
 ﻿using System.Runtime.CompilerServices;
 
-#if DOTNET5_4
+#if DOTNET5_4 || DOTNET5_1
 [assembly: InternalsVisibleTo("Serilog.Tests")]
 #else
 [assembly: InternalsVisibleTo("Serilog.Tests, PublicKey=" +

--- a/src/Serilog/Serilog.xproj
+++ b/src/Serilog/Serilog.xproj
@@ -21,4 +21,9 @@
     <ProduceOutputsOnBuild>True</ProduceOutputsOnBuild>
   </PropertyGroup>
   <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.targets" Condition="'$(VSToolsPath)' != ''" />
+  <ProjectExtensions>
+    <VisualStudio>
+      <UserProperties project_1json__JSONSchema="http://json.schemastore.org/project" />
+    </VisualStudio>
+  </ProjectExtensions>
 </Project>

--- a/src/Serilog/Settings/AppSettings/AppSettingsSettings.cs
+++ b/src/Serilog/Settings/AppSettings/AppSettingsSettings.cs
@@ -1,19 +1,18 @@
 ﻿// Copyright 2013-2015 Serilog Contributors
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if !PROFILE259 && !DOTNET5_4
-
+#if APPSETTINGS
 using System;
 using System.Configuration;
 using System.Linq;
@@ -36,7 +35,7 @@ namespace Serilog.Settings.AppSettings
             if (loggerConfiguration == null) throw new ArgumentNullException(nameof(loggerConfiguration));
 
             var settings = ConfigurationManager.AppSettings;
-            
+
             var pairs = settings.AllKeys
                 .Where(k => k.StartsWith(_settingPrefix))
                 .ToDictionary(k => k.Substring(_settingPrefix.Length), k => Environment.ExpandEnvironmentVariables(settings[k]));

--- a/src/Serilog/Settings/KeyValuePairs/KeyValuePairSettings.cs
+++ b/src/Serilog/Settings/KeyValuePairs/KeyValuePairSettings.cs
@@ -166,11 +166,7 @@ namespace Serilog.Settings.KeyValuePairs
                 .Select(t => t.Value)
                 .FirstOrDefault();
 
-#if !PROFILE259
             return convertor == null ? Convert.ChangeType(value, toType) : convertor(value);
-#else
-            return convertor == null ? Convert.ChangeType(value, toType) : convertor(value);
-#endif
         }
 
         internal static IList<MethodInfo> FindSinkConfigurationMethods(IEnumerable<Assembly> configurationAssemblies)

--- a/src/Serilog/Sinks/DiagnosticTrace/DiagnosticTraceSink.cs
+++ b/src/Serilog/Sinks/DiagnosticTrace/DiagnosticTraceSink.cs
@@ -19,7 +19,6 @@ using Serilog.Core;
 using Serilog.Events;
 using Serilog.Formatting;
 
-#if !PROFILE259
 namespace Serilog.Sinks.DiagnosticTrace
 {
     class DiagnosticTraceSink : ILogEventSink
@@ -51,4 +50,3 @@ namespace Serilog.Sinks.DiagnosticTrace
         }
     }
 }
-#endif

--- a/src/Serilog/Sinks/IOFile/CharacterCountLimitedTextWriter.cs
+++ b/src/Serilog/Sinks/IOFile/CharacterCountLimitedTextWriter.cs
@@ -12,12 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#if FILE_IO
+
 using System;
 using System.IO;
 using System.Text;
 using System.Threading;
 
-#if !PROFILE259
 namespace Serilog.Sinks.IOFile
 {
     sealed class CharacterCountLimitedTextWriter : TextWriter

--- a/src/Serilog/Sinks/IOFile/FileSink.cs
+++ b/src/Serilog/Sinks/IOFile/FileSink.cs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#if FILE_IO
+
 using System;
 using System.IO;
 using System.Text;
@@ -20,7 +22,6 @@ using Serilog.Debugging;
 using Serilog.Events;
 using Serilog.Formatting;
 
-#if !PROFILE259
 namespace Serilog.Sinks.IOFile
 {
     /// <summary>

--- a/src/Serilog/Sinks/IOFile/NullSink.cs
+++ b/src/Serilog/Sinks/IOFile/NullSink.cs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#if FILE_IO
+
 using Serilog.Core;
 using Serilog.Events;
 
@@ -28,3 +30,4 @@ namespace Serilog.Sinks.IOFile
         }
     }
 }
+#endif

--- a/src/Serilog/Sinks/PeriodicBatching/BatchedConnectionStatus.cs
+++ b/src/Serilog/Sinks/PeriodicBatching/BatchedConnectionStatus.cs
@@ -1,20 +1,21 @@
 ﻿// Copyright 2013-2015 Serilog Contributors
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#if PERIODIC_BATCHING
+
 using System;
 
-#if !PROFILE259
 namespace Serilog.Sinks.PeriodicBatching
 {
     /// <summary>

--- a/src/Serilog/Sinks/PeriodicBatching/PortableTimer.cs
+++ b/src/Serilog/Sinks/PeriodicBatching/PortableTimer.cs
@@ -1,18 +1,19 @@
 ﻿// Copyright 2013-2015 Serilog Contributors
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if DOTNET5_4
+#if PERIODIC_BATCHING && NO_TIMER
+
 using Serilog.Debugging;
 using System;
 using System.Threading;

--- a/src/Serilog/Sinks/RollingFile/Clock.cs
+++ b/src/Serilog/Sinks/RollingFile/Clock.cs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#if FILE_IO
+
 using System;
 
 namespace Serilog.Sinks.RollingFile
@@ -36,3 +38,4 @@ namespace Serilog.Sinks.RollingFile
         }
     }
 }
+#endif

--- a/src/Serilog/Sinks/RollingFile/RollingFileSink.cs
+++ b/src/Serilog/Sinks/RollingFile/RollingFileSink.cs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#if FILE_IO
+
 using System;
 using System.IO;
 using System.Linq;
@@ -23,7 +25,6 @@ using Serilog.Events;
 using Serilog.Formatting;
 using Serilog.Sinks.IOFile;
 
-#if !PROFILE259
 namespace Serilog.Sinks.RollingFile
 {
     /// <summary>

--- a/src/Serilog/Sinks/RollingFile/RollingLogFile.cs
+++ b/src/Serilog/Sinks/RollingFile/RollingLogFile.cs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#if FILE_IO
+
 using System;
 
 namespace Serilog.Sinks.RollingFile
@@ -32,3 +34,4 @@ namespace Serilog.Sinks.RollingFile
         public int SequenceNumber { get; }
     }
 }
+#endif

--- a/src/Serilog/Sinks/RollingFile/TemplatedPathRoller.cs
+++ b/src/Serilog/Sinks/RollingFile/TemplatedPathRoller.cs
@@ -12,13 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#if FILE_IO
+
 using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Text.RegularExpressions;
 
-#if !PROFILE259
 namespace Serilog.Sinks.RollingFile
 {
     // Rolls files based on the current date, using a path
@@ -33,7 +34,6 @@ namespace Serilog.Sinks.RollingFile
         const string DefaultSeparator = "-";
 
         readonly string _pathTemplate;
-
         readonly Regex _filenameMatcher;
 
         public TemplatedPathRoller(string pathTemplate)

--- a/src/Serilog/Sinks/SystemConsole/ColoredConsoleSink.cs
+++ b/src/Serilog/Sinks/SystemConsole/ColoredConsoleSink.cs
@@ -26,7 +26,6 @@ using IPropertyDictionary = System.Collections.Generic.IDictionary<string, Seril
 using IPropertyDictionary = System.Collections.Generic.IReadOnlyDictionary<string, Serilog.Events.LogEventPropertyValue>;
 #endif
 
-#if !PROFILE259
 namespace Serilog.Sinks.SystemConsole
 {
     class ColoredConsoleSink : ILogEventSink
@@ -175,4 +174,3 @@ namespace Serilog.Sinks.SystemConsole
         }
     }
 }
-#endif

--- a/src/Serilog/Sinks/SystemConsole/ConsoleSink.cs
+++ b/src/Serilog/Sinks/SystemConsole/ConsoleSink.cs
@@ -18,7 +18,6 @@ using Serilog.Core;
 using Serilog.Events;
 using Serilog.Formatting;
 
-#if !PROFILE259
 namespace Serilog.Sinks.SystemConsole
 {
     class ConsoleSink : ILogEventSink
@@ -40,4 +39,3 @@ namespace Serilog.Sinks.SystemConsole
         }
     }
 }
-#endif

--- a/src/Serilog/project.json
+++ b/src/Serilog/project.json
@@ -26,14 +26,6 @@
                 "System.Configuration": ""
             }
         },
-        "dnx451": {
-            "compilationOptions": {
-                "keyFile": "../../assets/Serilog.snk"
-            },
-            "frameworkAssemblies": {
-                "System.Configuration": ""
-            }
-        },
         ".NETPortable,Version=v4.5,Profile=Profile259": {
             "compilationOptions": {
                 "keyFile": "../../assets/Serilog.snk",

--- a/src/Serilog/project.json
+++ b/src/Serilog/project.json
@@ -26,26 +26,22 @@
                 "System.Configuration": ""
             }
         },
-        ".NETPortable,Version=v4.5,Profile=Profile259": {
+        "dotnet5.1": {
             "compilationOptions": {
-                "keyFile": "../../assets/Serilog.snk",
                 "define": [ "PROFILE259" ]
             },
-            "frameworkAssemblies": {
-                "Microsoft.CSharp": "",
-                "System.Collections": "",
-                "System.Diagnostics.Debug": "",
-                "System.Dynamic.Runtime": "",
-                "System.Globalization": "",
-                "System.IO": "",
-                "System.Linq": "",
-                "System.Reflection": "",
-                "System.Reflection.Extensions": "",
-                "System.Runtime": "",
-                "System.Runtime.Extensions": "",
-                "System.Text.RegularExpressions": "",
-                "System.Threading": "",
-                "System.Threading.Tasks": ""
+            "dependencies": {
+                "Microsoft.CSharp": "4.0.1-beta-23516",
+                "System.Console": "4.0.0-beta-23516",
+                "System.Diagnostics.TraceSource": "4.0.0-beta-23516",
+                "System.Globalization": "4.0.11-beta-23516",
+                "System.IO": "4.0.11-beta-23516",
+                "System.Linq": "4.0.1-beta-23516",
+                "System.Reflection.Extensions": "4.0.1-beta-23516",
+                "System.Runtime.Extensions": "4.0.11-beta-23516",
+                "System.Text.RegularExpressions": "4.0.11-beta-23516",
+                "System.Threading": "4.0.11-beta-23516",
+                "System.Threading.Thread": "4.0.0-beta-23516"
             }
         },
         "dotnet5.4": {
@@ -55,10 +51,14 @@
                 "System.Console": "4.0.0-beta-23516",
                 "System.Diagnostics.Process": "4.1.0-beta-23516",
                 "System.Diagnostics.TraceSource": "4.0.0-beta-23516",
+                "System.Globalization": "4.0.11-beta-23516",
                 "System.IO": "4.0.11-beta-23516",
                 "System.IO.FileSystem": "4.0.1-beta-23516",
                 "System.Linq": "4.0.1-beta-23516",
+                "System.Reflection.Extensions": "4.0.1-beta-23516",
+                "System.Runtime.Extensions": "4.0.11-beta-23516",
                 "System.Text.RegularExpressions": "4.0.11-beta-23516",
+                "System.Threading": "4.0.11-beta-23516",
                 "System.Threading.Thread": "4.0.0-beta-23516"
             }
         }

--- a/src/Serilog/project.json
+++ b/src/Serilog/project.json
@@ -9,7 +9,8 @@
     "frameworks": {
         "net40": {
             "compilationOptions": {
-                "keyFile": "../../assets/Serilog.snk"
+                "keyFile": "../../assets/Serilog.snk",
+                "define": [ "APPSETTINGS", "LOGCONTEXT", "PROCESS", "FILE_IO", "PERIODIC_BATCHING" ]
             },
             "frameworkAssemblies": {
                 "System.Configuration": ""
@@ -20,7 +21,8 @@
         },
         "net45": {
             "compilationOptions": {
-                "keyFile": "../../assets/Serilog.snk"
+                "keyFile": "../../assets/Serilog.snk",
+                "define": [ "APPSETTINGS", "LOGCONTEXT", "PROCESS", "FILE_IO", "PERIODIC_BATCHING" ]
             },
             "frameworkAssemblies": {
                 "System.Configuration": ""
@@ -28,7 +30,7 @@
         },
         "dotnet5.1": {
             "compilationOptions": {
-                "define": [ "PROFILE259" ]
+                "define": [ "NO_APPDOMAIN" ]
             },
             "dependencies": {
                 "Microsoft.CSharp": "4.0.1-beta-23516",
@@ -45,6 +47,9 @@
             }
         },
         "dotnet5.4": {
+            "compilationOptions": {
+                "define": [ "PROCESS", "FILE_IO", "PERIODIC_BATCHING", "NO_TIMER", "NO_APPDOMAIN" ]
+            },
             "dependencies": {
                 "Microsoft.CSharp": "4.0.1-beta-23516",
                 "System.Collections.Concurrent": "4.0.11-beta-23516",

--- a/test/Serilog.Tests/Context/LogContextTests.cs
+++ b/test/Serilog.Tests/Context/LogContextTests.cs
@@ -1,4 +1,4 @@
-﻿#if !DNXCORE50
+﻿#if LOGCONTEXT
 using System;
 using System.IO;
 using System.Runtime.Remoting.Messaging;

--- a/test/Serilog.Tests/Enrichers/EnvironmentUserNameEnricherTests.cs
+++ b/test/Serilog.Tests/Enrichers/EnvironmentUserNameEnricherTests.cs
@@ -1,4 +1,6 @@
-﻿using Serilog.Events;
+﻿#if PROCESS
+
+using Serilog.Events;
 using Serilog.Tests.Support;
 using Xunit;
 
@@ -22,3 +24,4 @@ namespace Serilog.Tests.Enrichers
         }
     }
 }
+#endif

--- a/test/Serilog.Tests/Settings/AppSettingsTests.cs
+++ b/test/Serilog.Tests/Settings/AppSettingsTests.cs
@@ -1,4 +1,4 @@
-﻿#if !DNXCORE50
+﻿#if APPSETTINGS
 using System;
 using System.Configuration;
 using Xunit;

--- a/test/Serilog.Tests/Settings/KeyValuePairSettingsTests.cs
+++ b/test/Serilog.Tests/Settings/KeyValuePairSettingsTests.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Generic;
+﻿#if APPSETTINGS
+
+using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using Xunit;
@@ -98,3 +100,4 @@ namespace Serilog.Tests.AppSettings.Tests
         }
     }
 }
+#endif

--- a/test/Serilog.Tests/Sinks/IOFile/FileSinkTests.cs
+++ b/test/Serilog.Tests/Sinks/IOFile/FileSinkTests.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿#if FILE_IO
+
+using System;
 using System.IO;
 using System.Linq;
 using Xunit;
@@ -86,3 +88,4 @@ namespace Serilog.Tests.Sinks.IOFile
         }
     }
 }
+#endif

--- a/test/Serilog.Tests/Sinks/PeriodicBatching/BatchedConnectionStatusTests.cs
+++ b/test/Serilog.Tests/Sinks/PeriodicBatching/BatchedConnectionStatusTests.cs
@@ -1,4 +1,4 @@
-﻿#if !DNXCORE50
+﻿#if PERIODIC_BATCHING
 using System;
 using Xunit;
 using Serilog.Sinks.PeriodicBatching;

--- a/test/Serilog.Tests/Sinks/RollingFile/RollingFileSinkTests.cs
+++ b/test/Serilog.Tests/Sinks/RollingFile/RollingFileSinkTests.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿#if FILE_IO
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using Xunit;
@@ -111,3 +113,4 @@ namespace Serilog.Tests.Sinks.RollingFile
         }
     }
 }
+#endif

--- a/test/Serilog.Tests/project.json
+++ b/test/Serilog.Tests/project.json
@@ -7,45 +7,25 @@
     "dependencies": {
         "Newtonsoft.Json": "7.0.1",
         "Rx-Main": "2.2.5",
-        "Serilog": "2.0.0-beta-*",
+        "Serilog": { "target": "project" },
         "xunit": "2.1.0",
-        "xunit.runner.visualstudio": "2.1.0"
+        "xunit.runner.visualstudio": "2.1.0",
+        "xunit.runner.dnx": "2.1.0-rc1-build204"
     },
     "frameworks": {
-        "net45": {
-            "compilationOptions": {
-                "keyFile": "../../assets/Serilog.snk"
-            },
-            "frameworkAssemblies": {
-                "System.Configuration": "",
-                "Microsoft.CSharp": "",
-                "System.Collections": "",
-                "System.Diagnostics.Debug": "",
-                "System.Dynamic.Runtime": "",
-                "System.Globalization": "",
-                "System.IO": "",
-                "System.Linq": "",
-                "System.Reflection": "",
-                "System.Reflection.Extensions": "",
-                "System.Runtime": "",
-                "System.Runtime.Extensions": "",
-                "System.Text.RegularExpressions": "",
-                "System.Threading": "",
-                "System.Threading.Tasks": ""
-            }
-        },
         "dnx451": {
             "compilationOptions": {
-                "keyFile": "../../assets/Serilog.snk"
+                "keyFile": "../../assets/Serilog.snk",
+                "define": [ "APPSETTINGS", "LOGCONTEXT", "FILE_IO", "PERIODIC_BATCHING" ]
             },
             "frameworkAssemblies": {
                 "System.Configuration": ""
-            },
-            "dependencies": {
-                "xunit.runner.dnx": "2.1.0-rc1-build204"
             }
         },
         "dnxcore50": {
+            "compilationOptions": {
+                "define": [ "FILE_IO", "PERIODIC_BATCHING" ]
+            },
             "dependencies": {
                 "Microsoft.CSharp": "4.0.1-beta-23516",
                 "System.Collections": "4.0.11-beta-23516",
@@ -60,8 +40,7 @@
                 "System.Text.RegularExpressions": "4.0.11-beta-23516",
                 "System.Threading": "4.0.11-beta-23516",
                 "System.Threading.Thread": "4.0.0-beta-23516",
-                "System.Threading.Timer": "4.0.1-beta-23516",
-                "xunit.runner.dnx": "2.1.0-rc1-build204"
+                "System.Threading.Timer": "4.0.1-beta-23516"
             }
         }
     }


### PR DESCRIPTION
This replaces the old `Profile259` with `dotnet5.1`, which is the way forward.

`dotnet5.1` is the lowest System.Runtime-based TFM, roughly equivalent to `Profile259`, and should support everything back to WP Silverlight 8.0. See the [Standard Platform document](https://github.com/dotnet/corefx/blob/50c66ffcf62be7683a756df14a2dbc75720ae263/Documentation/project-docs/standard-platform.md#mapping-the-net-platform-standard-to-platforms) for more details. BTW, `dotnet5.1` will be `netstandard1.0` (there's an off-by-one error) and that's what it's called in the document.

I also (mostly) moved away from #ifdef'ing on platform and moved to features instead. I think this makes it clearer why things are #ifdef'ed and what should be moved to separate packages. It would be really nice if Serilog core would just be `dotnet5.1` only. The difference is mostly `System.Diagnostics.Process` and `System.IO.FileSystem`, which aren't available until `dotnet5.4`. There's also the whole `AppDomain`/`Timer` stuff in the `PeriodicBatchingSink` :disappointed: 

This should also unlock the following on the `Profile259` platforms:

 - `DiagnosticTraceSink`
 - `ConsoleSink`
 - `ColoredConsoleSink`
 - `ThreadIdEnricher`