### PR TITLE
Mark assemblies CLSCompliant again

### DIFF
--- a/src/Serilog.Enrichers.Environment/Properties/AssemblyInfo.cs
+++ b/src/Serilog.Enrichers.Environment/Properties/AssemblyInfo.cs
@@ -1,0 +1,6 @@
+using System;
+using System.Reflection;
+
+[assembly: AssemblyVersion("2.0.0.0")]
+
+[assembly: CLSCompliant(true)]

--- a/src/Serilog.Enrichers.Process/Properties/AssemblyInfo.cs
+++ b/src/Serilog.Enrichers.Process/Properties/AssemblyInfo.cs
@@ -1,0 +1,6 @@
+using System;
+using System.Reflection;
+
+[assembly: AssemblyVersion("2.0.0.0")]
+
+[assembly: CLSCompliant(true)]

--- a/src/Serilog.Enrichers.Thread/Properties/AssemblyInfo.cs
+++ b/src/Serilog.Enrichers.Thread/Properties/AssemblyInfo.cs
@@ -1,0 +1,6 @@
+using System;
+using System.Reflection;
+
+[assembly: AssemblyVersion("2.0.0.0")]
+
+[assembly: CLSCompliant(true)]

--- a/src/Serilog.Settings.AppSettings/Properties/AssemblyInfo.cs
+++ b/src/Serilog.Settings.AppSettings/Properties/AssemblyInfo.cs
@@ -1,7 +1,10 @@
-﻿using System.Reflection;
+﻿using System;
+using System.Reflection;
 using System.Runtime.CompilerServices;
 
 [assembly: AssemblyVersion("2.0.0.0")]
