### PR TITLE
Log parameters not in message templates

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -1,0 +1,1 @@
+@powershell .\Build.ps1 

--- a/src/Serilog/Parameters/PropertyBinder.cs
+++ b/src/Serilog/Parameters/PropertyBinder.cs
@@ -70,10 +70,10 @@ namespace Serilog.Parameters
             var positionalProperties = template.PositionalProperties;
 
             var result = new LogEventProperty[messageTemplateParameters.Length];
-            for (int position = 0; position < messageTemplateParameters.Length; position++)
+            for (var position = 0; position < messageTemplateParameters.Length; position++)
             {
                 PropertyToken propertyToken = null;
-                for (int propIndex = 0; propIndex < positionalProperties.Length; propIndex++)
+                for (var propIndex = 0; propIndex < positionalProperties.Length; propIndex++)
                 {
                     int propertyTokenPosition;
                     if (positionalProperties[propIndex].TryGetPositionalValue(out propertyTokenPosition)

--- a/src/Serilog/Parameters/PropertyBinder.cs
+++ b/src/Serilog/Parameters/PropertyBinder.cs
@@ -54,14 +54,6 @@ namespace Serilog.Parameters
             if (messageTemplate.PositionalProperties == null)
                 return ConstructNamedProperties(messageTemplate, messageTemplateParameters);
 
-            // all are positional
-            if (messageTemplateParameters.Length == messageTemplate.PositionalProperties.Length)
-            {
-                // exactly the right number of positional parameters were provided
-                return ConstructPositionalPropertiesOptimisedAllMatching(messageTemplate, messageTemplateParameters);
-            }
-
-            SelfLog.WriteLine("Positional property count does not match parameter count: {0}", messageTemplate);
             return ConstructPositionalPropertiesWithSomeMissing(messageTemplate, messageTemplateParameters);
         }
 
@@ -87,26 +79,6 @@ namespace Serilog.Parameters
                     ? new LogEventProperty("__" + position,
                         _valueConverter.CreatePropertyValue(messageTemplateParameters[position]))
                     : ConstructProperty(propertyToken, messageTemplateParameters[position]);
-            }
-
-            return result;
-        }
-
-        IEnumerable<LogEventProperty> ConstructPositionalPropertiesOptimisedAllMatching(MessageTemplate template, object[] messageTemplateParameters)
-        {
-            var positionalProperties = template.PositionalProperties;
-            var result = new LogEventProperty[positionalProperties.Length];
-            for (var index = 0; index < positionalProperties.Length; index++)
-            {
-                var property = positionalProperties[index];
-                int position;
-                if (!property.TryGetPositionalValue(out position))
-                {
-                    throw new ArgumentException(
-                        "This method can only process a template with all positional properties.", nameof(template));
-                }
-
-                result[position] = ConstructProperty(property, messageTemplateParameters[position]);
             }
 
             return result;

--- a/src/Serilog/Parameters/PropertyBinder.cs
+++ b/src/Serilog/Parameters/PropertyBinder.cs
@@ -65,7 +65,6 @@ namespace Serilog.Parameters
                 SelfLog.WriteLine("Positional property count does not match parameter count: {0}", template);
 
             var result = new LogEventProperty[messageTemplateParameters.Length];
-            int nextUnmatchedPosition = 0;
             for (int position = 0; position < messageTemplateParameters.Length; position++)
             {
                 PropertyToken propertyToken = null;
@@ -79,17 +78,10 @@ namespace Serilog.Parameters
                     }
                 }
 
-                if (propertyToken == null)
-                {
-                    // found no property for this position; generate a default name
-                    result[position] = new LogEventProperty(
-                        "__" + nextUnmatchedPosition++,
-                        _valueConverter.CreatePropertyValue(messageTemplateParameters[position]));
-                }
-                else
-                {
-                    result[position] = ConstructProperty(propertyToken, messageTemplateParameters[position]);
-                }
+                result[position] = propertyToken == null
+                    ? new LogEventProperty("__" + position, 
+                        _valueConverter.CreatePropertyValue(messageTemplateParameters[position]))
+                    : ConstructProperty(propertyToken, messageTemplateParameters[position]);
             }
 
             return result;
@@ -108,23 +100,12 @@ namespace Serilog.Parameters
                 SelfLog.WriteLine("Named property count does not match parameter count: {0}", template);
             }
 
-            int nextUnmatchedPosition = 0;
             var result = new LogEventProperty[messageTemplateParameters.Length];
             for (var i = 0; i < result.Length; ++i)
             {
-                if (i < matchedRun)
-                {
-                    var property = template.NamedProperties[i];
-                    var value = messageTemplateParameters[i];
-                    result[i] = ConstructProperty(property, value);
-                }
-                else
-                {
-                    // found no property for this position; generate a default name
-                    result[i] = new LogEventProperty(
-                        "__" + nextUnmatchedPosition++,
-                        _valueConverter.CreatePropertyValue(messageTemplateParameters[i]));
-                }
+                result[i] = i < matchedRun
+                    ? ConstructProperty(template.NamedProperties[i], messageTemplateParameters[i])
+                    : new LogEventProperty("__" + i, _valueConverter.CreatePropertyValue(messageTemplateParameters[i]));
             }
 
             return result;

