### PR TITLE
A tiny internal change - make `Logger` implement `ILogEventSink` explicitly

### DIFF
--- a/src/Serilog/Core/Pipeline/Logger.cs
+++ b/src/Serilog/Core/Pipeline/Logger.cs
@@ -148,7 +148,7 @@ namespace Serilog.Core.Pipeline
             Dispatch(logEvent);
         }
 
-        public void Emit(LogEvent logEvent)
+        void ILogEventSink.Emit(LogEvent logEvent)
         {
             if (logEvent == null) throw new ArgumentNullException(nameof(logEvent));
             Write(logEvent);


### PR DESCRIPTION
...so that it's clearly an implementation detail and not something we depend on accidentally.