### PR TITLE
add fixed width functionality for log event output.

### DIFF
--- a/src/Serilog/Configuration/LoggerSinkConfiguration.cs
+++ b/src/Serilog/Configuration/LoggerSinkConfiguration.cs
@@ -14,12 +14,11 @@
 
 using System;
 using System.ComponentModel;
-using System.IO;
+
 using Serilog.Core;
 using Serilog.Core.Sinks;
 using Serilog.Debugging;
 using Serilog.Events;
-using Serilog.Formatting.Display; 
 
 namespace Serilog.Configuration
 {

--- a/src/Serilog/Formatting/Display/Casing.cs
+++ b/src/Serilog/Formatting/Display/Casing.cs
@@ -1,0 +1,23 @@
+﻿namespace Serilog.Formatting.Display
+{
+    internal static class Casing
+    {
+        /// <summary>
+        /// Apply upper or lower casing to <paramref name="value"/> when <paramref name="format"/> is provided.
+        /// Returns <paramref name="value"/> when no or invalid format provided
+        /// </summary>
+        /// <returns>The provided <paramref name="value"/> with formatting applied</returns>
+        public static string Format(string value, string format = null)
+        {
+            switch (format)
+            {
+                case "u":
+                    return value.ToUpperInvariant();
+                case "w":
+                    return value.ToLowerInvariant();
+                default:
+                    return value;
+            }
+        }
+    }
+}

--- a/src/Serilog/Formatting/Display/LiteralStringValue.cs
+++ b/src/Serilog/Formatting/Display/LiteralStringValue.cs
@@ -32,19 +32,7 @@ namespace Serilog.Formatting.Display
 
         public override void Render(TextWriter output, string format = null, IFormatProvider formatProvider = null)
         {
-            var toRender = _value;
-
-            switch (format)
-            {
-                case "u":
-                    toRender = _value.ToUpperInvariant();
-                    break;
-                case "w":
-                    toRender = _value.ToLowerInvariant();
-                    break;
-            }
-
-            output.Write(toRender);
+            output.Write(Casing.Format(_value, format));
         }
 
         public override bool Equals(object obj)

--- a/src/Serilog/Formatting/Display/LogEventLevelValue.cs
+++ b/src/Serilog/Formatting/Display/LogEventLevelValue.cs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 using System;
-using System.Collections.Generic;
 using System.IO;
 
 using Serilog.Events;
@@ -27,17 +26,16 @@ namespace Serilog.Formatting.Display
     {
         readonly LogEventLevel _value;
 
-        // Assumes reading from Dictionary<,> is thread-safe after construction
-        static readonly Dictionary<LogEventLevel, string[]> _shortenedLevelMap = new Dictionary<LogEventLevel, string[]>
-                                                                                  {
-                                                                                      { LogEventLevel.Verbose, new []{ "V", "Vb", "Vrb", "Verb" } },
-                                                                                      { LogEventLevel.Debug, new []{ "D", "De", "Dbg", "Dbug" } },
-                                                                                      { LogEventLevel.Information, new []{ "I", "In", "Inf", "Info" } },
-                                                                                      { LogEventLevel.Warning, new []{ "W", "Wn", "Wrn", "Warn" } },
-                                                                                      { LogEventLevel.Error, new []{ "E", "Er", "Err", "Eror" } },
-                                                                                      { LogEventLevel.Fatal, new []{ "F", "Fa", "Ftl", "Fatl" } },
-                                                                                  };
-
+        static readonly string[][] _shortenedLevelMap 
+            = {
+                new []{ "V", "Vb", "Vrb", "Verb" },
+                new []{ "D", "De", "Dbg", "Dbug" },
+                new []{ "I", "In", "Inf", "Info" },
+                new []{ "W", "Wn", "Wrn", "Warn" },
+                new []{ "E", "Er", "Err", "Eror" },
+                new []{ "F", "Fa", "Ftl", "Fatl" }
+              };
+        
         public LogEventLevelValue(
             LogEventLevel value)
         {
@@ -101,7 +99,11 @@ namespace Serilog.Formatting.Display
 
         private static string ShortLevelFor(LogEventLevel value, int width)
         {
-            return _shortenedLevelMap[value][width - 1];
+            var index = (int)value;
+            if (index < 0 || index > (int)LogEventLevel.Fatal)
+                return string.Empty;
+
+            return _shortenedLevelMap[index][width - 1];
         }
 
         private static bool IsOutputStringTooWide(Alignment alignmentValue, string formattedValue)

--- a/src/Serilog/Formatting/Display/LogEventLevelValue.cs
+++ b/src/Serilog/Formatting/Display/LogEventLevelValue.cs
@@ -1,0 +1,99 @@
+// Copyright 2013-2015 Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+using Serilog.Events;
+using Serilog.Parsing;
+
+namespace Serilog.Formatting.Display
+{
+    // allows for the specific handling of the {Level} element.
+    // can now have a fixed width applied to it, as well as casing rules.
+    class LogEventLevelValue : LogEventPropertyValue
+    {
+        private readonly LogEventLevel _value;
+        private readonly Alignment? _alignment;
+
+        private Dictionary<LogEventLevel, string[]> _shortenedLevelMap
+            = new Dictionary<LogEventLevel, string[]>
+                  {
+                      { LogEventLevel.Verbose, new []{ "V", "Vb", "Vrb", "Verb" } },
+                      { LogEventLevel.Debug, new []{ "D", "De", "Dbg", "Dbug" } },
+                      { LogEventLevel.Information, new []{ "I", "In", "Inf", "Info" } },
+                      { LogEventLevel.Warning, new []{ "W", "Wn", "Wrn", "Warn" } },
+                      { LogEventLevel.Error, new []{ "E", "Er", "Err", "Eror" } },
+                      { LogEventLevel.Fatal, new []{ "F", "Fa", "Ftl", "Fatl" } },
+                  };
+
+        public LogEventLevelValue(
+            LogEventLevel value,
+            Alignment? alignment)
+        {
+            _value = value;
+            _alignment = alignment;
+        }
+
+        public string FormattedValue()
+        {
+            var formattedValue = _value.ToString();
+
+            if (!_alignment.HasValue || _alignment.Value.Width <= 0)
+            {
+                return formattedValue;
+            }
+
+            var alignmentValue = _alignment.Value;
+
+            if (formattedValue.Length == alignmentValue.Width)
+            {
+                return formattedValue;
+            }
+
+            if (IsCustomWidthSupported(alignmentValue.Width))
+            {
+                return ShortLevelFor(alignmentValue);
+            }
+
+            if (IsOutputStringTooWide(alignmentValue, formattedValue))
+            {
+                return formattedValue.Substring(0, alignmentValue.Width);
+            }
+
+            return formattedValue;
+        }
+
+        public override void Render(TextWriter output, string format = null, IFormatProvider formatProvider = null)
+        {
+            new LiteralStringValue(FormattedValue()).Render(output, format, formatProvider);
+        }
+
+        private string ShortLevelFor(Alignment alignmentValue)
+        {
+            return _shortenedLevelMap[_value][alignmentValue.Width - 1];
+        }
+
+        private static bool IsOutputStringTooWide(Alignment alignmentValue, string formattedValue)
+        {
+            return alignmentValue.Width < formattedValue.Length;
+        }
+
+        private static bool IsCustomWidthSupported(int width)
+        {
+            return width > 0 && width < 5;
+        }
+    }
+}

--- a/src/Serilog/Formatting/Display/LogEventLevelValue.cs
+++ b/src/Serilog/Formatting/Display/LogEventLevelValue.cs
@@ -23,21 +23,20 @@ namespace Serilog.Formatting.Display
 {
     // allows for the specific handling of the {Level} element.
     // can now have a fixed width applied to it, as well as casing rules.
-    internal class LogEventLevelValue : LogEventPropertyValue
+    class LogEventLevelValue : LogEventPropertyValue
     {
-        private readonly LogEventLevel _value;
+        readonly LogEventLevel _value;
 
         // Assumes reading from Dictionary<,> is thread-safe after construction
-        private static readonly Dictionary<LogEventLevel, string[]> _shortenedLevelMap
-            = new Dictionary<LogEventLevel, string[]>
-                  {
-                      { LogEventLevel.Verbose, new []{ "V", "Vb", "Vrb", "Verb" } },
-                      { LogEventLevel.Debug, new []{ "D", "De", "Dbg", "Dbug" } },
-                      { LogEventLevel.Information, new []{ "I", "In", "Inf", "Info" } },
-                      { LogEventLevel.Warning, new []{ "W", "Wn", "Wrn", "Warn" } },
-                      { LogEventLevel.Error, new []{ "E", "Er", "Err", "Eror" } },
-                      { LogEventLevel.Fatal, new []{ "F", "Fa", "Ftl", "Fatl" } },
-                  };
+        static readonly Dictionary<LogEventLevel, string[]> _shortenedLevelMap = new Dictionary<LogEventLevel, string[]>
+                                                                                  {
+                                                                                      { LogEventLevel.Verbose, new []{ "V", "Vb", "Vrb", "Verb" } },
+                                                                                      { LogEventLevel.Debug, new []{ "D", "De", "Dbg", "Dbug" } },
+                                                                                      { LogEventLevel.Information, new []{ "I", "In", "Inf", "Info" } },
+                                                                                      { LogEventLevel.Warning, new []{ "W", "Wn", "Wrn", "Warn" } },
+                                                                                      { LogEventLevel.Error, new []{ "E", "Er", "Err", "Eror" } },
+                                                                                      { LogEventLevel.Fatal, new []{ "F", "Fa", "Ftl", "Fatl" } },
+                                                                                  };
 
         public LogEventLevelValue(
             LogEventLevel value)
@@ -70,27 +69,29 @@ namespace Serilog.Formatting.Display
 
         private string AlignedValue(Alignment? alignment)
         {
+            var stringValue = _value.ToString();
+
             if (!alignment.HasValue || alignment.Value.Width <= 0)
             {
-                return _value.ToString();
+                return stringValue;
             }
 
-            if (_value.ToString().Length == alignment.Value.Width)
+            if (stringValue.Length == alignment.Value.Width)
             {
-                return _value.ToString();
+                return stringValue;
             }
 
             if (IsCustomWidthSupported(alignment.Value.Width))
             {
-                return ShortLevelFor(_value, alignment.Value);
+                return ShortLevelFor(_value, alignment.Value.Width);
             }
 
-            if (IsOutputStringTooWide(alignment.Value, _value.ToString()))
+            if (IsOutputStringTooWide(alignment.Value, stringValue))
             {
-                return _value.ToString().Substring(0, alignment.Value.Width);
+                return stringValue.Substring(0, alignment.Value.Width);
             }
 
-            return _value.ToString();
+            return stringValue;
         }
 
         private void ApplyFormatting(TextWriter output, string value, Alignment? alignment, string format = null)
@@ -98,9 +99,9 @@ namespace Serilog.Formatting.Display
             Padding.Apply(output, Casing.Format(value, format), alignment);
         }
 
-        private static string ShortLevelFor(LogEventLevel value, Alignment alignmentValue)
+        private static string ShortLevelFor(LogEventLevel value, int width)
         {
-            return _shortenedLevelMap[value][alignmentValue.Width - 1];
+            return _shortenedLevelMap[value][width - 1];
         }
 
         private static bool IsOutputStringTooWide(Alignment alignmentValue, string formattedValue)

--- a/src/Serilog/Formatting/Display/MessageTemplateTextFormatter.cs
+++ b/src/Serilog/Formatting/Display/MessageTemplateTextFormatter.cs
@@ -62,7 +62,7 @@ namespace Serilog.Formatting.Display
             // everything from the log event, but often we won't need any more than
             // just the standard timestamp/message etc.
             var outputProperties = OutputProperties.GetOutputProperties(logEvent);
-
+            
             foreach (var token in _outputTemplate.Tokens)
             {
                 var pt = token as PropertyToken;
@@ -87,6 +87,15 @@ namespace Serilog.Formatting.Display
                     var overridden = new Dictionary<string, LogEventPropertyValue>
                     {
                         { pt.PropertyName, new LiteralStringValue((string) sv.Value) }
+                    };
+
+                    token.Render(overridden, output, _formatProvider);
+                }
+                else if (pt.IsLevelProperty)
+                {
+                    var overridden = new Dictionary<string, LogEventPropertyValue>
+                    {
+                        { pt.PropertyName, new LogEventLevelValue(logEvent.Level, pt.Alignment) }
                     };
 
                     token.Render(overridden, output, _formatProvider);

--- a/src/Serilog/Formatting/Display/MessageTemplateTextFormatter.cs
+++ b/src/Serilog/Formatting/Display/MessageTemplateTextFormatter.cs
@@ -82,6 +82,7 @@ namespace Serilog.Formatting.Display
                 // rendering and support some additional formats: 'u' for uppercase
                 // and 'w' for lowercase.
                 var sv = propertyValue as ScalarValue;
+                LogEventLevelValue lelv;
                 if (sv != null && sv.Value is string)
                 {
                     var overridden = new Dictionary<string, LogEventPropertyValue>
@@ -91,10 +92,9 @@ namespace Serilog.Formatting.Display
 
                     token.Render(overridden, output, _formatProvider);
                 }
-                else if (OutputProperties.IsLevelProperty(pt))
+                else if ((lelv = (propertyValue as LogEventLevelValue)) != null)
                 {
-                    var lpv = (LogEventLevelValue)propertyValue;
-                    lpv.Render(output, pt.Alignment, pt.Format);
+                    lelv.Render(output, pt.Alignment, pt.Format);
                 }
                 else
                 {

--- a/src/Serilog/Formatting/Display/MessageTemplateTextFormatter.cs
+++ b/src/Serilog/Formatting/Display/MessageTemplateTextFormatter.cs
@@ -91,14 +91,10 @@ namespace Serilog.Formatting.Display
 
                     token.Render(overridden, output, _formatProvider);
                 }
-                else if (pt.IsLevelProperty)
+                else if (OutputProperties.IsLevelProperty(pt))
                 {
-                    var overridden = new Dictionary<string, LogEventPropertyValue>
-                    {
-                        { pt.PropertyName, new LogEventLevelValue(logEvent.Level, pt.Alignment) }
-                    };
-
-                    token.Render(overridden, output, _formatProvider);
+                    var lpv = (LogEventLevelValue)propertyValue;
+                    lpv.Render(output, pt.Alignment, pt.Format);
                 }
                 else
                 {

--- a/src/Serilog/Formatting/Display/OutputProperties.cs
+++ b/src/Serilog/Formatting/Display/OutputProperties.cs
@@ -16,6 +16,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Serilog.Events;
+using Serilog.Parsing;
 
 namespace Serilog.Formatting.Display
 {
@@ -65,7 +66,7 @@ namespace Serilog.Formatting.Display
 
             result[MessagePropertyName] = new LogEventPropertyMessageValue(logEvent.MessageTemplate, logEvent.Properties);
             result[TimestampPropertyName] = new ScalarValue(logEvent.Timestamp);
-            result[LevelPropertyName] = new ScalarValue(logEvent.Level);
+            result[LevelPropertyName] = new LogEventLevelValue(logEvent.Level);
             result[NewLinePropertyName] = new LiteralStringValue(Environment.NewLine);
 
             var exception = logEvent.Exception == null ? "" : (logEvent.Exception + Environment.NewLine);
@@ -73,5 +74,10 @@ namespace Serilog.Formatting.Display
 
             return result;
         }
+
+        /// <summary>
+        /// Return whether the given token is for the Level property.
+        /// </summary>
+        public static bool IsLevelProperty(PropertyToken token) => LevelPropertyName.Equals(token.PropertyName);
     }
 }

--- a/src/Serilog/Formatting/Display/Padding.cs
+++ b/src/Serilog/Formatting/Display/Padding.cs
@@ -1,0 +1,31 @@
+﻿using System.IO;
+
+using Serilog.Parsing;
+
+namespace Serilog.Formatting.Display
+{
+    internal static class Padding
+    {
+        /// <summary>
+        /// Writes the provided value to the output, applying direction-based padding when <paramref name="alignment"/> is provided.
+        /// </summary>
+        public static void Apply(TextWriter output, string value, Alignment? alignment)
+        {
+            if (!alignment.HasValue)
+            {
+                output.Write(value);
+                return;
+            }
+
+            var pad = alignment.Value.Width - value.Length;
+
+            if (alignment.Value.Direction == AlignmentDirection.Right)
+                output.Write(new string(' ', pad));
+
+            output.Write(value);
+
+            if (alignment.Value.Direction == AlignmentDirection.Left)
+                output.Write(new string(' ', pad));
+        }
+    }
+}

--- a/src/Serilog/Formatting/Display/Padding.cs
+++ b/src/Serilog/Formatting/Display/Padding.cs
@@ -4,7 +4,7 @@ using Serilog.Parsing;
 
 namespace Serilog.Formatting.Display
 {
-    internal static class Padding
+    static class Padding
     {
         /// <summary>
         /// Writes the provided value to the output, applying direction-based padding when <paramref name="alignment"/> is provided.

--- a/src/Serilog/Parsing/PropertyToken.cs
+++ b/src/Serilog/Parsing/PropertyToken.cs
@@ -112,21 +112,8 @@ namespace Serilog.Parsing
                 return;
             }
 
-            var pad = Alignment.Value.Width - value.Length;
-
-            if (Alignment.Value.Direction == AlignmentDirection.Right)
-                output.Write(new string(' ', pad));
-
-            output.Write(value);
-
-            if (Alignment.Value.Direction == AlignmentDirection.Left)
-                output.Write(new string(' ', pad));
+            Padding.Apply(output, value, Alignment.Value);
         }
-
-        /// <summary>
-        /// Return whether this is the Level output token
-        /// </summary>
-        public bool IsLevelProperty => OutputProperties.LevelPropertyName.Equals(PropertyName);
 
         /// <summary>
         /// The property name.

--- a/src/Serilog/Parsing/PropertyToken.cs
+++ b/src/Serilog/Parsing/PropertyToken.cs
@@ -18,6 +18,7 @@ using System.ComponentModel;
 using System.Globalization;
 using System.IO;
 using Serilog.Events;
+using Serilog.Formatting.Display;
 
 namespace Serilog.Parsing
 {
@@ -121,6 +122,11 @@ namespace Serilog.Parsing
             if (Alignment.Value.Direction == AlignmentDirection.Left)
                 output.Write(new string(' ', pad));
         }
+
+        /// <summary>
+        /// Return whether this is the Level output token
+        /// </summary>
+        public bool IsLevelProperty => OutputProperties.LevelPropertyName.Equals(PropertyName);
 
         /// <summary>
         /// The property name.

--- a/test/Serilog.Tests/Formatting/Display/MessageTemplateTextFormatterTests.cs
+++ b/test/Serilog.Tests/Formatting/Display/MessageTemplateTextFormatterTests.cs
@@ -1,5 +1,8 @@
 ﻿using System.Globalization;
 using System.IO;
+
+using Serilog.Events;
+
 using Xunit;
 using Serilog.Tests.Support;
 using Serilog.Formatting.Display;
@@ -47,6 +50,95 @@ namespace Serilog.Tests.Formatting.Display
             var sw = new StringWriter();
             formatter.Format(evt, sw);
             Assert.Equal("nick", sw.ToString());
+        }
+
+        [Theory]
+        [InlineData(LogEventLevel.Verbose, 1, "V")]
+        [InlineData(LogEventLevel.Verbose, 2, "Vb")]
+        [InlineData(LogEventLevel.Verbose, 3, "Vrb")]
+        [InlineData(LogEventLevel.Verbose, 4, "Verb")]
+        [InlineData(LogEventLevel.Verbose, 5, "Verbo")]
+        [InlineData(LogEventLevel.Verbose, 6, "Verbos")]
+        [InlineData(LogEventLevel.Verbose, 7, "Verbose")]
+        [InlineData(LogEventLevel.Verbose, 8, " Verbose")]
+        [InlineData(LogEventLevel.Debug, 1, "D")]
+        [InlineData(LogEventLevel.Debug, 2, "De")]
+        [InlineData(LogEventLevel.Debug, 3, "Dbg")]
+        [InlineData(LogEventLevel.Debug, 4, "Dbug")]
+        [InlineData(LogEventLevel.Debug, 5, "Debug")]
+        [InlineData(LogEventLevel.Debug, 6, " Debug")]
+        [InlineData(LogEventLevel.Information, 1, "I")]
+        [InlineData(LogEventLevel.Information, 2, "In")]
+        [InlineData(LogEventLevel.Information, 3, "Inf")]
+        [InlineData(LogEventLevel.Information, 4, "Info")]
+        [InlineData(LogEventLevel.Information, 5, "Infor")]
+        [InlineData(LogEventLevel.Information, 6, "Inform")]
+        [InlineData(LogEventLevel.Information, 7, "Informa")]
+        [InlineData(LogEventLevel.Information, 8, "Informat")]
+        [InlineData(LogEventLevel.Information, 9, "Informati")]
+        [InlineData(LogEventLevel.Information, 10, "Informatio")]
+        [InlineData(LogEventLevel.Information, 11, "Information")]
+        [InlineData(LogEventLevel.Information, 12, " Information")]
+        [InlineData(LogEventLevel.Error, 1, "E")]
+        [InlineData(LogEventLevel.Error, 2, "Er")]
+        [InlineData(LogEventLevel.Error, 3, "Err")]
+        [InlineData(LogEventLevel.Error, 4, "Eror")]
+        [InlineData(LogEventLevel.Error, 5, "Error")]
+        [InlineData(LogEventLevel.Error, 6, " Error")]
+        [InlineData(LogEventLevel.Fatal, 1, "F")]
+        [InlineData(LogEventLevel.Fatal, 2, "Fa")]
+        [InlineData(LogEventLevel.Fatal, 3, "Ftl")]
+        [InlineData(LogEventLevel.Fatal, 4, "Fatl")]
+        [InlineData(LogEventLevel.Fatal, 5, "Fatal")]
+        [InlineData(LogEventLevel.Fatal, 6, " Fatal")]
+        [InlineData(LogEventLevel.Warning, 1, "W")]
+        [InlineData(LogEventLevel.Warning, 2, "Wn")]
+        [InlineData(LogEventLevel.Warning, 3, "Wrn")]
+        [InlineData(LogEventLevel.Warning, 4, "Warn")]
+        [InlineData(LogEventLevel.Warning, 5, "Warni")]
+        [InlineData(LogEventLevel.Warning, 6, "Warnin")]
+        [InlineData(LogEventLevel.Warning, 7, "Warning")]
+        [InlineData(LogEventLevel.Warning, 8, " Warning")]
+        public void FixedLengthLevelIsSupported(
+            LogEventLevel level,
+            int length, 
+            string expected)
+        {
+            var formatter = new MessageTemplateTextFormatter($"{{Level,{length}}}", CultureInfo.InvariantCulture);
+            var evt = DelegatingSink.GetLogEvent(l => l.Write(level, "Hello"));
+            var sw = new StringWriter();
+            formatter.Format(evt, sw);
+            Assert.Equal(expected, sw.ToString());
+        }
+
+        [Fact]
+        public void FixedLengthLevelSupportsUpperCasing()
+        {
+            var formatter = new MessageTemplateTextFormatter("{Level,3:u}", CultureInfo.InvariantCulture);
+            var evt = DelegatingSink.GetLogEvent(l => l.Information("Hello"));
+            var sw = new StringWriter();
+            formatter.Format(evt, sw);
+            Assert.Equal("INF", sw.ToString());
+        }
+
+        [Fact]
+        public void FixedLengthLevelSupportsLowerCasing()
+        {
+            var formatter = new MessageTemplateTextFormatter("{Level,3:w}", CultureInfo.InvariantCulture);
+            var evt = DelegatingSink.GetLogEvent(l => l.Information("Hello"));
+            var sw = new StringWriter();
+            formatter.Format(evt, sw);
+            Assert.Equal("inf", sw.ToString());
+        }
+
+        [Fact]
+        public void DefaultLevelLengthIsFullText()
+        {
+            var formatter = new MessageTemplateTextFormatter("{Level}", CultureInfo.InvariantCulture);
+            var evt = DelegatingSink.GetLogEvent(l => l.Information("Hello"));
+            var sw = new StringWriter();
+            formatter.Format(evt, sw);
+            Assert.Equal("Information", sw.ToString());
         }
     }
 }

--- a/test/Serilog.Tests/Support/DelegatingSink.cs
+++ b/test/Serilog.Tests/Support/DelegatingSink.cs
@@ -23,6 +23,7 @@ namespace Serilog.Tests.Support
         {
             LogEvent result = null;
             var l = new LoggerConfiguration()
+                .MinimumLevel.Verbose()
                 .WriteTo.Sink(new DelegatingSink(le => result = le))
                 .CreateLogger();
 


### PR DESCRIPTION
#574 Now supports {Level,1} style syntax. Also supports upper/lower variations.