--- a/src/Serilog/Parameters/PropertyBinder.cs
+++ b/src/Serilog/Parameters/PropertyBinder.cs
@@ -102,8 +102,10 @@ namespace Serilog.Parameters
                 int position;
                 if (!property.TryGetPositionalValue(out position))
                 {
-                    throw new Exception("should never happen here");
+                    throw new ArgumentException(
+                        "This method can only process a template with all positional properties.", nameof(template));
                 }
+
                 result[position] = ConstructProperty(property, messageTemplateParameters[position]);
             }
 

--- a/test/Serilog.Tests/Core/LogEventPropertyCapturingTests.cs
+++ b/test/Serilog.Tests/Core/LogEventPropertyCapturingTests.cs
@@ -45,6 +45,38 @@ namespace Serilog.Tests.Core
         }
 
         [Fact]
+        public void CapturingIntArrayAsScalarSequenceValuesWorks()
+        {
+            const string template = "Hello {sequence}";
+            var templateArguments = new[] { 1, 2, 3, };
+            var expected = new[] {
+                new LogEventProperty("sequence",
+                    new SequenceValue(new[] {
+                        new ScalarValue(1),
+                        new ScalarValue(2),
+                        new ScalarValue(3) })) };
+
+            Assert.Equal(expected, Capture(template, templateArguments),
+                new LogEventPropertyStructuralEqualityComparer());
+        }
+
+        [Fact]
+        public void CapturingDestructuredStringArrayAsScalarSequenceValuesWorks()
+        {
+            const string template = "Hello {@sequence}";
+            var templateArguments = new[] { "1", "2", "3", };
+            var expected = new[] {
+                new LogEventProperty("sequence",
+                    new SequenceValue(new[] {
+                        new ScalarValue("1"),
+                        new ScalarValue("2"),
+                        new ScalarValue("3") })) };
+
+            Assert.Equal(expected, Capture(template, new object[] { templateArguments }),
+                new LogEventPropertyStructuralEqualityComparer());
+        }
+
+        [Fact]
         public void CapturingMultipleSamePositionalsWithoutWarning()
         {
             var selfLogWriter = new StringWriter();

--- a/test/Serilog.Tests/Core/LogEventPropertyCapturingTests.cs
+++ b/test/Serilog.Tests/Core/LogEventPropertyCapturingTests.cs
@@ -1,6 +1,4 @@
-﻿#if INTERNAL_TESTS
-
-using System;
+﻿using System;
 using System.Linq;
 using System.Collections.Generic;
 
@@ -179,5 +177,3 @@ namespace Serilog.Tests.Core
         }
     }
 }
-
-#endif

