### PR TITLE
Less surprising "child logger" level configuration

### DIFF
--- a/src/Serilog/Configuration/LoggerSinkConfiguration.cs
+++ b/src/Serilog/Configuration/LoggerSinkConfiguration.cs
@@ -32,15 +32,18 @@ namespace Serilog.Configuration
     {
         readonly LoggerConfiguration _loggerConfiguration;
         readonly Action<ILogEventSink> _addSink;
+        readonly Action<LoggerConfiguration> _applyInheritedConfiguration;
 
         const string DefaultOutputTemplate = "{Timestamp} [{Level}] {Message}{NewLine}{Exception}";
 
-        internal LoggerSinkConfiguration(LoggerConfiguration loggerConfiguration, Action<ILogEventSink> addSink)
+        internal LoggerSinkConfiguration(LoggerConfiguration loggerConfiguration, Action<ILogEventSink> addSink, Action<LoggerConfiguration> applyInheritedConfiguration)
         {
             if (loggerConfiguration == null) throw new ArgumentNullException(nameof(loggerConfiguration));
             if (addSink == null) throw new ArgumentNullException(nameof(addSink));
+            if (applyInheritedConfiguration == null) throw new ArgumentNullException(nameof(applyInheritedConfiguration));
             _loggerConfiguration = loggerConfiguration;
             _addSink = addSink;
+            _applyInheritedConfiguration = applyInheritedConfiguration;
         }
 
         /// <summary>
@@ -156,8 +159,11 @@ namespace Serilog.Configuration
         {
             if (configureLogger == null) throw new ArgumentNullException(nameof(configureLogger));
             var lc = new LoggerConfiguration();
+
+            _applyInheritedConfiguration(lc);
+
             configureLogger(lc);
-            return Sink(new SecondaryLoggerSink(lc.CreateLogger(), attemptDispose: true), restrictedToMinimumLevel);
+            return Sink(new SecondaryLoggerSink(lc.CreateLogger(), attemptDispose: true), restrictedToMinimumLevel, levelSwitch);
         }
 
         /// <summary>

--- a/src/Serilog/LoggerConfiguration.cs
+++ b/src/Serilog/LoggerConfiguration.cs
@@ -47,7 +47,13 @@ namespace Serilog
         {
             get
             {
-                return new LoggerSinkConfiguration(this, s => _logEventSinks.Add(s));
+                return new LoggerSinkConfiguration(this, s => _logEventSinks.Add(s), child =>
+                {
+                    if (_levelSwitch != null)
+                        child.MinimumLevel.ControlledBy(_levelSwitch);
+                    else
+                        child.MinimumLevel.Is(_minimumLevel);
+                });
             }
         }
 
@@ -62,7 +68,10 @@ namespace Serilog
             get
             {
                 return new LoggerMinimumLevelConfiguration(this,
-                    l => _minimumLevel = l,
+                    l => {
+                        _minimumLevel = l;
+                        _levelSwitch = null;
+                    },
                     sw => _levelSwitch = sw);
             }
         }

--- a/test/Serilog.Tests/Core/SecondaryLoggerSinkTests.cs
+++ b/test/Serilog.Tests/Core/SecondaryLoggerSinkTests.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using Serilog.Tests.Support;
 using Xunit;
+using Serilog.Core;
+using Serilog.Events;
 
 namespace Serilog.Tests.Core
 {
@@ -52,6 +54,39 @@ namespace Serilog.Tests.Core
                 .CreateLogger()).Dispose();
 
             Assert.True(secondary.IsDisposed);
+        }
+
+        [Fact]
+        public void ChildLoggerInheritsParentLevelByDefault()
+        {
+            var sink = new CollectingSink();
+
+            var logger = new LoggerConfiguration()
+                .MinimumLevel.Debug()
+                .WriteTo.Logger(lc => lc
+                    .WriteTo.Sink(sink))
+                .CreateLogger();
+
+            logger.Write(Some.DebugEvent());
+
+            Assert.Equal(1, sink.Events.Count);
+        }
+
+        [Fact]
+        public void ChildLoggerCanOverrideInheritedLevel()
+        {
+            var sink = new CollectingSink();
+
+            var logger = new LoggerConfiguration()
+                .MinimumLevel.ControlledBy(new LoggingLevelSwitch(LogEventLevel.Debug))
+                .WriteTo.Logger(lc => lc
+                    .MinimumLevel.Error()
+                    .WriteTo.Sink(sink))
+                .CreateLogger();
+
+            logger.Write(Some.DebugEvent());
+
+            Assert.Equal(0, sink.Events.Count);
         }
     }
 }

--- a/test/Serilog.Tests/LoggerConfigurationTests.cs
+++ b/test/Serilog.Tests/LoggerConfigurationTests.cs
@@ -247,5 +247,21 @@ namespace Serilog.Tests
             var actual = new LoggerConfiguration().CreateLogger();
             Assert.Equal(actual.GetType().Name, "SilentLogger");
         }
+
+        [Fact]
+        public void LastMinimumLevelConfigurationWins()
+        {
+            var sink = new CollectingSink();
+
+            var logger = new LoggerConfiguration()
+                .MinimumLevel.ControlledBy(new LoggingLevelSwitch(LogEventLevel.Fatal))
+                .MinimumLevel.Debug()
+                .WriteTo.Sink(sink)
+                .CreateLogger();
+
+            logger.Write(Some.InformationEvent());
+
+            Assert.Equal(1, sink.Events.Count);
+        }
     }
 }

--- a/test/Serilog.Tests/Support/Some.cs
+++ b/test/Serilog.Tests/Support/Some.cs
@@ -41,10 +41,20 @@ namespace Serilog.Tests.Support
             return new DateTimeOffset(Instant());
         }
 
+        public static LogEvent LogEvent(DateTimeOffset? timestamp = null, LogEventLevel level = LogEventLevel.Information)
+        {
+            return new LogEvent(timestamp ?? OffsetInstant(), level,
+                null, MessageTemplate(), Enumerable.Empty<LogEventProperty>());
+        }
+
         public static LogEvent InformationEvent(DateTimeOffset? timestamp = null)
         {
-            return new LogEvent(timestamp ?? OffsetInstant(), LogEventLevel.Information,
-                null, MessageTemplate(), Enumerable.Empty<LogEventProperty>());
+            return LogEvent(timestamp, LogEventLevel.Information);
+        }
+
+        public static LogEvent DebugEvent(DateTimeOffset? timestamp = null)
+        {
+            return LogEvent(timestamp, LogEventLevel.Debug);
         }
 
         public static LogEventProperty LogEventProperty()


### PR DESCRIPTION
Found a few rough edges in `WriteTo.Logger()` - fixes:

 - When using `WriteTo.Logger(lc => ...)` the sub-logger inherits the level configured on the parent
 - Last-in always wins when setting minimum levels even when switching between `LoggingLevelSwitch` and basic level config
 - `WriteTo.Logger` no longer ignores the passed-in level switch argument if present (consistent with other sinks)