### PR TITLE
Fixing ColoredConsoleSink to prevent printing empty properties

### DIFF
--- a/src/Serilog.Sinks.ColoredConsole/Sinks/ColoredConsole/ColoredConsoleSink.cs
+++ b/src/Serilog.Sinks.ColoredConsole/Sinks/ColoredConsole/ColoredConsoleSink.cs
@@ -20,7 +20,7 @@ using System.Collections.Generic;
 using Serilog.Formatting.Display;
 using Serilog.Parsing;
 
-using IPropertyDictionary = System.Collections.Generic.IReadOnlyDictionary<string, Serilog.Events.LogEventPropertyValue>; 
+using IPropertyDictionary = System.Collections.Generic.IReadOnlyDictionary<string, Serilog.Events.LogEventPropertyValue>;
 
 namespace Serilog.Sinks.SystemConsole
 {
@@ -91,7 +91,15 @@ namespace Serilog.Sinks.SystemConsole
                         {
                             RenderOutputToken(palette, outputToken, outputProperties, output);
                         }
-                        else switch (propertyToken.PropertyName)
+                        else
+                        {
+                            LogEventPropertyValue propertyValue;
+                            if (!outputProperties.TryGetValue(propertyToken.PropertyName, out propertyValue))
+                            {
+                                continue;
+                            }
+
+                            switch (propertyToken.PropertyName)
                             {
                                 case OutputProperties.MessagePropertyName:
                                     RenderMessageToken(logEvent, palette, output);
@@ -103,6 +111,7 @@ namespace Serilog.Sinks.SystemConsole
                                     RenderOutputToken(palette, outputToken, outputProperties, output);
                                     break;
                             }
+                        }
                     }
                 }
                 finally { Console.ResetColor(); }


### PR DESCRIPTION
Fixes #649,

Strictly speaking, this is the _minimum_ in order to fix the issue. It uses the same lines as in ```MessageTemplateTextFormatter```, although in this case the if could be inverted.

I don't like it too much because this feels like duplicated logic, on the other hand ```ColoredConsoleSink``` needs to de-construct the message in order to apply different colours for different tokens.