--- a/test/Serilog.Tests/Core/LogEventPropertyCapturingTests.cs
+++ b/test/Serilog.Tests/Core/LogEventPropertyCapturingTests.cs
@@ -1,0 +1,183 @@
+﻿#if INTERNAL_TESTS
+
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using Serilog.Core;
+using Serilog.Events;
+using Serilog.Parameters;
+using Serilog.Parsing;
+
+using Xunit;
+
+namespace Serilog.Tests.Core
+{
+    public class LogEventPropertyCapturingTests
+    {
+        [Fact]
+        public void CapturingANamedScalarStringWorks()
+        {
+            Assert.Equal(
+                new[] { new LogEventProperty("who", new ScalarValue("world")) },
+                Capture("Hello {who}", "world"),
+                new LogEventPropertyStructuralEqualityComparer());
+        }
+
+        [Fact]
+        public void CapturingAPositionalScalarStringWorks()
+        {
+            Assert.Equal(
+                new[] { new LogEventProperty("0", new ScalarValue("world")) },
+                Capture("Hello {0}", "world"),
+                new LogEventPropertyStructuralEqualityComparer());
+        }
+
+        [Fact]
+        public void CapturingMixedPositionalAndNamedScalarsWorksUsingNames()
+        {
+            Assert.Equal(new[]
+                {
+                    new LogEventProperty("who", new ScalarValue("worldNamed")),
+                    new LogEventProperty("0", new ScalarValue("worldPositional")),
+                },
+                Capture("Hello {who} {0} {0}", "worldNamed", "worldPositional"),
+                new LogEventPropertyStructuralEqualityComparer());
+        }
+
+        [Fact(Skip="Proposed behaviour")]
+        public void WillCaptureAdditionalPositionalsNotInTemplate()
+        {
+            Assert.Equal(new[]
+                {
+                    new LogEventProperty("0", new ScalarValue(0)),
+                    new LogEventProperty("1", new ScalarValue(1)),
+                    new LogEventProperty("<todo - decide naming strategy>1", new ScalarValue(2)),
+                    new LogEventProperty("<todo - decide naming strategy>2", new ScalarValue(3)),
+                },
+                Capture("Hello {1} {0} 2}", 1, 0, 2, 3),
+                new LogEventPropertyStructuralEqualityComparer());
+        }
+
+        [Fact(Skip="Proposed behaviour")]
+        public void WillCaptureAdditionalNamedPropsNotInTemplate()
+        {
+            Assert.Equal(new[]
+                {
+                    new LogEventProperty("who", new ScalarValue("who")),
+                    new LogEventProperty("what", new ScalarValue("what")),
+                    new LogEventProperty("<todo - decide naming strategy>1", new ScalarValue("where")),
+                    new LogEventProperty("<todo - decide naming strategy>2", new ScalarValue("how")),
+                },
+                Capture("Hello {who} {what} where}", "who", "what", "where", "how"),
+                new LogEventPropertyStructuralEqualityComparer());
+        }
+        
+        static IEnumerable<LogEventProperty> Capture(string messageTemplate, params object[] properties)
+        {
+            var mt = new MessageTemplateParser().Parse(messageTemplate);
+            var binder = new PropertyBinder(
+                new PropertyValueConverter(10, Enumerable.Empty<Type>(), Enumerable.Empty<IDestructuringPolicy>()));
+            return binder.ConstructProperties(mt, properties);
+        }
+
+        [Fact]
+        public void StructuralEqualityComparerKindaSortaWorksForScalars()
+        {
+            var scalarStringA = new LogEventProperty("a", new ScalarValue("a"));
+            var scalarStringAStructurallyEqual = new LogEventProperty("a", new ScalarValue("a"));
+
+            var scalarStringB = new LogEventProperty("b", new ScalarValue("b"));
+            var scalarStringBStructurallyNotEqual = new LogEventProperty("b", new ScalarValue("notEqual"));
+
+            var scalarIntA1 = new LogEventProperty("a", new ScalarValue(1));
+            var scalarIntA1StructurallyEqual = new LogEventProperty("a", new ScalarValue(1));
+            var scalarIntA1DiffValueSameType = new LogEventProperty("a", new ScalarValue(0));
+            var scalarIntB1 = new LogEventProperty("b", new ScalarValue(1));
+
+            var guid1 = Guid.NewGuid();
+            var guid2 = Guid.NewGuid();
+            var scalarGuid1 = new LogEventProperty("1", new ScalarValue(guid1));
+            var scalarGuid1StructurallyEqual = new LogEventProperty("1", new ScalarValue(guid1));
+            var scalarGuid1StructurallyNotEqual = new LogEventProperty("1", new ScalarValue("notEqual"));
+            var scalarGuid2 = new LogEventProperty("2", new ScalarValue(guid2));
+
+            var sut = new LogEventPropertyStructuralEqualityComparer();
+
+            Assert.True(sut.Equals(scalarStringA, scalarStringAStructurallyEqual));
+            Assert.True(sut.Equals(scalarIntA1, scalarIntA1StructurallyEqual));
+            Assert.True(sut.Equals(scalarGuid1, scalarGuid1StructurallyEqual));
+
+            Assert.False(sut.Equals(scalarStringB, scalarStringBStructurallyNotEqual));
+            Assert.False(sut.Equals(scalarIntA1, scalarIntB1));
+            Assert.False(sut.Equals(scalarIntA1, scalarIntA1DiffValueSameType));
+
+            Assert.False(sut.Equals(scalarGuid1, scalarGuid2));
+            Assert.False(sut.Equals(scalarGuid1, scalarGuid1StructurallyNotEqual));
+        }
+
+        class LogEventPropertyStructuralEqualityComparer : IEqualityComparer<LogEventProperty>
+        {
+            readonly IEqualityComparer<LogEventPropertyValue> _valueEqualityComparer;
+
+            public LogEventPropertyStructuralEqualityComparer(
+                IEqualityComparer<LogEventPropertyValue> valueEqualityComparer = null)
+            {
+                this._valueEqualityComparer =
+                    valueEqualityComparer ?? new LogEventPropertyValueComparer(EqualityComparer<object>.Default);
+            }
+
+            public bool Equals(LogEventProperty x, LogEventProperty y)
+            {
+                return x.Name == y.Name
+                    && _valueEqualityComparer.Equals(x.Value, y.Value);
+            }
+
+            public int GetHashCode(LogEventProperty obj)
+            {
+                return 0;
+            }
+        }
+
+        class LogEventPropertyValueComparer : IEqualityComparer<LogEventPropertyValue>
+        {
+            readonly IEqualityComparer<object> _objectEqualityComparer;
+
+            public LogEventPropertyValueComparer(IEqualityComparer<object> objectEqualityComparer = null)
+            {
+                this._objectEqualityComparer = objectEqualityComparer ?? EqualityComparer<object>.Default;
+            }
+
+            public bool Equals(LogEventPropertyValue x, LogEventPropertyValue y)
+            {
+                var scalarX = x as ScalarValue;
+                var scalarY = y as ScalarValue;
+                if (scalarX != null && scalarY != null)
+                {
+                    return _objectEqualityComparer.Equals(scalarX.Value, scalarY.Value);
+                }
+                else if (x is SequenceValue && y is SequenceValue)
+                {
+                    throw new NotImplementedException();
+                }
+                else if (x is StructureValue && y is StructureValue)
+                {
+                    throw new NotImplementedException();
+                }
+                else if (x is DictionaryValue && y is DictionaryValue)
+                {
+                    throw new NotImplementedException();
+                }
+
+                throw new NotImplementedException();
+            }
+
+            public int GetHashCode(LogEventPropertyValue obj)
+            {
+                return 0;
+            }
+        }
+    }
+}
+
+#endif

--- a/test/Serilog.Tests/Core/LogEventPropertyCapturingTests.cs
+++ b/test/Serilog.Tests/Core/LogEventPropertyCapturingTests.cs
@@ -1,8 +1,9 @@
 ﻿using System;
 using System.Linq;
 using System.Collections.Generic;
