### PR TITLE
Enable strong naming on CoreCLR builds

### DIFF
--- a/src/Serilog/Properties/InternalsVisibleTo.cs
+++ b/src/Serilog/Properties/InternalsVisibleTo.cs
@@ -1,12 +1,11 @@
-﻿using System.Runtime.CompilerServices;
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
 
-#if DOTNET5_4 || DOTNET5_1
-[assembly: InternalsVisibleTo("Serilog.Tests")]
-#else
+[assembly: AssemblyVersion("2.0.0.0")]
+
 [assembly: InternalsVisibleTo("Serilog.Tests, PublicKey=" +
                               "0024000004800000940000000602000000240000525341310004000001000100fb8d13fd344a1c" +
                               "6fe0fe83ef33c1080bf30690765bc6eb0df26ebfdf8f21670c64265b30db09f73a0dea5b3db4c9" +
                               "d18dbf6d5a25af5ce9016f281014d79dc3b4201ac646c451830fc7e61a2dfd633d34c39f87b818" +
                               "94191652df5ac63cc40c77f3542f702bda692e6e8a9158353df189007a49da0f3cfd55eb250066" +
                               "b19485ec")]
-#endif

--- a/src/Serilog/project.json
+++ b/src/Serilog/project.json
@@ -30,6 +30,7 @@
         },
         "dotnet5.1": {
             "compilationOptions": {
+                "keyFile": "../../assets/Serilog.snk",
                 "define": [ "NO_APPDOMAIN" ]
             },
             "dependencies": {
@@ -48,6 +49,7 @@
         },
         "dotnet5.4": {
             "compilationOptions": {
+                "keyFile": "../../assets/Serilog.snk",
                 "define": [ "PROCESS", "FILE_IO", "PERIODIC_BATCHING", "NO_TIMER", "NO_APPDOMAIN" ]
             },
             "dependencies": {

--- a/test/Serilog.Tests/Core/MessageTemplateTests.cs
+++ b/test/Serilog.Tests/Core/MessageTemplateTests.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿#if INTERNAL_TESTS
+
+using System;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -165,3 +167,5 @@ namespace Serilog.Tests.Core
         }
     }
 }
+
+#endif

--- a/test/Serilog.Tests/Core/SafeAggregateSinkTests.cs
+++ b/test/Serilog.Tests/Core/SafeAggregateSinkTests.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿#if INTERNAL_TESTS
+
+using System;
 using Xunit;
 using Serilog.Core.Sinks;
 using Serilog.Tests.Support;
@@ -39,3 +41,5 @@ namespace Serilog.Tests.Core
         }
     }
 }
+
+#endif

--- a/test/Serilog.Tests/Events/LogEventPropertyValueTests.cs
+++ b/test/Serilog.Tests/Events/LogEventPropertyValueTests.cs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#if INTERNAL_TESTS
+
 using System;
 using System.Globalization;
 using System.Linq;
@@ -75,3 +77,5 @@ namespace Serilog.Tests.Events
         }
     }
 }
+
+#endif

--- a/test/Serilog.Tests/LogTests.cs
+++ b/test/Serilog.Tests/LogTests.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿#if INTERNAL_TESTS
+
+using System;
 using Xunit;
 using Serilog.Core.Pipeline;
 using Serilog.Tests.Support;
@@ -45,3 +47,5 @@ namespace Serilog.Tests
         }
     }
 }
+
+#endif

--- a/test/Serilog.Tests/LoggerConfigurationTests.cs
+++ b/test/Serilog.Tests/LoggerConfigurationTests.cs
@@ -59,6 +59,8 @@ namespace Serilog.Tests
             Assert.False(sink.IsDisposed);
         }
 
+#if INTERNAL_TESTS
+
         [Fact]
         public void AFilterPreventsMatchedEventsFromPassingToTheSink()
         {
@@ -78,7 +80,9 @@ namespace Serilog.Tests
             Assert.True(events.Contains(included));
         }
 
-// ReSharper disable UnusedMember.Local, UnusedAutoPropertyAccessor.Local
+#endif
+
+        // ReSharper disable UnusedMember.Local, UnusedAutoPropertyAccessor.Local
         class AB
         {
             public int A { get; set; }

--- a/test/Serilog.Tests/Parameters/PropertyValueConverterTests.cs
+++ b/test/Serilog.Tests/Parameters/PropertyValueConverterTests.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿#if INTERNAL_TESTS
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Xunit;
@@ -234,3 +236,5 @@ namespace Serilog.Tests.Parameters
         }
     }
 }
+
+#endif

--- a/test/Serilog.Tests/Sinks/PeriodicBatching/BatchedConnectionStatusTests.cs
+++ b/test/Serilog.Tests/Sinks/PeriodicBatching/BatchedConnectionStatusTests.cs
@@ -1,4 +1,4 @@
-﻿#if PERIODIC_BATCHING
+﻿#if PERIODIC_BATCHING && INTERNAL_TESTS
 using System;
 using Xunit;
 using Serilog.Sinks.PeriodicBatching;

--- a/test/Serilog.Tests/Sinks/RollingFile/RollingFileSinkTests.cs
+++ b/test/Serilog.Tests/Sinks/RollingFile/RollingFileSinkTests.cs
@@ -1,4 +1,4 @@
-﻿#if FILE_IO
+﻿#if FILE_IO && INTERNAL_TESTS
 
 using System;
 using System.Collections.Generic;

--- a/test/Serilog.Tests/Sinks/RollingFile/TemplatedPathRollerTests.cs
+++ b/test/Serilog.Tests/Sinks/RollingFile/TemplatedPathRollerTests.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿#if INTERNAL_TESTS
+
+using System;
 using System.IO;
 using System.Linq;
 using Xunit;
@@ -126,3 +128,5 @@ namespace Serilog.Tests.Sinks.RollingFile
         }
     }
 }
+
+#endif

--- a/test/Serilog.Tests/project.json
+++ b/test/Serilog.Tests/project.json
@@ -16,7 +16,7 @@
         "dnx451": {
             "compilationOptions": {
                 "keyFile": "../../assets/Serilog.snk",
-                "define": [ "APPSETTINGS", "LOGCONTEXT", "FILE_IO", "PERIODIC_BATCHING" ]
+                "define": [ "APPSETTINGS", "LOGCONTEXT", "FILE_IO", "PERIODIC_BATCHING", "INTERNAL_TESTS" ]
             },
             "frameworkAssemblies": {
                 "System.Configuration": ""


### PR DESCRIPTION
Excludes tests using internal APIs until we can modify/rewrite them. Need to get this through so that Serilog has only a single binary identity across all targets.

Adds a fixed "AssemblyVersion" of "2.0.0.0" that we can keep constant throughout the 2.x series.

Fixes #589.