### PR TITLE
Change to Build.ps1 to use separate package folders

### DIFF
--- a/Build.ps1
+++ b/Build.ps1
@@ -35,7 +35,7 @@ function Restore-Packages
 
 function Build-Projects
 {
-    param( $Directory)
+    param($Directory, $pack)
      
     $DirectoryName = $Directory.DirectoryName
     $artifactsFolder = join-path $root "artifacts"
@@ -44,22 +44,12 @@ function Build-Projects
     $packageFolder = join-path $projectsFolder "packages"
      
     & dnu build ("""" + $DirectoryName + """") --configuration Release --out $buildFolder; if($LASTEXITCODE -ne 0) { exit 1 }
-    & dnu pack ("""" + $DirectoryName + """") --configuration Release --out $packageFolder; if($LASTEXITCODE -ne 0) { exit 1 }
-}
-
-function Build-TestProjects
-{
-    param($Directory)
     
-    $DirectoryName = $Directory.DirectoryName
-    $artifactsFolder = join-path $root "artifacts"
-    $projectsFolder = join-path $artifactsFolder $Directory.Name 
-    $buildFolder = join-path $projectsFolder "testbin"
-    $packageFolder = join-path $projectsFolder "packages"
-    
-    & dnu build ("""" + $DirectoryName + """") --configuration Release --out $buildFolder; if($LASTEXITCODE -ne 0) { exit 1 }
+    if($pack){
+        & dnu pack ("""" + $DirectoryName + """") --configuration Release --out $packageFolder; if($LASTEXITCODE -ne 0) { exit 1 }
+    }
 }
-
+ 
 function Test-Projects
 {
     param([string] $DirectoryName)
@@ -104,8 +94,8 @@ $env:DNX_BUILD_VERSION = @{ $true = $env:APPVEYOR_BUILD_NUMBER; $false = 1 }[$en
 Write-Host "Build number: " $env:DNX_BUILD_VERSION
 
 # Build/package
-Get-ChildItem -Path .\src -Filter *.xproj -Recurse | ForEach-Object { Build-Projects $_ }
-Get-ChildItem -Path .\test -Filter *.xproj -Recurse | ForEach-Object { Build-TestProjects $_ }
+Get-ChildItem -Path .\src -Filter *.xproj -Recurse | ForEach-Object { Build-Projects $_ $true }
+Get-ChildItem -Path .\test -Filter *.xproj -Recurse | ForEach-Object { Build-Projects $_ $false }
 
 # Test
 Get-ChildItem -Path .\test -Filter *.xproj -Recurse | ForEach-Object { Test-Projects $_.DirectoryName }

--- a/Build.ps1
+++ b/Build.ps1
@@ -1,3 +1,5 @@
+$root = $(Get-Item $($MyInvocation.MyCommand.Path)).DirectoryName
+
 function Install-Dnvm
 {
     & where.exe dnvm 2>&1 | Out-Null
@@ -33,15 +35,29 @@ function Restore-Packages
 
 function Build-Projects
 {
-    param([string] $DirectoryName)
-    & dnu build ("""" + $DirectoryName + """") --configuration Release --out .\artifacts\testbin; if($LASTEXITCODE -ne 0) { exit 1 }
-    & dnu pack ("""" + $DirectoryName + """") --configuration Release --out .\artifacts\packages; if($LASTEXITCODE -ne 0) { exit 1 }
+    param( $Directory)
+     
+    $DirectoryName = $Directory.DirectoryName
+    $artifactsFolder = join-path $root "artifacts"
+    $projectsFolder = join-path $artifactsFolder $Directory.Name 
+    $buildFolder = join-path $projectsFolder "testbin"
+    $packageFolder = join-path $projectsFolder "packages"
+     
+    & dnu build ("""" + $DirectoryName + """") --configuration Release --out $buildFolder; if($LASTEXITCODE -ne 0) { exit 1 }
+    & dnu pack ("""" + $DirectoryName + """") --configuration Release --out $packageFolder; if($LASTEXITCODE -ne 0) { exit 1 }
 }
 
 function Build-TestProjects
 {
-    param([string] $DirectoryName)
-    & dnu build ("""" + $DirectoryName + """") --configuration Release --out .\artifacts\testbin; if($LASTEXITCODE -ne 0) { exit 1 }
+    param($Directory)
+    
+    $DirectoryName = $Directory.DirectoryName
+    $artifactsFolder = join-path $root "artifacts"
+    $projectsFolder = join-path $artifactsFolder $Directory.Name 
+    $buildFolder = join-path $projectsFolder "testbin"
+    $packageFolder = join-path $projectsFolder "packages"
+    
+    & dnu build ("""" + $DirectoryName + """") --configuration Release --out $buildFolder; if($LASTEXITCODE -ne 0) { exit 1 }
 }
 
 function Test-Projects
@@ -88,8 +104,8 @@ $env:DNX_BUILD_VERSION = @{ $true = $env:APPVEYOR_BUILD_NUMBER; $false = 1 }[$en
 Write-Host "Build number: " $env:DNX_BUILD_VERSION
 
 # Build/package
-Get-ChildItem -Path .\src -Filter *.xproj -Recurse | ForEach-Object { Build-Projects $_.DirectoryName }
-Get-ChildItem -Path .\test -Filter *.xproj -Recurse | ForEach-Object { Build-TestProjects $_.DirectoryName }
+Get-ChildItem -Path .\src -Filter *.xproj -Recurse | ForEach-Object { Build-Projects $_ }
+Get-ChildItem -Path .\test -Filter *.xproj -Recurse | ForEach-Object { Build-TestProjects $_ }
 
 # Test
 Get-ChildItem -Path .\test -Filter *.xproj -Recurse | ForEach-Object { Test-Projects $_.DirectoryName }


### PR DESCRIPTION
Fixes #672

- Consolidated build/package of tests
- Use project specific package folders for `dnu pack`