-
+using System.IO;
 using Serilog.Core;
+using Serilog.Debugging;
 using Serilog.Events;
 using Serilog.Parameters;
 using Serilog.Parsing;
@@ -40,6 +41,37 @@ namespace Serilog.Tests.Core
                     new LogEventProperty("0", new ScalarValue("worldPositional")),
                 },
                 Capture("Hello {who} {0} {0}", "worldNamed", "worldPositional"),
+                new LogEventPropertyStructuralEqualityComparer());
+        }
+
+        [Fact]
+        public void CapturingMultipleSamePositionalsWithoutWarning()
+        {
+            var selfLogWriter = new StringWriter();
+            SelfLog.Enable(selfLogWriter);
+
+            Assert.Equal(new[]
+                {
+                    new LogEventProperty("0", new ScalarValue(Environment.NewLine)),
+                    new LogEventProperty("1", new ScalarValue("Adam")),
+                },
+                Capture("Hello {0}{1} {0}It's me", Environment.NewLine, "Adam"),
+                new LogEventPropertyStructuralEqualityComparer());
+
+            Assert.Equal("", selfLogWriter.ToString());
+            SelfLog.Disable();
+        }
+
+        [Fact]
+        public void CapturingMultipleSamePositionalsStillCapturesMissing()
+        {
+            Assert.Equal(new[]
+                {
+                    new LogEventProperty("0", new ScalarValue(Environment.NewLine)),
+                    new LogEventProperty("1", new ScalarValue("Adam")),
+                    new LogEventProperty("__2", new ScalarValue("Missing")),
+                },
+                Capture("Hello {0}{1} {0}It's me", Environment.NewLine, "Adam", "Missing"),
                 new LogEventPropertyStructuralEqualityComparer());
         }
 

--- a/test/Serilog.Tests/Core/LogEventPropertyCapturingTests.cs
+++ b/test/Serilog.Tests/Core/LogEventPropertyCapturingTests.cs
@@ -43,31 +43,69 @@ namespace Serilog.Tests.Core
                 new LogEventPropertyStructuralEqualityComparer());
         }
 
-        [Fact(Skip="Proposed behaviour")]
+        [Fact]
+        public void WillCaptureProvidedPositionalValuesEvenIfSomeAreMissing()
+        {
+            Assert.Equal(new[]
+                {
+                    new LogEventProperty("0", new ScalarValue(0)),
+                    new LogEventProperty("1", new ScalarValue(1)),
+                },
+                Capture("Hello {3} {2} {1} {0} nothing more", 0, 1), // missing {2} and {3}
+                new LogEventPropertyStructuralEqualityComparer());
+        }
+
+        [Fact]
+        public void WillCaptureProvidedNamedValuesEvenIfSomeAreMissing()
+        {
+            Assert.Equal(new[]
+                {
+                    new LogEventProperty("who", new ScalarValue("who")),
+                    new LogEventProperty("what", new ScalarValue("what")),
+                },
+                Capture("Hello {who} {what} {where}", "who", "what"), // missing "where"
+                new LogEventPropertyStructuralEqualityComparer());
+        }
+
+        [Fact]
         public void WillCaptureAdditionalPositionalsNotInTemplate()
         {
             Assert.Equal(new[]
                 {
                     new LogEventProperty("0", new ScalarValue(0)),
                     new LogEventProperty("1", new ScalarValue(1)),
-                    new LogEventProperty("<todo - decide naming strategy>1", new ScalarValue(2)),
-                    new LogEventProperty("<todo - decide naming strategy>2", new ScalarValue(3)),
+                    new LogEventProperty("__0", new ScalarValue("__0")),
+                    new LogEventProperty("__1", new ScalarValue("__1")),
                 },
-                Capture("Hello {1} {0} 2}", 1, 0, 2, 3),
+                Capture("Hello {0} {1} nothing more", 0, 1, "__0", "__1"),
                 new LogEventPropertyStructuralEqualityComparer());
         }
 
-        [Fact(Skip="Proposed behaviour")]
+        [Fact]
+        public void WillCaptureAdditionalPositionalsNotInTemplatePreservingPositionsInTemplate()
+        {
+            Assert.Equal(new[]
+                {
+                    new LogEventProperty("0", new ScalarValue(0)),
+                    new LogEventProperty("1", new ScalarValue(1)),
+                    new LogEventProperty("__0", new ScalarValue("__0")),
+                    new LogEventProperty("__1", new ScalarValue("__1")),
+                },
+                Capture("Hello {1} {0} nothing more", 0, 1, "__0", "__1"),
+                new LogEventPropertyStructuralEqualityComparer());
+        }
+
+        [Fact]
         public void WillCaptureAdditionalNamedPropsNotInTemplate()
         {
             Assert.Equal(new[]
                 {
                     new LogEventProperty("who", new ScalarValue("who")),
                     new LogEventProperty("what", new ScalarValue("what")),
-                    new LogEventProperty("<todo - decide naming strategy>1", new ScalarValue("where")),
-                    new LogEventProperty("<todo - decide naming strategy>2", new ScalarValue("how")),
+                    new LogEventProperty("__0", new ScalarValue("__0")),
+                    new LogEventProperty("__1", new ScalarValue("__1")),
                 },
-                Capture("Hello {who} {what} where}", "who", "what", "where", "how"),
+                Capture("Hello {who} {what} where}", "who", "what", "__0", "__1"),
                 new LogEventPropertyStructuralEqualityComparer());
         }
         

