### PR TITLE
Added function to detect anonymous types and appropriate tests

### DIFF
--- a/src/Serilog/Platform/TypeInfo-net40.cs
+++ b/src/Serilog/Platform/TypeInfo-net40.cs
@@ -55,6 +55,8 @@ namespace Serilog.Platform
         public IEnumerable<PropertyInfo> DeclaredProperties => Type.GetProperties();
 
         public bool IsAssignableFrom(TypeInfo targetType) => Type.IsAssignableFrom(targetType.Type);
+
+        public bool IsNotPublic => Type.IsNotPublic;
     }
 }
 #endif

--- a/test/Serilog.Tests/Parameters/PropertyValueConverterTests.cs
+++ b/test/Serilog.Tests/Parameters/PropertyValueConverterTests.cs
@@ -232,5 +232,15 @@ namespace Serilog.Tests.Parameters
             var item = pv.Properties.Single();
             Assert.Equal("Item", item.Name);
         }
+
+        [Fact]
+        public void CSharpAnonymousTypesAreRecognizedWhenDestructuring()
+        {
+            var o = new { Foo = "Bar" };
+            var result = _converter.CreatePropertyValue(o, true);
+            Assert.Equal(typeof(StructureValue), result.GetType());
+            var structuredValue = (StructureValue)result;
+            Assert.Equal(null, structuredValue.TypeTag);
+        }
     }
 }


### PR DESCRIPTION
Adressing #618 

I used some of the code pointed in the defect discussion, added a function to detect anonymous types based on the type name and some tests.

I didn't add a proper test for VB - a real test using a anonymous type coming from a VB library - as this is a bit tedious. This could be done with [Roslyn](https://github.com/dotnet/roslyn) though but I don't think it's worth the hassle.

I nevertheless did test the new dll in a console app written in VB and it works.