### PR TITLE
Removes a redundant `ToArray()` call from `ForContext()`

### DIFF
--- a/src/Serilog/Core/Logger.cs
+++ b/src/Serilog/Core/Logger.cs
@@ -46,7 +46,7 @@ namespace Serilog.Core
             MessageTemplateProcessor messageTemplateProcessor,
             LogEventLevel minimumLevel,
             ILogEventSink sink,
-            IEnumerable<ILogEventEnricher> enrichers,
+            ILogEventEnricher[] enrichers,
             Action dispose = null)
             : this(messageTemplateProcessor, minimumLevel, sink, enrichers, dispose, null)
         {
@@ -56,7 +56,7 @@ namespace Serilog.Core
             MessageTemplateProcessor messageTemplateProcessor,
             LoggingLevelSwitch levelSwitch,
             ILogEventSink sink,
-            IEnumerable<ILogEventEnricher> enrichers,
+            ILogEventEnricher[] enrichers,
             Action dispose = null)
             : this(messageTemplateProcessor, LevelAlias.Minimum, sink, enrichers, dispose, levelSwitch)
         {
@@ -66,7 +66,7 @@ namespace Serilog.Core
             MessageTemplateProcessor messageTemplateProcessor,
             LogEventLevel minimumLevel,
             ILogEventSink sink,
-            IEnumerable<ILogEventEnricher> enrichers,
+            ILogEventEnricher[] enrichers,
             Action dispose = null,
             LoggingLevelSwitch levelSwitch = null)
         {
@@ -78,7 +78,7 @@ namespace Serilog.Core
             _sink = sink;
             _dispose = dispose;
             _levelSwitch = levelSwitch;
-            _enrichers = enrichers.ToArray();
+            _enrichers = enrichers;
         }
 
         /// <summary>

--- a/src/Serilog/LoggerConfiguration.cs
+++ b/src/Serilog/LoggerConfiguration.cs
@@ -152,8 +152,8 @@ namespace Serilog
             var processor = new MessageTemplateProcessor(converter);
 
             return _levelSwitch == null ?
-                new Logger(processor, _minimumLevel, sink, _enrichers, dispose) :
-                new Logger(processor, _levelSwitch, sink, _enrichers, dispose);
+                new Logger(processor, _minimumLevel, sink, _enrichers.ToArray(), dispose) :
+                new Logger(processor, _levelSwitch, sink, _enrichers.ToArray(), dispose);
         }
     }
 }


### PR DESCRIPTION
Since the `Logger()` constructor is only called internally, and there's already a "sanitizing" `ToArray()` call covering the `IEnumerable<ILogEventEnricher>` supplied by the user in `ForContext()`, we can skip the one in `Logger`'s constructor:

```diff
-            _enrichers = enrichers.ToArray();
+            _enrichers = enrichers;
```