--- a/test/Serilog.Tests/Core/LogEventPropertyCapturingTests.cs
+++ b/test/Serilog.Tests/Core/LogEventPropertyCapturingTests.cs
@@ -56,6 +56,19 @@ namespace Serilog.Tests.Core
         }
 
         [Fact]
+        public void WillCaptureProvidedPositionalValuesEvenIfSomeEarlierLowerNumberedAreMissing()
+        {
+            Assert.Equal(new[]
+                {
+                    new LogEventProperty("__0", new ScalarValue(0)),
+                    new LogEventProperty("1", new ScalarValue(1)),
+                    new LogEventProperty("2", new ScalarValue(2)),
+                },
+                Capture("Hello {1} {2} nothing more", 0, 1, 2), // missing {0}
+                new LogEventPropertyStructuralEqualityComparer());
+        }
+
+        [Fact]
         public void WillCaptureProvidedNamedValuesEvenIfSomeAreMissing()
         {
             Assert.Equal(new[]
@@ -108,7 +121,7 @@ namespace Serilog.Tests.Core
                 Capture("Hello {who} {what} where}", "who", "what", "__2", "__3"),
                 new LogEventPropertyStructuralEqualityComparer());
         }
-        
+
         static IEnumerable<LogEventProperty> Capture(string messageTemplate, params object[] properties)
         {
             var mt = new MessageTemplateParser().Parse(messageTemplate);

--- a/test/Serilog.Tests/Core/LogEventPropertyCapturingTests.cs
+++ b/test/Serilog.Tests/Core/LogEventPropertyCapturingTests.cs
@@ -6,7 +6,7 @@ using Serilog.Core;
 using Serilog.Events;
 using Serilog.Parameters;
 using Serilog.Parsing;
-
+using Serilog.Tests.Support;
 using Xunit;
 
 namespace Serilog.Tests.Core
@@ -130,101 +130,5 @@ namespace Serilog.Tests.Core
             return binder.ConstructProperties(mt, properties);
         }
 
-        [Fact]
-        public void StructuralEqualityComparerKindaSortaWorksForScalars()
-        {
-            var scalarStringA = new LogEventProperty("a", new ScalarValue("a"));
-            var scalarStringAStructurallyEqual = new LogEventProperty("a", new ScalarValue("a"));
-
-            var scalarStringB = new LogEventProperty("b", new ScalarValue("b"));
-            var scalarStringBStructurallyNotEqual = new LogEventProperty("b", new ScalarValue("notEqual"));
-
-            var scalarIntA1 = new LogEventProperty("a", new ScalarValue(1));
-            var scalarIntA1StructurallyEqual = new LogEventProperty("a", new ScalarValue(1));
-            var scalarIntA1DiffValueSameType = new LogEventProperty("a", new ScalarValue(0));
-            var scalarIntB1 = new LogEventProperty("b", new ScalarValue(1));
-
-            var guid1 = Guid.NewGuid();
-            var guid2 = Guid.NewGuid();
-            var scalarGuid1 = new LogEventProperty("1", new ScalarValue(guid1));
-            var scalarGuid1StructurallyEqual = new LogEventProperty("1", new ScalarValue(guid1));
-            var scalarGuid1StructurallyNotEqual = new LogEventProperty("1", new ScalarValue("notEqual"));
-            var scalarGuid2 = new LogEventProperty("2", new ScalarValue(guid2));
-
-            var sut = new LogEventPropertyStructuralEqualityComparer();
-
-            Assert.True(sut.Equals(scalarStringA, scalarStringAStructurallyEqual));
-            Assert.True(sut.Equals(scalarIntA1, scalarIntA1StructurallyEqual));
-            Assert.True(sut.Equals(scalarGuid1, scalarGuid1StructurallyEqual));
-
-            Assert.False(sut.Equals(scalarStringB, scalarStringBStructurallyNotEqual));
-            Assert.False(sut.Equals(scalarIntA1, scalarIntB1));
-            Assert.False(sut.Equals(scalarIntA1, scalarIntA1DiffValueSameType));
-
-            Assert.False(sut.Equals(scalarGuid1, scalarGuid2));
-            Assert.False(sut.Equals(scalarGuid1, scalarGuid1StructurallyNotEqual));
-        }
-
-        class LogEventPropertyStructuralEqualityComparer : IEqualityComparer<LogEventProperty>
-        {
-            readonly IEqualityComparer<LogEventPropertyValue> _valueEqualityComparer;
-
-            public LogEventPropertyStructuralEqualityComparer(
-                IEqualityComparer<LogEventPropertyValue> valueEqualityComparer = null)
-            {
-                this._valueEqualityComparer =
-                    valueEqualityComparer ?? new LogEventPropertyValueComparer(EqualityComparer<object>.Default);
-            }
-
-            public bool Equals(LogEventProperty x, LogEventProperty y)
-            {
-                return x.Name == y.Name
-                    && _valueEqualityComparer.Equals(x.Value, y.Value);
-            }
-
-            public int GetHashCode(LogEventProperty obj)
-            {
-                return 0;
-            }
-        }
-
-        class LogEventPropertyValueComparer : IEqualityComparer<LogEventPropertyValue>
-        {
-            readonly IEqualityComparer<object> _objectEqualityComparer;
-
-            public LogEventPropertyValueComparer(IEqualityComparer<object> objectEqualityComparer = null)
-            {
-                this._objectEqualityComparer = objectEqualityComparer ?? EqualityComparer<object>.Default;
-            }
-
-            public bool Equals(LogEventPropertyValue x, LogEventPropertyValue y)
-            {
-                var scalarX = x as ScalarValue;
-                var scalarY = y as ScalarValue;
-                if (scalarX != null && scalarY != null)
-                {
-                    return _objectEqualityComparer.Equals(scalarX.Value, scalarY.Value);
-                }
-                else if (x is SequenceValue && y is SequenceValue)
-                {
-                    throw new NotImplementedException();
-                }
-                else if (x is StructureValue && y is StructureValue)
-                {
-                    throw new NotImplementedException();
-                }
-                else if (x is DictionaryValue && y is DictionaryValue)
-                {
-                    throw new NotImplementedException();
-                }
-
-                throw new NotImplementedException();
-            }
-
-            public int GetHashCode(LogEventPropertyValue obj)
-            {
-                return 0;
-            }
-        }
     }
 }

