### PR TITLE
Add BindMessageTemplate() and BindProperty() to ILogger

### DIFF
--- a/src/Serilog/Core/Pipeline/SilentLogger.cs
+++ b/src/Serilog/Core/Pipeline/SilentLogger.cs
@@ -118,5 +118,19 @@ namespace Serilog.Core.Pipeline
         public void Fatal(Exception exception, string messageTemplate, params object[] propertyValues)
         {
         }
+
+        [MessageTemplateFormatMethod("messageTemplate")]
+        public bool BindMessageTemplate(string messageTemplate, object[] propertyValues, out MessageTemplate parsedTemplate, out IEnumerable<LogEventProperty> boundProperties)
+        {
+            parsedTemplate = null;
+            boundProperties = null;
+            return false;
+        }
+
+        public bool BindProperty(string propertyName, object value, bool destructureObjects, out LogEventProperty property)
+        {
+            property = null;
+            return false;
+        }
     }
 }

--- a/src/Serilog/ILogger.cs
+++ b/src/Serilog/ILogger.cs
@@ -46,6 +46,10 @@ namespace Serilog
         /// <summary>
         /// Create a logger that enriches log events with the specified property.
         /// </summary>
+        /// <param name="propertyName">The name of the property. Must be non-empty.</param>
+        /// <param name="value">The property value.</param>
+        /// <param name="destructureObjects">If true, the value will be serialized as a structured
+        /// object if possible; if false, the object will be recorded as a scalar or simple array.</param>
         /// <returns>A logger that will enrich log events as specified.</returns>
         ILogger ForContext(string propertyName, object value, bool destructureObjects = false);
 
@@ -235,5 +239,42 @@ namespace Serilog
         /// </example>
         [MessageTemplateFormatMethod("messageTemplate")]
         void Fatal(Exception exception, string messageTemplate, params object[] propertyValues);
+
+        /// <summary>
+        /// Uses configured scalar conversion and destructuring rules to bind a set of properties to a
+        /// message template. Returns false if the template or values are invalid (<summary>ILogger</summary>
+        /// methods never throw exceptions).
+        /// </summary>
+        /// <param name="messageTemplate">Message template describing an event.</param>
+        /// <param name="propertyValues">Objects positionally formatted into the message template.</param>
+        /// <param name="parsedTemplate">The internal representation of the template, which may be used to
+        /// render the <paramref name="boundProperties"/> as text.</param>
+        /// <param name="boundProperties">Captured properties from the template and <paramref name="propertyValues"/>.</param>
+        /// <example>
+        /// MessageTemplate template;
+        /// IEnumerable&lt;LogEventProperty&gt; properties>;
+        /// if (Log.BindMessageTemplate("Hello, {Name}!", new[] { "World" }, out template, out properties)
+        /// {
+        ///     var propsByName = properties.ToDictionary(p => p.Name, p => p.Value);
+        ///     Console.WriteLine(template.Render(propsByName, null));
+        ///     // -> "Hello, World!"
+        /// }
+        /// </example>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        bool BindMessageTemplate(string messageTemplate, object[] propertyValues,
+                                 out MessageTemplate parsedTemplate, out IEnumerable<LogEventProperty> boundProperties);
+
+        /// <summary>
+        /// Uses configured scalar conversion and destructuring rules to bind a property value to its captured
+        /// representation.
+        /// </summary>
+        /// <returns>True if the property could be bound, otherwise false (<summary>ILogger</summary>
+        /// <param name="propertyName">The name of the property. Must be non-empty.</param>
+        /// <param name="value">The property value.</param>
+        /// <param name="destructureObjects">If true, the value will be serialized as a structured
+        /// object if possible; if false, the object will be recorded as a scalar or simple array.</param>
+        /// <param name="property">The resulting property.</param>
+        /// methods never throw exceptions).</returns>
+        bool BindProperty(string propertyName, object value, bool destructureObjects, out LogEventProperty property);
     }
 }

--- a/src/Serilog/Log.cs
+++ b/src/Serilog/Log.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using System;
+using System.Collections.Generic;
 using System.Threading;
 using Serilog.Core;
 using Serilog.Core.Pipeline;
@@ -985,6 +986,32 @@ namespace Serilog
         public static void Fatal(Exception exception, string messageTemplate, params object[] propertyValues)
         {
             Logger.Fatal(exception, messageTemplate, propertyValues);
+        }
+
+        /// <summary>
+        /// Uses configured scalar conversion and destructuring rules to bind a set of properties to a
+        /// message template. Returns false if the template or values are invalid (<summary>ILogger</summary>
+        /// methods never throw exceptions).
+        /// </summary>
+        /// <param name="messageTemplate">Message template describing an event.</param>
+        /// <param name="propertyValues">Objects positionally formatted into the message template.</param>
+        /// <param name="parsedTemplate">The internal representation of the template, which may be used to
+        /// render the <paramref name="boundProperties"/> as text.</param>
+        /// <param name="boundProperties">Captured properties from the template and <paramref name="propertyValues"/>.</param>
+        /// <example>
+        /// MessageTemplate template;
+        /// IEnumerable&lt;LogEventProperty&gt; properties>;
+        /// if (Log.BindMessageTemplate("Hello, {Name}!", new[] { "World" }, out template, out properties)
+        /// {
+        ///     var propsByName = properties.ToDictionary(p => p.Name, p => p.Value);
+        ///     Console.WriteLine(template.Render(propsByName, null));
+        ///     // -> "Hello, World!"
+        /// }
+        /// </example>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        public static bool BindMessageTemplate(string messageTemplate, object[] propertyValues, out MessageTemplate parsedTemplate, out IEnumerable<LogEventProperty> boundProperties)
+        {
+            return Logger.BindMessageTemplate(messageTemplate, propertyValues, out parsedTemplate, out boundProperties);
         }
     }
 }

