### PR TITLE
Move `FromLogContext` to `LoggerEnrichmentConfiguration`, tidy some ifdefs

### DIFF
--- a/src/Serilog/Configuration/LoggerEnrichmentConfiguration.cs
+++ b/src/Serilog/Configuration/LoggerEnrichmentConfiguration.cs
@@ -15,6 +15,7 @@
 using System;
 using Serilog.Core;
 using Serilog.Core.Enrichers;
+using Serilog.Enrichers;
 
 namespace Serilog.Configuration
 {
@@ -78,6 +79,16 @@ namespace Serilog.Configuration
         public LoggerConfiguration WithProperty(string name, object value, bool destructureObjects = false)
         {
             return With(new PropertyEnricher(name, value, destructureObjects));
+        }
+
+        /// <summary>
+        /// Enrich log events with properties from <see cref="Context.LogContext"/>.
+        /// </summary>
+        /// <returns>Configuration object allowing method chaining.</returns>
+        /// <exception cref="ArgumentNullException"></exception>
+        public LoggerConfiguration FromLogContext()
+        {
+            return With<LogContextEnricher>();
         }
     }
 }

--- a/src/Serilog/Context/LogContext.cs
+++ b/src/Serilog/Context/LogContext.cs
@@ -14,23 +14,22 @@
 
 
 using System;
-#if REMOTING
-using System.Runtime.Remoting.Messaging;
-#endif
-#if ASYNCLOCAL
-using System.Collections.Generic;
-using System.Threading;
-#endif
 using Serilog.Core;
 using Serilog.Core.Enrichers;
 using Serilog.Events;
+
+#if ASYNCLOCAL
+using System.Collections.Generic;
+using System.Threading;
+#elif REMOTING
+using System.Runtime.Remoting.Messaging;
+#endif
 
 namespace Serilog.Context
 {
     /// <summary>
     /// Holds ambient properties that can be attached to log events. To
-    /// configure, use the <see cref="LoggerConfigurationExtensions.FromLogContext"/>
-    /// extension method.
+    /// configure, use the <see cref="Serilog.Configuration.LoggerEnrichmentConfiguration.FromLogContext"/> method.
     /// </summary>
     /// <example>
     /// Configuration:
@@ -58,13 +57,11 @@ namespace Serilog.Context
     {
 #if ASYNCLOCAL
         static readonly AsyncLocal<ImmutableStack<ILogEventEnricher>> Data = new AsyncLocal<ImmutableStack<ILogEventEnricher>>();
-#else
-#if DOTNET5_1
+#elif REMOTING
+        static readonly string DataSlotName = typeof(LogContext).FullName;
+#else // DOTNET_51
         [ThreadStatic]
         static ImmutableStack<ILogEventEnricher> Data;
-#else
-        static readonly string DataSlotName = typeof(LogContext).FullName;
-#endif
 #endif
 
         /// <summary>
@@ -143,88 +140,6 @@ namespace Serilog.Context
             return enrichers;
         }
 
-#if ASYNCLOCAL
-       static ImmutableStack<ILogEventEnricher> Enrichers
-        {
-            get
-            {
-                return Data.Value;
-            }
-            set
-            {
-                Data.Value = GetContext(value);
-            }
-        }
-#else
-
-#if DOTNET5_1
-       static ImmutableStack<ILogEventEnricher> Enrichers
-        {
-            get
-            {
-                return Data;
-            }
-            set
-            {
-                Data = GetContext(value);
-            }
-        }
-
-#else
-        static ImmutableStack<ILogEventEnricher> Enrichers
-        {
-            get
-            {
-                var data = CallContext.LogicalGetData(DataSlotName);
-
-                ImmutableStack<ILogEventEnricher> context;
-#if REMOTING
-                if (PermitCrossAppDomainCalls)
-                {
-                    context = ((Wrapper)data)?.Value;
-                }
-                else
-                {
-                    context = (ImmutableStack<ILogEventEnricher>)data;
-                }
-#else
-                context = data;
-#endif
-                return context;
-            }
-            set
-            {
-                var context = GetContext(value);
-                CallContext.LogicalSetData(DataSlotName, context);
-            }
-        }
-#endif
-#endif
-
-#if REMOTING
-        /// <summary>
-        /// When calling into appdomains without Serilog loaded, e.g. via remoting or during unit testing,
-        /// it may be necesary to set this value to true so that serialization exceptions are avoided. When possible,
-        /// using the <see cref="Suspend"/> method in a using block around the call has a lower overhead and
-        /// should be preferred.
-        /// </summary>
-        public static bool PermitCrossAppDomainCalls { get; set; }
-
-        static object GetContext(ImmutableStack<ILogEventEnricher> value)
-        {
-            var context = !PermitCrossAppDomainCalls ? (object) value : new Wrapper
-            {
-                Value = value
-            };
-            return context;
-        }
-#else
-        static ImmutableStack<ILogEventEnricher> GetContext(ImmutableStack<ILogEventEnricher> value)
-        {
-            return value;
-        }
-#endif
-
         internal static void Enrich(LogEvent logEvent, ILogEventPropertyFactory propertyFactory)
         {
             var enrichers = Enrichers;
@@ -252,10 +167,82 @@ namespace Serilog.Context
             }
         }
 