--- a/test/Serilog.Tests/Core/LogEventPropertyCapturingTests.cs
+++ b/test/Serilog.Tests/Core/LogEventPropertyCapturingTests.cs
@@ -74,10 +74,10 @@ namespace Serilog.Tests.Core
                 {
                     new LogEventProperty("0", new ScalarValue(0)),
                     new LogEventProperty("1", new ScalarValue(1)),
-                    new LogEventProperty("__0", new ScalarValue("__0")),
-                    new LogEventProperty("__1", new ScalarValue("__1")),
+                    new LogEventProperty("__2", new ScalarValue("__2")),
+                    new LogEventProperty("__3", new ScalarValue("__3")),
                 },
-                Capture("Hello {0} {1} nothing more", 0, 1, "__0", "__1"),
+                Capture("Hello {0} {1} nothing more", 0, 1, "__2", "__3"),
                 new LogEventPropertyStructuralEqualityComparer());
         }
 
@@ -88,10 +88,10 @@ namespace Serilog.Tests.Core
                 {
                     new LogEventProperty("0", new ScalarValue(0)),
                     new LogEventProperty("1", new ScalarValue(1)),
-                    new LogEventProperty("__0", new ScalarValue("__0")),
-                    new LogEventProperty("__1", new ScalarValue("__1")),
+                    new LogEventProperty("__2", new ScalarValue("__2")),
+                    new LogEventProperty("__3", new ScalarValue("__3")),
                 },
-                Capture("Hello {1} {0} nothing more", 0, 1, "__0", "__1"),
+                Capture("Hello {1} {0} nothing more", 0, 1, "__2", "__3"),
                 new LogEventPropertyStructuralEqualityComparer());
         }
 
@@ -102,10 +102,10 @@ namespace Serilog.Tests.Core
                 {
                     new LogEventProperty("who", new ScalarValue("who")),
                     new LogEventProperty("what", new ScalarValue("what")),
-                    new LogEventProperty("__0", new ScalarValue("__0")),
-                    new LogEventProperty("__1", new ScalarValue("__1")),
+                    new LogEventProperty("__2", new ScalarValue("__2")),
+                    new LogEventProperty("__3", new ScalarValue("__3")),
                 },
-                Capture("Hello {who} {what} where}", "who", "what", "__0", "__1"),
+                Capture("Hello {who} {what} where}", "who", "what", "__2", "__3"),
                 new LogEventPropertyStructuralEqualityComparer());
         }
         

--- a/test/Serilog.Tests/Support/LogEventPropertyStructuralEqualityComparer.cs
+++ b/test/Serilog.Tests/Support/LogEventPropertyStructuralEqualityComparer.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using Serilog.Events;
 
@@ -16,6 +17,9 @@ namespace Serilog.Tests.Support
 
         public bool Equals(LogEventProperty x, LogEventProperty y)
         {
+            if (x == null || y == null)
+                return false; // throw new Exception($"the comparer doesn't support nulls, x={x}, y={y}");
+
             return x.Name == y.Name
                    && _valueEqualityComparer.Equals(x.Value, y.Value);
         }

--- a/test/Serilog.Tests/Support/LogEventPropertyStructuralEqualityComparer.cs
+++ b/test/Serilog.Tests/Support/LogEventPropertyStructuralEqualityComparer.cs
@@ -1,0 +1,28 @@
+using System.Collections.Generic;
+using Serilog.Events;
+
+namespace Serilog.Tests.Support
+{
+    class LogEventPropertyStructuralEqualityComparer : IEqualityComparer<LogEventProperty>
+    {
+        readonly IEqualityComparer<LogEventPropertyValue> _valueEqualityComparer;
+
+        public LogEventPropertyStructuralEqualityComparer(
+            IEqualityComparer<LogEventPropertyValue> valueEqualityComparer = null)
+        {
+            this._valueEqualityComparer =
+                valueEqualityComparer ?? new LogEventPropertyValueComparer(EqualityComparer<object>.Default);
+        }
+
+        public bool Equals(LogEventProperty x, LogEventProperty y)
+        {
+            return x.Name == y.Name
+                   && _valueEqualityComparer.Equals(x.Value, y.Value);
+        }
+
+        public int GetHashCode(LogEventProperty obj)
+        {
+            return 0;
+        }
+    }
+}

