### PR TITLE
Use round-trippable floating point formatting in JSON

### DIFF
--- a/src/Serilog/Formatting/Json/JsonFormatter.cs
+++ b/src/Serilog/Formatting/Json/JsonFormatter.cs
@@ -91,8 +91,8 @@ namespace Serilog.Formatting.Json
                 { typeof(uint), WriteToString },
                 { typeof(long), WriteToString },
                 { typeof(ulong), WriteToString },
-                { typeof(float), WriteToString },
-                { typeof(double), WriteToString },
+                { typeof(float), (v, q, w) => WriteSingle((float)v, w) },
+                { typeof(double), (v, q, w) => WriteDouble((double)v, w) },
                 { typeof(decimal), WriteToString },
                 { typeof(string), (v, q, w) => WriteString((string)v, w) },
                 { typeof(DateTime), (v, q, w) => WriteDateTime((DateTime)v, w) },
@@ -380,6 +380,16 @@ namespace Serilog.Formatting.Json
         static void WriteBoolean(bool value, TextWriter output)
         {
             output.Write(value ? "true" : "false");
+        }
+
+        static void WriteSingle(float value, TextWriter output)
+        {
+            output.Write(value.ToString("R", CultureInfo.InvariantCulture));
+        }
+
+        static void WriteDouble(double value, TextWriter output)
+        {
+            output.Write(value.ToString("R", CultureInfo.InvariantCulture));
         }
 
         static void WriteOffset(DateTimeOffset value, TextWriter output)

--- a/src/Serilog/Sinks/PeriodicBatching/PeriodicBatchingSink.cs
+++ b/src/Serilog/Sinks/PeriodicBatching/PeriodicBatchingSink.cs
@@ -23,10 +23,6 @@ using Serilog.Debugging;
 using Serilog.Events;
 using System.Threading;
 
-#if !NO_TIMER
-using System.Threading;
-#endif
-
 namespace Serilog.Sinks.PeriodicBatching
 {
     /// <summary>


### PR DESCRIPTION
Use "R" round-trip specifier when formatting floating-point numbers to JSON. Without this specifier, floating point numbers logged as JSON cannot be parsed using the standard `Double` and `Single` parsing in the framework, and break libraries such as JSON.NET that rely on these.

See: http://www.hanselman.com/blog/WhyYouCantDoubleParseDoubleMaxValueToStringOrSystemOverloadExceptionsWhenUsingDoubleParse.aspx

(Fixes https://github.com/continuousit/seq-releases/issues/358)