--- a/test/Serilog.Tests/Core/LoggerTests.cs
+++ b/test/Serilog.Tests/Core/LoggerTests.cs
@@ -18,9 +18,11 @@ namespace Serilog.Tests.Core
 
             var l = new LoggerConfiguration()
                 .WriteTo.Sink(new StringSink())
-                .Enrich.With(new DelegatingEnricher((le, pf) => {
+                .Enrich.With(new DelegatingEnricher((le, pf) =>
+                {
                     thrown = true;
-                    throw new Exception("No go, pal."); }))
+                    throw new Exception("No go, pal.");
+                }))
                 .CreateLogger();
 
             l.Information(Some.String());
@@ -32,7 +34,7 @@ namespace Serilog.Tests.Core
         public void AContextualLoggerAddsTheSourceTypeName()
         {
             var evt = DelegatingSink.GetLogEvent(l => l.ForContext<LoggerTests>()
-                                        .Information(Some.String()));
+                .Information(Some.String()));
 
             var lv = evt.Properties[Constants.SourceContextPropertyName].LiteralValue();
             Assert.Equal(typeof(LoggerTests).FullName, lv);
@@ -45,8 +47,8 @@ namespace Serilog.Tests.Core
             var v1 = Some.Int();
             var v2 = Some.Int();
             var evt = DelegatingSink.GetLogEvent(l => l.ForContext(name, v1)
-                                        .ForContext(name, v2)
-                                        .Write(Some.InformationEvent()));
+                .ForContext(name, v2)
+                .Write(Some.InformationEvent()));
 
             var pActual = evt.Properties[name];
             Assert.Equal(v2, pActual.LiteralValue());
@@ -86,6 +88,33 @@ namespace Serilog.Tests.Core
 
             Assert.Equal(4, events.Count);
             Assert.True(events.All(evt => evt.RenderMessage() == "Emitted"));
+        }
+
+        [Fact]
+        public void MessageTemplatesCanBeBound()
+        {
+            var log = new LoggerConfiguration()
+                .CreateLogger();
+
+            MessageTemplate template;
+            IEnumerable<LogEventProperty> properties;
+            Assert.True(log.BindMessageTemplate("Hello, {Name}!", new object[] { "World" }, out template, out properties));
+
+            Assert.Equal("Hello, {Name}!", template.Text);
+            Assert.Equal("World", properties.Single().Value.LiteralValue());
+        }
+
+        [Fact]
+        public void PropertiesCanBeBound()
+        {
+            var log = new LoggerConfiguration()
+                .CreateLogger();
+
+            LogEventProperty property;
+            Assert.True(log.BindProperty("Name", "World", false, out property));
+
+            Assert.Equal("Name", property.Name);
+            Assert.Equal("World", property.Value.LiteralValue());
         }
     }
 }

--- a/test/Serilog.Tests/Support/DisposableLogger.cs
+++ b/test/Serilog.Tests/Support/DisposableLogger.cs
@@ -113,5 +113,15 @@ namespace Serilog.Tests.Support
         {
             throw new NotImplementedException();
         }
+
+        public bool BindMessageTemplate(string messageTemplate, object[] propertyValues, out MessageTemplate parsedTemplate, out IEnumerable<LogEventProperty> boundProperties)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool BindProperty(string propertyName, object value, bool destructureObjects, out LogEventProperty property)
+        {
+            throw new NotImplementedException();
+        }
     }
 }


### PR DESCRIPTION
## Breaking change

Adds two methods to `ILogger`. Change 2 of 3.

## Details

A modification of Proposal 1 from #746

```csharp
MessageTemplate messageTemplate;
IEnumerable<LogEventProperty> properties;
if (!logger.BindMessageTemplate("Some {Number}", new object[] { 42 }))
    return;

var evt = logger.CreateEvent(DateTimeOffset.Now, level, exception, messageTemplate, properties);

LogEventProperty ticksProperty;
if (logger.CreateProperty("Ticks", 123, false, out ticksProperty))
    evt.AddOrUpdateProperty(ticksProperty);

LogEventProperty userProperty;
if (logger.CreateProperty("User", user, true, out userProperty))
    evt.AddOrUpdateProperty(userProperty);

logger.Write(evt);
```

Not the prettiest API in the world, but:

 * Keeps things orthogonal - there's already a public constructor on `LogEvent` so there's no need to return one
 * Maps 1:1 with what `Logger` internally needs to do, so adds little/no overhead
 * The methods can fail, but `ILogger` never throws - hence the `bool` return types

Notes:

Internally, `Logger.Write()` makes allowances for calls like:

```csharp
var myInts = new[] { 1, 2, 3 };
log.Information("Numbers are {Ints}", myInts);
```

https://github.com/serilog/serilog/blob/dev/src/Serilog/Core/Logger.cs#L174

The C# binder will consider the `int[]` as covariant with `object[]`, and so without our little hack, `Ints` ends up with the value `1`.

This behavior is _not_ propagated by `BindMessageTemplate()`, since that API is designed for programmatic scenarios we can't foresee and might break via the heuristic mentioned above.