--- a/test/Serilog.Tests/Support/LogEventPropertyStructuralEqualityComparerTests.cs
+++ b/test/Serilog.Tests/Support/LogEventPropertyStructuralEqualityComparerTests.cs
@@ -1,0 +1,44 @@
+using System;
+using Serilog.Events;
+using Xunit;
+
+namespace Serilog.Tests.Support
+{
+    public class LogEventPropertyStructuralEqualityComparerTests
+    {
+        [Fact]
+        public void LogEventPropertyStructuralEqualityComparerWorksForScalars()
+        {
+            var scalarStringA = new LogEventProperty("a", new ScalarValue("a"));
+            var scalarStringAStructurallyEqual = new LogEventProperty("a", new ScalarValue("a"));
+
+            var scalarStringB = new LogEventProperty("b", new ScalarValue("b"));
+            var scalarStringBStructurallyNotEqual = new LogEventProperty("b", new ScalarValue("notEqual"));
+
+            var scalarIntA1 = new LogEventProperty("a", new ScalarValue(1));
+            var scalarIntA1StructurallyEqual = new LogEventProperty("a", new ScalarValue(1));
+            var scalarIntA1DiffValueSameType = new LogEventProperty("a", new ScalarValue(0));
+            var scalarIntB1 = new LogEventProperty("b", new ScalarValue(1));
+
+            var guid1 = Guid.NewGuid();
+            var guid2 = Guid.NewGuid();
+            var scalarGuid1 = new LogEventProperty("1", new ScalarValue(guid1));
+            var scalarGuid1StructurallyEqual = new LogEventProperty("1", new ScalarValue(guid1));
+            var scalarGuid1StructurallyNotEqual = new LogEventProperty("1", new ScalarValue("notEqual"));
+            var scalarGuid2 = new LogEventProperty("2", new ScalarValue(guid2));
+
+            var sut = new LogEventPropertyStructuralEqualityComparer();
+
+            Assert.True(sut.Equals(scalarStringA, scalarStringAStructurallyEqual));
+            Assert.True(sut.Equals(scalarIntA1, scalarIntA1StructurallyEqual));
+            Assert.True(sut.Equals(scalarGuid1, scalarGuid1StructurallyEqual));
+
+            Assert.False(sut.Equals(scalarStringB, scalarStringBStructurallyNotEqual));
+            Assert.False(sut.Equals(scalarIntA1, scalarIntB1));
+            Assert.False(sut.Equals(scalarIntA1, scalarIntA1DiffValueSameType));
+
+            Assert.False(sut.Equals(scalarGuid1, scalarGuid2));
+            Assert.False(sut.Equals(scalarGuid1, scalarGuid1StructurallyNotEqual));
+        }
+    }
+}

--- a/test/Serilog.Tests/Support/LogEventPropertyStructuralEqualityComparerTests.cs
+++ b/test/Serilog.Tests/Support/LogEventPropertyStructuralEqualityComparerTests.cs
@@ -16,6 +16,42 @@ namespace Serilog.Tests.Support
         }
 
         [Fact]
