### PR TITLE
Make the return value of `LoggerConfiguration.CreateLogger()` concrete

### DIFF
--- a/src/Serilog/Core/Logger.cs
+++ b/src/Serilog/Core/Logger.cs
@@ -20,9 +20,9 @@ using Serilog.Debugging;
 using Serilog.Events;
 using Serilog.Parameters;
 
-namespace Serilog.Core.Pipeline
+namespace Serilog.Core
 {
-    sealed class Logger : ILogger, ILogEventSink, IDisposable
+    public sealed class Logger : ILogger, ILogEventSink, IDisposable
     {
         readonly MessageTemplateProcessor _messageTemplateProcessor;
         readonly ILogEventSink _sink;
@@ -37,7 +37,7 @@ namespace Serilog.Core.Pipeline
         readonly LogEventLevel _minimumLevel;
         readonly LoggingLevelSwitch _levelSwitch;
 
-        public Logger(
+        internal Logger(
             MessageTemplateProcessor messageTemplateProcessor,
             LogEventLevel minimumLevel,
             ILogEventSink sink,
@@ -47,7 +47,7 @@ namespace Serilog.Core.Pipeline
         {
         }
 
-        public Logger(
+        internal Logger(
             MessageTemplateProcessor messageTemplateProcessor,
             LoggingLevelSwitch levelSwitch,
             ILogEventSink sink,

--- a/src/Serilog/LoggerConfiguration.cs
+++ b/src/Serilog/LoggerConfiguration.cs
@@ -17,7 +17,6 @@ using System.Collections.Generic;
 using System.Linq;
 using Serilog.Configuration;
 using Serilog.Core;
-using Serilog.Core.Pipeline;
 using Serilog.Core.Sinks;
 using Serilog.Events;
 using Serilog.Parameters;
@@ -132,15 +131,11 @@ namespace Serilog
         /// <remarks>To free resources held by sinks ahead of program shutdown,
         /// the returned logger may be cast to <see cref="IDisposable"/> and
         /// disposed.</remarks>
-        public ILogger CreateLogger()
+        public Logger CreateLogger()
         {
             if (_loggerCreated)
-                throw new InvalidOperationException($"CreateLogger was previously called and can only be called once.");
+                throw new InvalidOperationException("CreateLogger was previously called and can only be called once.");
             _loggerCreated = true;
-
-            if (!_logEventSinks.Any())
-                return new SilentLogger();
-
 
             Action dispose = () =>
             {

--- a/test/Serilog.Tests/LoggerConfigurationTests.cs
+++ b/test/Serilog.Tests/LoggerConfigurationTests.cs
@@ -246,13 +246,6 @@ namespace Serilog.Tests
         }
 
         [Fact]
-        public void AnUnconfiguredLoggerShouldBeTheNullLogger()
-        {
-            var actual = new LoggerConfiguration().CreateLogger();
-            Assert.Equal(actual.GetType().Name, "SilentLogger");
-        }
-
-        [Fact]
         public void LastMinimumLevelConfigurationWins()
         {
             var sink = new CollectingSink();


### PR DESCRIPTION
This PR communicates the dispose requirement of the logging pipeline by returning a concrete disposable type, `Logger`, from `CreateLogger()`.

One consequence is that `using` syntax can be applied:

```csharp
using (var log = new LoggerConfiguration()
    .WriteTo.Console()
    .CreateLogger())
{
    // <app runs here>
}
```

It's not anticipated that users will generally wrap logger creation in a `using` block however; rather in 2.0 the `CloseAndFlush()` method will cover apps that base logging off of the static `Log` class.

```csharp
Log.Logger = new LoggerConfiguration()
    .WriteTo.Console()
    .CreateLogger();

// <app runs here>

Log.CloseAndFlush();
```

Doing this however clarifies at the API level that the logger needs to be flushed in some way. This is important as .NET Core doesn't expose any `AppDomain` unload-time hooks to trigger flushing, which historically we've relied on.

See also #718, where working around this design issue has lead us astray.

## Caveats

This regresses one minor point - a logger with no sinks configured is no longer switched for a `SilentLogger` behind the scenes; users relying on this behaviour instead need to avoid configuring the logger at all. The alternative - returning something that could be shared in common with `SilentLogger`, would require one of the less-appealing options discussed in _Alternatives_ below.

Another caveat is that in order to prevent a public-surface-area explosion, the constructors of this type are internal. This should not be a significant issue as `ILogger` should be the interface used in application code.

## Alternatives

Instead of exposing the concrete `Logger` class, the following options were also available:

 * Return a disposable interface - `ILoggingPipeline` or similar: disposable interfaces are a semantic wart since only implementations determine the need for disposal
 * Return a new abstract base class - this adds the need for virtual dispatch in more places, for example level checking, which adds up if not kept under control