-#if REMOTING
+#if ASYNCLOCAL
+
+        static ImmutableStack<ILogEventEnricher> Enrichers
+        {
+            get
+            {
+                return Data.Value;
+            }
+            set
+            {
+                Data.Value = value;
+            }
+        }
+
+#elif REMOTING
+
+        /// <summary>
+        /// When calling into appdomains without Serilog loaded, e.g. via remoting or during unit testing,
+        /// it may be necesary to set this value to true so that serialization exceptions are avoided. When possible,
+        /// using the <see cref="Suspend"/> method in a using block around the call has a lower overhead and
+        /// should be preferred.
+        /// </summary>
+        // ReSharper disable once UnusedAutoPropertyAccessor.Global
+        public static bool PermitCrossAppDomainCalls { get; set; }
+
         sealed class Wrapper : MarshalByRefObject
         {
             public ImmutableStack<ILogEventEnricher> Value { get; set; }
+        }
+
+        static object GetContext(ImmutableStack<ILogEventEnricher> value)
+        {
+            var context = !PermitCrossAppDomainCalls ? (object)value : new Wrapper
+            {
+                Value = value
+            };
+            return context;
+        }
+
+        static ImmutableStack<ILogEventEnricher> Enrichers
+        {
+            get
+            {
+                var data = CallContext.LogicalGetData(DataSlotName);
+
+                ImmutableStack<ILogEventEnricher> context;
+                if (PermitCrossAppDomainCalls)
+                {
+                    context = ((Wrapper)data)?.Value;
+                }
+                else
+                {
+                    context = (ImmutableStack<ILogEventEnricher>)data;
+                }
+
+                return context;
+            }
+            set
+            {
+                var context = GetContext(value);
+                CallContext.LogicalSetData(DataSlotName, context);
+            }
+        }
+
+#else // DOTNET_51
+
+        static ImmutableStack<ILogEventEnricher> Enrichers
+        {
+            get
+            {
+                return Data;
+            }
+            set
+            {
+                Data = value;
+            }
         }
 #endif
     }

--- a/src/Serilog/LoggerConfigurationExtensions.cs
+++ b/src/Serilog/LoggerConfigurationExtensions.cs
@@ -39,22 +39,8 @@ namespace Serilog
     /// </summary>
     public static class LoggerConfigurationExtensions
     {
-         
         /// <summary>
-        /// Enrich log events with properties from <see cref="Context.LogContext"/>.
-        /// </summary>
-        /// <param name="enrichmentConfiguration">Logger enrichment configuration.</param>
-        /// <returns>Configuration object allowing method chaining.</returns>
-        /// <exception cref="ArgumentNullException"></exception>
-        public static LoggerConfiguration FromLogContext(
-            this LoggerEnrichmentConfiguration enrichmentConfiguration)
-        {
-            if (enrichmentConfiguration == null) throw new ArgumentNullException(nameof(enrichmentConfiguration));
-            return enrichmentConfiguration.With<LogContextEnricher>();
-        }
-
-        /// <summary>
-        /// Enrich log events with a ThreadId property containing the current <see cref="Thread.ManagedThreadId"/>.
+        /// Enrich log events with a ThreadId property containing the current <see cref="System.Threading.Thread.ManagedThreadId"/>.
         /// </summary>
         /// <param name="enrichmentConfiguration">Logger enrichment configuration.</param>
         /// <returns>Configuration object allowing method chaining.</returns>

--- a/test/Serilog.Tests/Settings/KeyValuePairSettingsTests.cs
+++ b/test/Serilog.Tests/Settings/KeyValuePairSettingsTests.cs
@@ -61,12 +61,7 @@ namespace Serilog.Tests.AppSettings.Tests
         public void FindsEventEnrichersWithinAnAssembly()
         {
             var eventEnrichers = KeyValuePairSettings
-                .FindEventEnricherConfigurationMethods(new[] { typeof(Log)
-#if DNXCORE50
-                    .GetTypeInfo()
-#endif
-                    .Assembly
-                    })
+                .FindEventEnricherConfigurationMethods(new[] { typeof(Log).GetTypeInfo().Assembly })
                 .Select(m => m.Name)
                 .Distinct()
                 .ToList();


### PR DESCRIPTION
From #593.

Took the opportunity to codify the series of fallbacks we want in LogContext implementation using the pattern:

```csharp
#if ASYNCLOCAL
  // Preferred
#elif REMOTING
  // Good but not everywhere
#else
  // Must be DOTNET_51
#endif
```

Makes a positive difference to readability in that class.