+        public void LogEventPropertyStructuralEqualityComparerWorksForSequences()
+        {
+            var intStringDoubleScalarArray =
+                new[] { new ScalarValue(1), new ScalarValue("2"), new ScalarValue(3.0), };
+
+            var intStringFloatScalarArray =
+                new[] { new ScalarValue("1"), new ScalarValue(2), new ScalarValue(3.0f), };
+
+            var sequenceOfScalarsIntStringDoubleA = new LogEventProperty("a", new SequenceValue(intStringDoubleScalarArray));
+
+            var sequenceOfScalarsIntStringDoubleAStructurallyEqual = new LogEventProperty("a",
+                new SequenceValue(new[] { new ScalarValue(1), new ScalarValue("2"), new ScalarValue(3.0), }));
+
+            var sequenceOfScalarsIntStringDoubleAStructurallyNotEqual = new LogEventProperty("a",
+                new SequenceValue(new [] { new ScalarValue(1), new ScalarValue("2"), new ScalarValue(3.1), }));
+
+            var sequenceOfScalarsIntStringFloatA = new LogEventProperty("a", new ScalarValue(intStringFloatScalarArray));
+
+            var sequenceOfScalarsIntStringDoubleB = new LogEventProperty("b", new SequenceValue(intStringDoubleScalarArray));
+
+            var sut = new LogEventPropertyStructuralEqualityComparer();
+
+            // Structurally equal
+            Assert.True(sut.Equals(sequenceOfScalarsIntStringDoubleA, sequenceOfScalarsIntStringDoubleAStructurallyEqual));
+
+            // Not equal due to having a different property name (but otherwise structurally equal)
+            Assert.False(sut.Equals(sequenceOfScalarsIntStringDoubleA, sequenceOfScalarsIntStringDoubleB));
+            
+            // Structurally not equal because element 3 has a different value
+            Assert.False(sut.Equals(sequenceOfScalarsIntStringDoubleA, sequenceOfScalarsIntStringDoubleAStructurallyNotEqual));
+
+            // Strucrtually not equal because element 3 has a different underlying value and type
+            Assert.False(sut.Equals(sequenceOfScalarsIntStringDoubleA, sequenceOfScalarsIntStringFloatA));
+        }
+
+        [Fact]
         public void LogEventPropertyStructuralEqualityComparerWorksForScalars()
         {
             var scalarStringA = new LogEventProperty("a", new ScalarValue("a"));

--- a/test/Serilog.Tests/Support/LogEventPropertyStructuralEqualityComparerTests.cs
+++ b/test/Serilog.Tests/Support/LogEventPropertyStructuralEqualityComparerTests.cs
@@ -7,6 +7,15 @@ namespace Serilog.Tests.Support
     public class LogEventPropertyStructuralEqualityComparerTests
     {
         [Fact]
+        public void HandlesNullAsNotEqual()
+        {
+            var sut = new LogEventPropertyStructuralEqualityComparer();
+            Assert.False(sut.Equals(null, new LogEventProperty("a", new ScalarValue(null))));
+            Assert.False(sut.Equals(new LogEventProperty("a", new ScalarValue(null)), null));
+            Assert.False(sut.Equals(null, null));
+        }
+
+        [Fact]
         public void LogEventPropertyStructuralEqualityComparerWorksForScalars()
         {
             var scalarStringA = new LogEventProperty("a", new ScalarValue("a"));

--- a/test/Serilog.Tests/Support/LogEventPropertyValueComparer.cs
+++ b/test/Serilog.Tests/Support/LogEventPropertyValueComparer.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Serilog.Events;
 
 namespace Serilog.Tests.Support
@@ -21,9 +22,13 @@ namespace Serilog.Tests.Support
             {
                 return _objectEqualityComparer.Equals(scalarX.Value, scalarY.Value);
             }
-            else if (x is SequenceValue && y is SequenceValue)
+
+            var sequenceX = x as SequenceValue;
+            var sequenceY = y as SequenceValue;
+            if (sequenceX != null && sequenceY != null)
             {
-                throw new NotImplementedException();
+                return sequenceX.Elements
+                    .SequenceEqual(sequenceY.Elements, this);
             }
             else if (x is StructureValue && y is StructureValue)
             {
@@ -34,7 +39,7 @@ namespace Serilog.Tests.Support
                 throw new NotImplementedException();
             }
 
-            throw new NotImplementedException();
+            return false;
         }
 
         public int GetHashCode(LogEventPropertyValue obj)

--- a/test/Serilog.Tests/Support/LogEventPropertyValueComparer.cs
+++ b/test/Serilog.Tests/Support/LogEventPropertyValueComparer.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Collections.Generic;
+using Serilog.Events;
+
+namespace Serilog.Tests.Support
+{
+    class LogEventPropertyValueComparer : IEqualityComparer<LogEventPropertyValue>
+    {
+        readonly IEqualityComparer<object> _objectEqualityComparer;
+
+        public LogEventPropertyValueComparer(IEqualityComparer<object> objectEqualityComparer = null)
+        {
+            this._objectEqualityComparer = objectEqualityComparer ?? EqualityComparer<object>.Default;
+        }
+
+        public bool Equals(LogEventPropertyValue x, LogEventPropertyValue y)
+        {
+            var scalarX = x as ScalarValue;
+            var scalarY = y as ScalarValue;
+            if (scalarX != null && scalarY != null)
+            {
+                return _objectEqualityComparer.Equals(scalarX.Value, scalarY.Value);
+            }
+            else if (x is SequenceValue && y is SequenceValue)
+            {
+                throw new NotImplementedException();
+            }
+            else if (x is StructureValue && y is StructureValue)
+            {
+                throw new NotImplementedException();
+            }
+            else if (x is DictionaryValue && y is DictionaryValue)
+            {
+                throw new NotImplementedException();
+            }
+
+            throw new NotImplementedException();
+        }
+
+        public int GetHashCode(LogEventPropertyValue obj)
+        {
+            return 0;
+        }
+    }
+}


### PR DESCRIPTION
Opening PR for discussion. This attempts to address #737.

Consider the following scenario:
```csharp
log.Information("Hello, {name}, you have outcome}", "Adam", "Failed");
```

The message template above was accidentally malformed, missing the opening brace before outcome}. Serilog currently would recognise and match the {name} field, but would totally ignore the {outcome} field because it doesn't have a corresponding/matching valid placeholder field in the message template. Because we provided the 2nd argument value "Failed", Serilog would write a warning to SelfLog as follows:

> 2016-05-11T09:32:39 Named property count does not match parameter count: Hello, {name}, you have outcome}

I believe Serilog should include the "Failed" value with some default/obvious name instead of dropping / ignoring the value.

## Issues

### Functionality
- [x] ~~Decide if it's a breaking change, and therefore if it needs to be in a major release~~ So far it doesn't seem to be - and probabaly will go into 2.0 anyway.
- [x] Decide how to name extra parameters that are not in the message template

### Testing strategy
- [x] ~~Decide if tests should work against the internal `PropertyBinder`~~ Seems OK
- [x] ~~Decide if `IEqualityComparer<LogEventProperty>` is appropriate~~ Seems OK
 
