### PR TITLE
Internalize IScalarConversionPolicy, since no API allows one to be plugged in

### DIFF
--- a/src/Serilog/Core/IScalarConversionPolicy.cs
+++ b/src/Serilog/Core/IScalarConversionPolicy.cs
@@ -6,7 +6,7 @@ namespace Serilog.Core
     /// Determine how a simple value is carried through the logging
     /// pipeline as an immutable <see cref="ScalarValue"/>.
     /// </summary>
-    public interface IScalarConversionPolicy
+    interface IScalarConversionPolicy
     {
         /// <summary>
         /// If supported, convert the provided value into an immutable scalar.


### PR DESCRIPTION
This interface is public, but no API allows an instance to be plugged in, so it is unusable as-is.

Internally, the implementation around this interface may have to change if the feature is ever opened up. Let's defer committing to a design for the public interface until the rest of the feature is fully planned out (if ever).

See discussion in #723.