+
+[assembly: CLSCompliant(true)]
 
 [assembly: InternalsVisibleTo("Serilog.Tests, PublicKey=" +
                               "0024000004800000940000000602000000240000525341310004000001000100fb8d13fd344a1c" +

--- a/src/Serilog.Sinks.ColoredConsole/Properties/AssemblyInfo.cs
+++ b/src/Serilog.Sinks.ColoredConsole/Properties/AssemblyInfo.cs
@@ -1,7 +1,10 @@
-﻿using System.Reflection;
+﻿using System;
+using System.Reflection;
 using System.Runtime.CompilerServices;
 
 [assembly: AssemblyVersion("2.0.0.0")]
+
+[assembly: CLSCompliant(true)]
 
 [assembly: InternalsVisibleTo("Serilog.Tests, PublicKey=" +
                               "0024000004800000940000000602000000240000525341310004000001000100fb8d13fd344a1c" +

--- a/src/Serilog.Sinks.Console/Properties/AssemblyInfo.cs
+++ b/src/Serilog.Sinks.Console/Properties/AssemblyInfo.cs
@@ -1,7 +1,10 @@
-﻿using System.Reflection;
+﻿using System;
+using System.Reflection;
 using System.Runtime.CompilerServices;
 
 [assembly: AssemblyVersion("2.0.0.0")]
+
+[assembly: CLSCompliant(true)]
 
 [assembly: InternalsVisibleTo("Serilog.Tests, PublicKey=" +
                               "0024000004800000940000000602000000240000525341310004000001000100fb8d13fd344a1c" +

--- a/src/Serilog.Sinks.File/Properties/AssemblyInfo.cs
+++ b/src/Serilog.Sinks.File/Properties/AssemblyInfo.cs
@@ -1,7 +1,10 @@
-﻿using System.Reflection;
+﻿using System;
+using System.Reflection;
 using System.Runtime.CompilerServices;
 
 [assembly: AssemblyVersion("2.0.0.0")]
+
+[assembly: CLSCompliant(true)]
 
 [assembly: InternalsVisibleTo("Serilog.Tests, PublicKey=" +
                               "0024000004800000940000000602000000240000525341310004000001000100fb8d13fd344a1c" +

--- a/src/Serilog.Sinks.Observable/Properties/AssemblyInfo.cs
+++ b/src/Serilog.Sinks.Observable/Properties/AssemblyInfo.cs
@@ -1,7 +1,10 @@
-﻿using System.Reflection;
+﻿using System;
+using System.Reflection;
 using System.Runtime.CompilerServices;
 
 [assembly: AssemblyVersion("2.0.0.0")]
+
+[assembly: CLSCompliant(true)]
 
 [assembly: InternalsVisibleTo("Serilog.Tests, PublicKey=" +
                               "0024000004800000940000000602000000240000525341310004000001000100fb8d13fd344a1c" +

--- a/src/Serilog.Sinks.PeriodicBatching/Properties/AssemblyInfo.cs
+++ b/src/Serilog.Sinks.PeriodicBatching/Properties/AssemblyInfo.cs
@@ -1,7 +1,10 @@
-﻿using System.Reflection;
+﻿using System;
+using System.Reflection;
 using System.Runtime.CompilerServices;
 
 [assembly: AssemblyVersion("2.0.0.0")]
+
+[assembly: CLSCompliant(true)]
 
 [assembly: InternalsVisibleTo("Serilog.Tests, PublicKey=" +
                               "0024000004800000940000000602000000240000525341310004000001000100fb8d13fd344a1c" +

--- a/src/Serilog.Sinks.RollingFile/Properties/AssemblyInfo.cs
+++ b/src/Serilog.Sinks.RollingFile/Properties/AssemblyInfo.cs
@@ -1,7 +1,10 @@
-﻿using System.Reflection;
+﻿using System;
+using System.Reflection;
 using System.Runtime.CompilerServices;
 
 [assembly: AssemblyVersion("2.0.0.0")]
+
+[assembly: CLSCompliant(true)]
 
 [assembly: InternalsVisibleTo("Serilog.Tests, PublicKey=" +
                               "0024000004800000940000000602000000240000525341310004000001000100fb8d13fd344a1c" +

--- a/src/Serilog.Sinks.TextWriter/Properties/AssemblyInfo.cs
+++ b/src/Serilog.Sinks.TextWriter/Properties/AssemblyInfo.cs
@@ -1,7 +1,10 @@
-﻿using System.Reflection;
+﻿using System;
+using System.Reflection;
 using System.Runtime.CompilerServices;
 
 [assembly: AssemblyVersion("2.0.0.0")]
+
+[assembly: CLSCompliant(true)]
 
 [assembly: InternalsVisibleTo("Serilog.Tests, PublicKey=" +
                               "0024000004800000940000000602000000240000525341310004000001000100fb8d13fd344a1c" +

--- a/src/Serilog.Sinks.Trace/Properties/AssemblyInfo.cs
+++ b/src/Serilog.Sinks.Trace/Properties/AssemblyInfo.cs
@@ -1,7 +1,10 @@
-﻿using System.Reflection;
+﻿using System;
+using System.Reflection;
 using System.Runtime.CompilerServices;
 
 [assembly: AssemblyVersion("2.0.0.0")]
+
+[assembly: CLSCompliant(true)]
 
 [assembly: InternalsVisibleTo("Serilog.Tests, PublicKey=" +
                               "0024000004800000940000000602000000240000525341310004000001000100fb8d13fd344a1c" +

--- a/src/Serilog/Properties/AssemblyInfo.cs
+++ b/src/Serilog/Properties/AssemblyInfo.cs
@@ -1,7 +1,10 @@
-﻿using System.Reflection;
+﻿using System;
+using System.Reflection;
 using System.Runtime.CompilerServices;
 
 [assembly: AssemblyVersion("2.0.0.0")]
+
+[assembly: CLSCompliant(true)]
 
 [assembly: InternalsVisibleTo("Serilog.Tests, PublicKey=" +
                               "0024000004800000940000000602000000240000525341310004000001000100fb8d13fd344a1c" +


### PR DESCRIPTION
Fixes #687.

I didn't know if you wanted all assemblies `CLSCompliant` or just `Serilog.dll`, I've marked all of them in this repo, let me know if you want me to change it.