### PR TITLE
Optimize ForContext() by removing allocations

### DIFF
--- a/src/Serilog/Core/Enrichers/EmptyEnricher.cs
+++ b/src/Serilog/Core/Enrichers/EmptyEnricher.cs
@@ -1,0 +1,25 @@
+﻿// Copyright 2013-2015 Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Serilog.Events;
+
+namespace Serilog.Core.Enrichers
+{
+    class EmptyEnricher : ILogEventEnricher
+    {
+        public void Enrich(LogEvent logEvent, ILogEventPropertyFactory propertyFactory)
+        {
+        }
+    }
+}

--- a/src/Serilog/Core/Enrichers/SafeAggregateEnricher.cs
+++ b/src/Serilog/Core/Enrichers/SafeAggregateEnricher.cs
@@ -1,0 +1,48 @@
+﻿// Copyright 2013-2015 Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Serilog.Debugging;
+using Serilog.Events;
+
+namespace Serilog.Core.Enrichers
+{
+    class SafeAggregateEnricher : ILogEventEnricher
+    {
+        readonly ILogEventEnricher[] _enrichers;
+
+        public SafeAggregateEnricher(IEnumerable<ILogEventEnricher> enrichers)
+        {
+            if (enrichers == null) throw new ArgumentNullException(nameof(enrichers));
+            _enrichers = enrichers.ToArray();
+        }
+
+        public void Enrich(LogEvent logEvent, ILogEventPropertyFactory propertyFactory)
+        {
+            foreach (var enricher in _enrichers)
+            {
+                try
+                {
+                    enricher.Enrich(logEvent, propertyFactory);
+                }
+                catch (Exception ex)
+                {
+                    SelfLog.WriteLine("Exception {0} caught while enriching {1} with {2}.", ex, logEvent, enricher);
+                }
+            }
+        }
+    }
+}

--- a/src/Serilog/Core/Pipeline/SilentLogger.cs
+++ b/src/Serilog/Core/Pipeline/SilentLogger.cs
@@ -20,6 +20,11 @@ namespace Serilog.Core.Pipeline
 {
     class SilentLogger : ILogger
     {
+        public ILogger ForContext(ILogEventEnricher enricher)
+        {
+            return this;
+        }
+
         public ILogger ForContext(IEnumerable<ILogEventEnricher> enrichers)
         {
             return this;

--- a/src/Serilog/Core/Sinks/FilteringSink.cs
+++ b/src/Serilog/Core/Sinks/FilteringSink.cs
@@ -15,6 +15,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Serilog.Debugging;
 using Serilog.Events;
 
 namespace Serilog.Core.Sinks
@@ -34,13 +35,20 @@ namespace Serilog.Core.Sinks
 
         public void Emit(LogEvent logEvent)
         {
-            foreach (var logEventFilter in _filters)
+            try
             {
-                if (!logEventFilter.IsEnabled(logEvent))
-                    return;
-            }
+                foreach (var logEventFilter in _filters)
+                {
+                    if (!logEventFilter.IsEnabled(logEvent))
+                        return;
+                }
 
-            _sink.Emit(logEvent);
+                _sink.Emit(logEvent);
+            }
+            catch (Exception ex)
+            {
+                SelfLog.WriteLine("Caught exception {0} while applying filters.", ex);
+            }
         }
     }
 }

--- a/src/Serilog/ILogger.cs
+++ b/src/Serilog/ILogger.cs
@@ -24,7 +24,7 @@ namespace Serilog
     /// </summary>
     /// <example>
     /// var log = new LoggerConfiguration()
-    ///     .WithConsoleSink()
+    ///     .WriteTo.Console()
     ///     .CreateLogger();
     ///
     /// var thing = "World";
@@ -36,6 +36,13 @@ namespace Serilog
     /// </remarks>
     public interface ILogger
     {
+        /// <summary>
+        /// Create a logger that enriches log events via the provided enrichers.
+        /// </summary>
+        /// <param name="enricher">Enricher that applies in the context.</param>
+        /// <returns>A logger that will enrich log events as specified.</returns>
+        ILogger ForContext(ILogEventEnricher enricher);
+
         /// <summary>
         /// Create a logger that enriches log events via the provided enrichers.
         /// </summary>

--- a/src/Serilog/Log.cs
+++ b/src/Serilog/Log.cs
@@ -68,6 +68,16 @@ namespace Serilog
         /// <summary>
         /// Create a logger that enriches log events via the provided enrichers.
         /// </summary>
+        /// <param name="enricher">Enricher that applies in the context.</param>
+        /// <returns>A logger that will enrich log events as specified.</returns>
+        public static ILogger ForContext(ILogEventEnricher enricher)
+        {
+            return Logger.ForContext(enricher);
+        }
+
+        /// <summary>
+        /// Create a logger that enriches log events via the provided enrichers.
+        /// </summary>
         /// <param name="enrichers">Enrichers that apply in the context.</param>
         /// <returns>A logger that will enrich log events as specified.</returns>
         public static ILogger ForContext(ILogEventEnricher[] enrichers)

--- a/test/Serilog.Tests/Support/DisposableLogger.cs
+++ b/test/Serilog.Tests/Support/DisposableLogger.cs
@@ -14,6 +14,11 @@ namespace Serilog.Tests.Support
             Disposed = true;
         }
 
+        public ILogger ForContext(ILogEventEnricher enricher)
+        {
+            throw new NotImplementedException();
+        }
+
         public ILogger ForContext(IEnumerable<ILogEventEnricher> enrichers)
         {
             throw new NotImplementedException();


### PR DESCRIPTION
The `ForContext()` set of methods are performance and allocation-sensitive because they're on the code path even when logging is off or at a level that produces few events. The change speeds up `ForContext()` by almost 4x in common usage.

This is one of three incoming 2.0 PRs that break `ILogger`, so ideally won't be merged until all three are ready.

## Breaking change

**Adds `ForContext(ILogEventEnricher)` to `ILogger`, thus a breaking change.**

Impact should be low - will not break packages that consume `ILogger`, but will break code that implements it.

## Measurements

Most of the allocations were due to `ForContext()` requiring a list or enrichers - since most `ForContext()` calls are to add a single property, this is hugely wasteful - array allocations, iteration, etc.

The PR shifts `Logger` to call through a single enricher, and if more than one is provided a new `SafeAggregateEnricher` (internal) replicates the existing behaviour.

Benchmark is:

```csharp
var logger = new LoggerConfiguration()
    .WriteTo.Console()
    .CreateLogger();

var sw = Stopwatch.StartNew();

for (var i = 0; i < 10000000; ++i)
{
    var ctx = logger.ForContext("I", i);
    if (i == 9999999)
        ctx.Information("Event!");
}

Console.WriteLine(sw.Elapsed);
```

Best of three runs timing:

 * 4.30 sec for Serilog 2.0 RC on .NET 4.6
 * 1.08 sec for the patched version, same configuration

Existing code the calls `ForContext(p, q)` will benefit without modification.

## Other changes

* Since auditing is no longer an interesting scenario, an additional indirection through `SafeAggregateSink` has been eliminated when filters are active.
* A couple of `Logger` methods that could throw were fixed
