### PR TITLE
Adding buffered boolean param to FileSink and RollingFileSink

### DIFF
--- a/src/Serilog.Sinks.File/FileLoggerConfigurationExtensions.cs
+++ b/src/Serilog.Sinks.File/FileLoggerConfigurationExtensions.cs
@@ -41,6 +41,8 @@ namespace Serilog
         /// the default is "{Timestamp} [{Level}] {Message}{NewLine}{Exception}".</param>
         /// <param name="fileSizeLimitBytes">The maximum size, in bytes, to which a log file will be allowed to grow.
         /// For unrestricted growth, pass null. The default is 1 GB.</param>
+        /// <param name="buffered">Indicates if flushing to the output file can be buffered or not. The default
+        /// is false.</param>
         /// <returns>Configuration object allowing method chaining.</returns>
         /// <remarks>The file will be written using the UTF-8 character set.</remarks>
         public static LoggerConfiguration File(
@@ -50,7 +52,8 @@ namespace Serilog
             string outputTemplate = DefaultOutputTemplate,
             IFormatProvider formatProvider = null,
             long? fileSizeLimitBytes = DefaultFileSizeLimitBytes,
-            LoggingLevelSwitch levelSwitch = null)
+            LoggingLevelSwitch levelSwitch = null,
+            bool buffered = false)
         {
             if (sinkConfiguration == null) throw new ArgumentNullException(nameof(sinkConfiguration));
             if (outputTemplate == null) throw new ArgumentNullException(nameof(outputTemplate));
@@ -59,7 +62,7 @@ namespace Serilog
             FileSink sink;
             try
             {
-                sink = new FileSink(path, formatter, fileSizeLimitBytes);
+                sink = new FileSink(path, formatter, fileSizeLimitBytes, buffered: buffered);
             }
             catch (ArgumentException)
             {

--- a/src/Serilog.Sinks.RollingFile/RollingFileLoggerConfigurationExtensions.cs
+++ b/src/Serilog.Sinks.RollingFile/RollingFileLoggerConfigurationExtensions.cs
@@ -46,6 +46,8 @@ namespace Serilog.Sinks.RollingFile
         /// For unrestricted growth, pass null. The default is 1 GB.</param>
         /// <param name="retainedFileCountLimit">The maximum number of log files that will be retained,
         /// including the current log file. For unlimited retention, pass null. The default is 31.</param>
+        /// <param name="buffered">Indicates if flushing to the output file can be buffered or not. The default
+        /// is false.</param>
         /// <returns>Configuration object allowing method chaining.</returns>
         /// <remarks>The file will be written using the UTF-8 character set.</remarks>
         public static LoggerConfiguration RollingFile(
@@ -56,12 +58,13 @@ namespace Serilog.Sinks.RollingFile
             IFormatProvider formatProvider = null,
             long? fileSizeLimitBytes = DefaultFileSizeLimitBytes,
             int? retainedFileCountLimit = DefaultRetainedFileCountLimit,
-            LoggingLevelSwitch levelSwitch = null)
+            LoggingLevelSwitch levelSwitch = null,
+            bool buffered = false)
         {
             if (sinkConfiguration == null) throw new ArgumentNullException(nameof(sinkConfiguration));
             if (outputTemplate == null) throw new ArgumentNullException(nameof(outputTemplate));
             var formatter = new MessageTemplateTextFormatter(outputTemplate, formatProvider);
-            var sink = new RollingFileSink(pathFormat, formatter, fileSizeLimitBytes, retainedFileCountLimit);
+            var sink = new RollingFileSink(pathFormat, formatter, fileSizeLimitBytes, retainedFileCountLimit, buffered: buffered);
             return sinkConfiguration.Sink(sink, restrictedToMinimumLevel, levelSwitch);
         }
     }

--- a/src/Serilog.Sinks.RollingFile/Sinks/RollingFile/RollingFileSink.cs
+++ b/src/Serilog.Sinks.RollingFile/Sinks/RollingFile/RollingFileSink.cs
@@ -38,6 +38,7 @@ namespace Serilog.Sinks.RollingFile
         readonly long? _fileSizeLimitBytes;
         readonly int? _retainedFileCountLimit;
         readonly Encoding _encoding;
+        readonly bool _buffered;
         readonly object _syncRoot = new object();
 
         bool _isDisposed;
@@ -54,13 +55,16 @@ namespace Serilog.Sinks.RollingFile
         /// <param name="retainedFileCountLimit">The maximum number of log files that will be retained,
         /// including the current log file. For unlimited retention, pass null. The default is 31.</param>
         /// <param name="encoding">Character encoding used to write the text file. The default is UTF-8.</param>
+        /// <param name="buffered">Indicates if flushing to the output file can be buffered or not. The default
+        /// is false.</param>
         /// <returns>Configuration object allowing method chaining.</returns>
         /// <remarks>The file will be written using the UTF-8 character set.</remarks>
         public RollingFileSink(string pathFormat,
                               ITextFormatter textFormatter,
                               long? fileSizeLimitBytes,
                               int? retainedFileCountLimit,
-                              Encoding encoding = null)
+                              Encoding encoding = null,
+                              bool buffered = false)
         {
             if (pathFormat == null) throw new ArgumentNullException(nameof(pathFormat));
             if (fileSizeLimitBytes.HasValue && fileSizeLimitBytes < 0) throw new ArgumentException("Negative value provided; file size limit must be non-negative");
@@ -71,6 +75,7 @@ namespace Serilog.Sinks.RollingFile
             _fileSizeLimitBytes = fileSizeLimitBytes;
             _retainedFileCountLimit = retainedFileCountLimit;
             _encoding = encoding ?? Encoding.UTF8;
+            _buffered = buffered;
         }
 
         /// <summary>
@@ -143,7 +148,7 @@ namespace Serilog.Sinks.RollingFile
 
                 try
                 {
-                    _currentFile = new FileSink(path, _textFormatter, _fileSizeLimitBytes, _encoding);
+                    _currentFile = new FileSink(path, _textFormatter, _fileSizeLimitBytes, _encoding, _buffered);
                 }
                 catch (IOException ex)
                 {


### PR DESCRIPTION
This is a rough draft implementation to address #650. I open this PR so we have code to discuss; this code is definitely not ready :wink: 

In all honesty, I don't like the boolean parameter too much. Very often boolean parameters are passed around to mean "behave in this way if true, in that way if false"; I think if two behaviours are distinct enough they should have they own classes (```BufferedFileSink```?).

The second point is the task that is started to process what is put in the queue. I don't like it too much either and I'm wondering if there would be a way to use the explicit implementation of ```IProducerConsumerCollection<T>```. I didn't look into this too much so I will explore, but maybe someone already has an idea.

Let me know what you think.
