### PR TITLE
Add allocation-saving generic overloads to ILogger

### DIFF
--- a/src/Serilog/Core/Logger.cs
+++ b/src/Serilog/Core/Logger.cs
@@ -29,6 +29,8 @@ namespace Serilog.Core
     /// </summary>
     public sealed class Logger : ILogger, ILogEventSink, IDisposable
     {
+        static readonly object[] NoPropertyValues = new object[0];
+
         readonly MessageTemplateProcessor _messageTemplateProcessor;
         readonly ILogEventSink _sink;
         readonly Action _dispose;
@@ -136,6 +138,21 @@ namespace Serilog.Core
         /// </summary>
         /// <param name="level">The level of the event.</param>
         /// <param name="messageTemplate">Message template describing the event.</param>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        public void Write(LogEventLevel level, string messageTemplate)
+        {
+            // Avoid the array allocation and any boxing allocations when the level isn't enabled
+            if (IsEnabled(level))
+            {
+                Write(level, messageTemplate, NoPropertyValues);
+            }
+        }
+
+        /// <summary>
+        /// Write a log event with the specified level.
+        /// </summary>
+        /// <param name="level">The level of the event.</param>
+        /// <param name="messageTemplate">Message template describing the event.</param>
         /// <param name="propertyValue">Object positionally formatted into the message template.</param>
         [MessageTemplateFormatMethod("messageTemplate")]
         public void Write<T>(LogEventLevel level, string messageTemplate, T propertyValue)
@@ -202,13 +219,28 @@ namespace Serilog.Core
         /// <returns>True if the level is enabled; otherwise, false.</returns>
         public bool IsEnabled(LogEventLevel level)
         {
-            if ((int)level < (int)_minimumLevel)
+            if ((int) level < (int) _minimumLevel)
                 return false;
 
             return _levelSwitch == null ||
-                (int)level >= (int)_levelSwitch.MinimumLevel;
+                   (int) level >= (int) _levelSwitch.MinimumLevel;
         }
 
+        /// <summary>
+        /// Write a log event with the specified level and associated exception.
+        /// </summary>
+        /// <param name="level">The level of the event.</param>
+        /// <param name="exception">Exception related to the event.</param>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        public void Write(LogEventLevel level, Exception exception, string messageTemplate)
+        {
+            // Avoid the array allocation and any boxing allocations when the level isn't enabled
+            if (IsEnabled(level))
+            {
+                Write(level, exception, messageTemplate, NoPropertyValues);
+            }
+        }
 
         /// <summary>
         /// Write a log event with the specified level and associated exception.
@@ -330,6 +362,19 @@ namespace Serilog.Core
         /// Write a log event with the <see cref="LogEventLevel.Verbose"/> level.
         /// </summary>
         /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <example>
+        /// Log.Verbose("Staring into space, wondering if we're alone.");
+        /// </example>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        public void Verbose(string messageTemplate)
+        {
+            Write(LogEventLevel.Verbose, messageTemplate, NoPropertyValues);
+        }
+
+        /// <summary>
+        /// Write a log event with the <see cref="LogEventLevel.Verbose"/> level.
+        /// </summary>
+        /// <param name="messageTemplate">Message template describing the event.</param>
         /// <param name="propertyValue">Object positionally formatted into the message template.</param>
         /// <example>
         /// Log.Verbose("Staring into space, wondering if we're alone.");
@@ -383,6 +428,20 @@ namespace Serilog.Core
         public void Verbose(string messageTemplate, params object[] propertyValues)
         {
             Verbose((Exception)null, messageTemplate, propertyValues);
+        }
+
+        /// <summary>
+        /// Write a log event with the <see cref="LogEventLevel.Verbose"/> level and associated exception.
+        /// </summary>
+        /// <param name="exception">Exception related to the event.</param>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <example>
+        /// Log.Verbose(ex, "Staring into space, wondering where this comet came from.");
+        /// </example>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        public void Verbose(Exception exception, string messageTemplate)
+        {
+            Write(LogEventLevel.Verbose, exception, messageTemplate, NoPropertyValues);
         }
 
         /// <summary>
@@ -452,6 +511,19 @@ namespace Serilog.Core
         /// Write a log event with the <see cref="LogEventLevel.Debug"/> level.
         /// </summary>
         /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <example>
+        /// Log.Debug("Starting up at {StartedAt}.", DateTime.Now);
+        /// </example>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        public void Debug(string messageTemplate)
+        {
+            Write(LogEventLevel.Debug, messageTemplate, NoPropertyValues);
+        }
+
+        /// <summary>
+        /// Write a log event with the <see cref="LogEventLevel.Debug"/> level.
+        /// </summary>
+        /// <param name="messageTemplate">Message template describing the event.</param>
         /// <param name="propertyValue">Object positionally formatted into the message template.</param>
         /// <example>
         /// Log.Debug("Starting up at {StartedAt}.", DateTime.Now);
@@ -505,6 +577,20 @@ namespace Serilog.Core
         public void Debug(string messageTemplate, params object[] propertyValues)
         {
             Debug((Exception)null, messageTemplate, propertyValues);
+        }
+
+        /// <summary>
+        /// Write a log event with the <see cref="LogEventLevel.Debug"/> level and associated exception.
+        /// </summary>
+        /// <param name="exception">Exception related to the event.</param>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <example>
+        /// Log.Debug(ex, "Swallowing a mundane exception.");
+        /// </example>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        public void Debug(Exception exception, string messageTemplate)
+        {
+            Write(LogEventLevel.Debug, exception, messageTemplate, NoPropertyValues);
         }
 
         /// <summary>
@@ -574,6 +660,19 @@ namespace Serilog.Core
         /// Write a log event with the <see cref="LogEventLevel.Information"/> level.
         /// </summary>
         /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <example>
+        /// Log.Information("Processed {RecordCount} records in {TimeMS}.", records.Length, sw.ElapsedMilliseconds);
+        /// </example>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        public void Information(string messageTemplate)
+        {
+            Write(LogEventLevel.Information, messageTemplate, NoPropertyValues);
+        }
+
+        /// <summary>
+        /// Write a log event with the <see cref="LogEventLevel.Information"/> level.
+        /// </summary>
+        /// <param name="messageTemplate">Message template describing the event.</param>
         /// <param name="propertyValue">Object positionally formatted into the message template.</param>
         /// <example>
         /// Log.Information("Processed {RecordCount} records in {TimeMS}.", records.Length, sw.ElapsedMilliseconds);
@@ -627,6 +726,20 @@ namespace Serilog.Core
         public void Information(string messageTemplate, params object[] propertyValues)
         {
             Information((Exception)null, messageTemplate, propertyValues);
+        }
+
+        /// <summary>
+        /// Write a log event with the <see cref="LogEventLevel.Information"/> level and associated exception.
+        /// </summary>
+        /// <param name="exception">Exception related to the event.</param>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <example>
+        /// Log.Information(ex, "Processed {RecordCount} records in {TimeMS}.", records.Length, sw.ElapsedMilliseconds);
+        /// </example>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        public void Information(Exception exception, string messageTemplate)
+        {
+            Write(LogEventLevel.Information, exception, messageTemplate, NoPropertyValues);
         }
 
         /// <summary>
@@ -696,6 +809,19 @@ namespace Serilog.Core
         /// Write a log event with the <see cref="LogEventLevel.Warning"/> level.
         /// </summary>
         /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <example>
+        /// Log.Warning("Skipped {SkipCount} records.", skippedRecords.Length);
+        /// </example>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        public void Warning(string messageTemplate)
+        {
+            Write(LogEventLevel.Warning, messageTemplate, NoPropertyValues);
+        }
+
+        /// <summary>
+        /// Write a log event with the <see cref="LogEventLevel.Warning"/> level.
+        /// </summary>
+        /// <param name="messageTemplate">Message template describing the event.</param>
         /// <param name="propertyValue">Object positionally formatted into the message template.</param>
         /// <example>
         /// Log.Warning("Skipped {SkipCount} records.", skippedRecords.Length);
@@ -749,6 +875,20 @@ namespace Serilog.Core
         public void Warning(string messageTemplate, params object[] propertyValues)
         {
             Warning((Exception)null, messageTemplate, propertyValues);
+        }
+
+        /// <summary>
+        /// Write a log event with the <see cref="LogEventLevel.Warning"/> level and associated exception.
+        /// </summary>
+        /// <param name="exception">Exception related to the event.</param>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <example>
+        /// Log.Warning(ex, "Skipped {SkipCount} records.", skippedRecords.Length);
+        /// </example>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        public void Warning(Exception exception, string messageTemplate)
+        {
+            Write(LogEventLevel.Warning, exception, messageTemplate, NoPropertyValues);
         }
 
         /// <summary>
@@ -818,6 +958,19 @@ namespace Serilog.Core
         /// Write a log event with the <see cref="LogEventLevel.Error"/> level.
         /// </summary>
         /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <example>
+        /// Log.Error("Failed {ErrorCount} records.", brokenRecords.Length);
+        /// </example>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        public void Error(string messageTemplate)
+        {
+            Write(LogEventLevel.Error, messageTemplate, NoPropertyValues);
+        }
+
+        /// <summary>
+        /// Write a log event with the <see cref="LogEventLevel.Error"/> level.
+        /// </summary>
+        /// <param name="messageTemplate">Message template describing the event.</param>
         /// <param name="propertyValue">Object positionally formatted into the message template.</param>
         /// <example>
         /// Log.Error("Failed {ErrorCount} records.", brokenRecords.Length);
@@ -871,6 +1024,20 @@ namespace Serilog.Core
         public void Error(string messageTemplate, params object[] propertyValues)
         {
             Error((Exception)null, messageTemplate, propertyValues);
+        }
+
+        /// <summary>
+        /// Write a log event with the <see cref="LogEventLevel.Error"/> level and associated exception.
+        /// </summary>
+        /// <param name="exception">Exception related to the event.</param>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <example>
+        /// Log.Error(ex, "Failed {ErrorCount} records.", brokenRecords.Length);
+        /// </example>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        public void Error(Exception exception, string messageTemplate)
+        {
+            Write(LogEventLevel.Error, exception, messageTemplate, NoPropertyValues);
         }
 
         /// <summary>
@@ -940,6 +1107,19 @@ namespace Serilog.Core
         /// Write a log event with the <see cref="LogEventLevel.Fatal"/> level.
         /// </summary>
         /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <example>
+        /// Log.Fatal("Process terminating.");
+        /// </example>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        public void Fatal(string messageTemplate)
+        {
+            Write(LogEventLevel.Fatal, messageTemplate, NoPropertyValues);
+        }
+
+        /// <summary>
+        /// Write a log event with the <see cref="LogEventLevel.Fatal"/> level.
+        /// </summary>
+        /// <param name="messageTemplate">Message template describing the event.</param>
         /// <param name="propertyValue">Object positionally formatted into the message template.</param>
         /// <example>
         /// Log.Fatal("Process terminating.");
@@ -993,6 +1173,20 @@ namespace Serilog.Core
         public void Fatal(string messageTemplate, params object[] propertyValues)
         {
             Fatal((Exception)null, messageTemplate, propertyValues);
+        }
+
+        /// <summary>
+        /// Write a log event with the <see cref="LogEventLevel.Fatal"/> level and associated exception.
+        /// </summary>
+        /// <param name="exception">Exception related to the event.</param>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <example>
+        /// Log.Fatal(ex, "Process terminating.");
+        /// </example>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        public void Fatal(Exception exception, string messageTemplate)
+        {
+            Write(LogEventLevel.Fatal, exception, messageTemplate, NoPropertyValues);
         }
 
         /// <summary>

--- a/src/Serilog/Core/Logger.cs
+++ b/src/Serilog/Core/Logger.cs
@@ -135,12 +135,63 @@ namespace Serilog.Core
         /// Write a log event with the specified level.
         /// </summary>
         /// <param name="level">The level of the event.</param>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <param name="propertyValue">Object positionally formatted into the message template.</param>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        public void Write<T>(LogEventLevel level, string messageTemplate, T propertyValue)
+        {
+            // Avoid the array allocation and any boxing allocations when the level isn't enabled
+            if (IsEnabled(level))
+            {
+                Write(level, messageTemplate, new object[] { propertyValue });
+            }
+        }
+
+        /// <summary>
+        /// Write a log event with the specified level.
+        /// </summary>
+        /// <param name="level">The level of the event.</param>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <param name="propertyValue0">Object positionally formatted into the message template.</param>
+        /// <param name="propertyValue1">Object positionally formatted into the message template.</param>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        public void Write<T0, T1>(LogEventLevel level, string messageTemplate, T0 propertyValue0, T1 propertyValue1)
+        {
+            // Avoid the array allocation and any boxing allocations when the level isn't enabled
+            if (IsEnabled(level))
+            {
+                Write(level, messageTemplate, new object[] { propertyValue0, propertyValue1 });
+            }
+        }
+
+        /// <summary>
+        /// Write a log event with the specified level.
+        /// </summary>
+        /// <param name="level">The level of the event.</param>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <param name="propertyValue0">Object positionally formatted into the message template.</param>
+        /// <param name="propertyValue1">Object positionally formatted into the message template.</param>
+        /// <param name="propertyValue2">Object positionally formatted into the message template.</param>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        public void Write<T0, T1, T2>(LogEventLevel level, string messageTemplate, T0 propertyValue0, T1 propertyValue1, T2 propertyValue2)
+        {
+            // Avoid the array allocation and any boxing allocations when the level isn't enabled
+            if (IsEnabled(level))
+            {
+                Write(level, messageTemplate, new object[] { propertyValue0, propertyValue1, propertyValue2 });
+            }
+        }
+
+        /// <summary>
+        /// Write a log event with the specified level.
+        /// </summary>
+        /// <param name="level">The level of the event.</param>
         /// <param name="messageTemplate"></param>
         /// <param name="propertyValues"></param>
         [MessageTemplateFormatMethod("messageTemplate")]
         public void Write(LogEventLevel level, string messageTemplate, params object[] propertyValues)
         {
-            Write(level, null, messageTemplate, propertyValues);
+            Write(level, (Exception)null, messageTemplate, propertyValues);
         }
 
         /// <summary>
@@ -156,6 +207,61 @@ namespace Serilog.Core
 
             return _levelSwitch == null ||
                 (int)level >= (int)_levelSwitch.MinimumLevel;
+        }
+
+
+        /// <summary>
+        /// Write a log event with the specified level and associated exception.
+        /// </summary>
+        /// <param name="level">The level of the event.</param>
+        /// <param name="exception">Exception related to the event.</param>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <param name="propertyValue">Object positionally formatted into the message template.</param>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        public void Write<T>(LogEventLevel level, Exception exception, string messageTemplate, T propertyValue)
+        {
+            // Avoid the array allocation and any boxing allocations when the level isn't enabled
+            if (IsEnabled(level))
+            {
+                Write(level, exception, messageTemplate, new object[] { propertyValue });
+            }
+        }
+
+        /// <summary>
+        /// Write a log event with the specified level and associated exception.
+        /// </summary>
+        /// <param name="level">The level of the event.</param>
+        /// <param name="exception">Exception related to the event.</param>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <param name="propertyValue0">Object positionally formatted into the message template.</param>
+        /// <param name="propertyValue1">Object positionally formatted into the message template.</param>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        public void Write<T0, T1>(LogEventLevel level, Exception exception, string messageTemplate, T0 propertyValue0, T1 propertyValue1)
+        {
+            // Avoid the array allocation and any boxing allocations when the level isn't enabled
+            if (IsEnabled(level))
+            {
+                Write(level, exception, messageTemplate, new object[] { propertyValue0, propertyValue1 });
+            }
+        }
+
+        /// <summary>
+        /// Write a log event with the specified level and associated exception.
+        /// </summary>
+        /// <param name="level">The level of the event.</param>
+        /// <param name="exception">Exception related to the event.</param>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <param name="propertyValue0">Object positionally formatted into the message template.</param>
+        /// <param name="propertyValue1">Object positionally formatted into the message template.</param>
+        /// <param name="propertyValue2">Object positionally formatted into the message template.</param>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        public void Write<T0, T1, T2>(LogEventLevel level, Exception exception, string messageTemplate, T0 propertyValue0, T1 propertyValue1, T2 propertyValue2)
+        {
+            // Avoid the array allocation and any boxing allocations when the level isn't enabled
+            if (IsEnabled(level))
+            {
+                Write(level, exception, messageTemplate, new object[] { propertyValue0, propertyValue1, propertyValue2 });
+            }
         }
 
         /// <summary>
@@ -221,6 +327,51 @@ namespace Serilog.Core
         }
 
         /// <summary>
+        /// Write a log event with the <see cref="LogEventLevel.Verbose"/> level.
+        /// </summary>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <param name="propertyValue">Object positionally formatted into the message template.</param>
+        /// <example>
+        /// Log.Verbose("Staring into space, wondering if we're alone.");
+        /// </example>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        public void Verbose<T>(string messageTemplate, T propertyValue)
+        {
+            Write(LogEventLevel.Verbose, messageTemplate, propertyValue);
+        }
+
+        /// <summary>
+        /// Write a log event with the <see cref="LogEventLevel.Verbose"/> level.
+        /// </summary>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <param name="propertyValue0">Object positionally formatted into the message template.</param>
+        /// <param name="propertyValue1">Object positionally formatted into the message template.</param>
+        /// <example>
+        /// Log.Verbose("Staring into space, wondering if we're alone.");
+        /// </example>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        public void Verbose<T0, T1>(string messageTemplate, T0 propertyValue0, T1 propertyValue1)
+        {
+            Write(LogEventLevel.Verbose, messageTemplate, propertyValue0, propertyValue1);
+        }
+
+        /// <summary>
+        /// Write a log event with the <see cref="LogEventLevel.Verbose"/> level.
+        /// </summary>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <param name="propertyValue0">Object positionally formatted into the message template.</param>
+        /// <param name="propertyValue1">Object positionally formatted into the message template.</param>
+        /// <param name="propertyValue2">Object positionally formatted into the message template.</param>
+        /// <example>
+        /// Log.Verbose("Staring into space, wondering if we're alone.");
+        /// </example>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        public void Verbose<T0, T1, T2>(string messageTemplate, T0 propertyValue0, T1 propertyValue1, T2 propertyValue2)
+        {
+            Write(LogEventLevel.Verbose, messageTemplate, propertyValue0, propertyValue1, propertyValue2);
+        }
+
+        /// <summary>
         /// Write a log event with the <see cref="LogEventLevel.Verbose"/> level and associated exception.
         /// </summary>
         /// <param name="messageTemplate">Message template describing the event.</param>
@@ -231,7 +382,55 @@ namespace Serilog.Core
         [MessageTemplateFormatMethod("messageTemplate")]
         public void Verbose(string messageTemplate, params object[] propertyValues)
         {
-            Verbose(null, messageTemplate, propertyValues);
+            Verbose((Exception)null, messageTemplate, propertyValues);
+        }
+
+        /// <summary>
+        /// Write a log event with the <see cref="LogEventLevel.Verbose"/> level and associated exception.
+        /// </summary>
+        /// <param name="exception">Exception related to the event.</param>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <param name="propertyValue">Object positionally formatted into the message template.</param>
+        /// <example>
+        /// Log.Verbose(ex, "Staring into space, wondering where this comet came from.");
+        /// </example>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        public void Verbose<T>(Exception exception, string messageTemplate, T propertyValue)
+        {
+            Write(LogEventLevel.Verbose, exception, messageTemplate, propertyValue);
+        }
+
+        /// <summary>
+        /// Write a log event with the <see cref="LogEventLevel.Verbose"/> level and associated exception.
+        /// </summary>
+        /// <param name="exception">Exception related to the event.</param>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <param name="propertyValue0">Object positionally formatted into the message template.</param>
+        /// <param name="propertyValue1">Object positionally formatted into the message template.</param>
+        /// <example>
+        /// Log.Verbose(ex, "Staring into space, wondering where this comet came from.");
+        /// </example>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        public void Verbose<T0, T1>(Exception exception, string messageTemplate, T0 propertyValue0, T1 propertyValue1)
+        {
+            Write(LogEventLevel.Verbose, exception, messageTemplate, propertyValue0, propertyValue1);
+        }
+
+        /// <summary>
+        /// Write a log event with the <see cref="LogEventLevel.Verbose"/> level and associated exception.
+        /// </summary>
+        /// <param name="exception">Exception related to the event.</param>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <param name="propertyValue0">Object positionally formatted into the message template.</param>
+        /// <param name="propertyValue1">Object positionally formatted into the message template.</param>
+        /// <param name="propertyValue2">Object positionally formatted into the message template.</param>
+        /// <example>
+        /// Log.Verbose(ex, "Staring into space, wondering where this comet came from.");
+        /// </example>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        public void Verbose<T0, T1, T2>(Exception exception, string messageTemplate, T0 propertyValue0, T1 propertyValue1, T2 propertyValue2)
+        {
+            Write(LogEventLevel.Verbose, exception, messageTemplate, propertyValue0, propertyValue1, propertyValue2);
         }
 
         /// <summary>
@@ -250,6 +449,51 @@ namespace Serilog.Core
         }
 
         /// <summary>
+        /// Write a log event with the <see cref="LogEventLevel.Debug"/> level.
+        /// </summary>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <param name="propertyValue">Object positionally formatted into the message template.</param>
+        /// <example>
+        /// Log.Debug("Starting up at {StartedAt}.", DateTime.Now);
+        /// </example>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        public void Debug<T>(string messageTemplate, T propertyValue)
+        {
+            Write(LogEventLevel.Debug, messageTemplate, propertyValue);
+        }
+
+        /// <summary>
+        /// Write a log event with the <see cref="LogEventLevel.Debug"/> level.
+        /// </summary>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <param name="propertyValue0">Object positionally formatted into the message template.</param>
+        /// <param name="propertyValue1">Object positionally formatted into the message template.</param>
+        /// <example>
+        /// Log.Debug("Starting up at {StartedAt}.", DateTime.Now);
+        /// </example>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        public void Debug<T0, T1>(string messageTemplate, T0 propertyValue0, T1 propertyValue1)
+        {
+            Write(LogEventLevel.Debug, messageTemplate, propertyValue0, propertyValue1);
+        }
+
+        /// <summary>
+        /// Write a log event with the <see cref="LogEventLevel.Debug"/> level.
+        /// </summary>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <param name="propertyValue0">Object positionally formatted into the message template.</param>
+        /// <param name="propertyValue1">Object positionally formatted into the message template.</param>
+        /// <param name="propertyValue2">Object positionally formatted into the message template.</param>
+        /// <example>
+        /// Log.Debug("Starting up at {StartedAt}.", DateTime.Now);
+        /// </example>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        public void Debug<T0, T1, T2>(string messageTemplate, T0 propertyValue0, T1 propertyValue1, T2 propertyValue2)
+        {
+            Write(LogEventLevel.Debug, messageTemplate, propertyValue0, propertyValue1, propertyValue2);
+        }
+
+        /// <summary>
         /// Write a log event with the <see cref="LogEventLevel.Debug"/> level and associated exception.
         /// </summary>
         /// <param name="messageTemplate">Message template describing the event.</param>
@@ -260,7 +504,55 @@ namespace Serilog.Core
         [MessageTemplateFormatMethod("messageTemplate")]
         public void Debug(string messageTemplate, params object[] propertyValues)
         {
-            Debug(null, messageTemplate, propertyValues);
+            Debug((Exception)null, messageTemplate, propertyValues);
+        }
+
+        /// <summary>
+        /// Write a log event with the <see cref="LogEventLevel.Debug"/> level and associated exception.
+        /// </summary>
+        /// <param name="exception">Exception related to the event.</param>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <param name="propertyValue">Object positionally formatted into the message template.</param>
+        /// <example>
+        /// Log.Debug(ex, "Swallowing a mundane exception.");
+        /// </example>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        public void Debug<T>(Exception exception, string messageTemplate, T propertyValue)
+        {
+            Write(LogEventLevel.Debug, exception, messageTemplate, propertyValue);
+        }
+
+        /// <summary>
+        /// Write a log event with the <see cref="LogEventLevel.Debug"/> level and associated exception.
+        /// </summary>
+        /// <param name="exception">Exception related to the event.</param>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <param name="propertyValue0">Object positionally formatted into the message template.</param>
+        /// <param name="propertyValue1">Object positionally formatted into the message template.</param>
+        /// <example>
+        /// Log.Debug(ex, "Swallowing a mundane exception.");
+        /// </example>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        public void Debug<T0, T1>(Exception exception, string messageTemplate, T0 propertyValue0, T1 propertyValue1)
+        {
+            Write(LogEventLevel.Debug, exception, messageTemplate, propertyValue0, propertyValue1);
+        }
+
+        /// <summary>
+        /// Write a log event with the <see cref="LogEventLevel.Debug"/> level and associated exception.
+        /// </summary>
+        /// <param name="exception">Exception related to the event.</param>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <param name="propertyValue0">Object positionally formatted into the message template.</param>
+        /// <param name="propertyValue1">Object positionally formatted into the message template.</param>
+        /// <param name="propertyValue2">Object positionally formatted into the message template.</param>
+        /// <example>
+        /// Log.Debug(ex, "Swallowing a mundane exception.");
+        /// </example>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        public void Debug<T0, T1, T2>(Exception exception, string messageTemplate, T0 propertyValue0, T1 propertyValue1, T2 propertyValue2)
+        {
+            Write(LogEventLevel.Debug, exception, messageTemplate, propertyValue0, propertyValue1, propertyValue2);
         }
 
         /// <summary>
@@ -279,6 +571,51 @@ namespace Serilog.Core
         }
 
         /// <summary>
+        /// Write a log event with the <see cref="LogEventLevel.Information"/> level.
+        /// </summary>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <param name="propertyValue">Object positionally formatted into the message template.</param>
+        /// <example>
+        /// Log.Information("Processed {RecordCount} records in {TimeMS}.", records.Length, sw.ElapsedMilliseconds);
+        /// </example>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        public void Information<T>(string messageTemplate, T propertyValue)
+        {
+            Write(LogEventLevel.Information, messageTemplate, propertyValue);
+        }
+
+        /// <summary>
+        /// Write a log event with the <see cref="LogEventLevel.Information"/> level.
+        /// </summary>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <param name="propertyValue0">Object positionally formatted into the message template.</param>
+        /// <param name="propertyValue1">Object positionally formatted into the message template.</param>
+        /// <example>
+        /// Log.Information("Processed {RecordCount} records in {TimeMS}.", records.Length, sw.ElapsedMilliseconds);
+        /// </example>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        public void Information<T0, T1>(string messageTemplate, T0 propertyValue0, T1 propertyValue1)
+        {
+            Write(LogEventLevel.Information, messageTemplate, propertyValue0, propertyValue1);
+        }
+
+        /// <summary>
+        /// Write a log event with the <see cref="LogEventLevel.Information"/> level.
+        /// </summary>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <param name="propertyValue0">Object positionally formatted into the message template.</param>
+        /// <param name="propertyValue1">Object positionally formatted into the message template.</param>
+        /// <param name="propertyValue2">Object positionally formatted into the message template.</param>
+        /// <example>
+        /// Log.Information("Processed {RecordCount} records in {TimeMS}.", records.Length, sw.ElapsedMilliseconds);
+        /// </example>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        public void Information<T0, T1, T2>(string messageTemplate, T0 propertyValue0, T1 propertyValue1, T2 propertyValue2)
+        {
+            Write(LogEventLevel.Information, messageTemplate, propertyValue0, propertyValue1, propertyValue2);
+        }
+
+        /// <summary>
         /// Write a log event with the <see cref="LogEventLevel.Information"/> level and associated exception.
         /// </summary>
         /// <param name="messageTemplate">Message template describing the event.</param>
@@ -289,7 +626,55 @@ namespace Serilog.Core
         [MessageTemplateFormatMethod("messageTemplate")]
         public void Information(string messageTemplate, params object[] propertyValues)
         {
-            Information(null, messageTemplate, propertyValues);
+            Information((Exception)null, messageTemplate, propertyValues);
+        }
+
+        /// <summary>
+        /// Write a log event with the <see cref="LogEventLevel.Information"/> level and associated exception.
+        /// </summary>
+        /// <param name="exception">Exception related to the event.</param>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <param name="propertyValue">Object positionally formatted into the message template.</param>
+        /// <example>
+        /// Log.Information(ex, "Processed {RecordCount} records in {TimeMS}.", records.Length, sw.ElapsedMilliseconds);
+        /// </example>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        public void Information<T>(Exception exception, string messageTemplate, T propertyValue)
+        {
+            Write(LogEventLevel.Information, exception, messageTemplate, propertyValue);
+        }
+
+        /// <summary>
+        /// Write a log event with the <see cref="LogEventLevel.Information"/> level and associated exception.
+        /// </summary>
+        /// <param name="exception">Exception related to the event.</param>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <param name="propertyValue0">Object positionally formatted into the message template.</param>
+        /// <param name="propertyValue1">Object positionally formatted into the message template.</param>
+        /// <example>
+        /// Log.Information(ex, "Processed {RecordCount} records in {TimeMS}.", records.Length, sw.ElapsedMilliseconds);
+        /// </example>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        public void Information<T0, T1>(Exception exception, string messageTemplate, T0 propertyValue0, T1 propertyValue1)
+        {
+            Write(LogEventLevel.Information, exception, messageTemplate, propertyValue0, propertyValue1);
+        }
+
+        /// <summary>
+        /// Write a log event with the <see cref="LogEventLevel.Information"/> level and associated exception.
+        /// </summary>
+        /// <param name="exception">Exception related to the event.</param>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <param name="propertyValue0">Object positionally formatted into the message template.</param>
+        /// <param name="propertyValue1">Object positionally formatted into the message template.</param>
+        /// <param name="propertyValue2">Object positionally formatted into the message template.</param>
+        /// <example>
+        /// Log.Information(ex, "Processed {RecordCount} records in {TimeMS}.", records.Length, sw.ElapsedMilliseconds);
+        /// </example>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        public void Information<T0, T1, T2>(Exception exception, string messageTemplate, T0 propertyValue0, T1 propertyValue1, T2 propertyValue2)
+        {
+            Write(LogEventLevel.Information, exception, messageTemplate, propertyValue0, propertyValue1, propertyValue2);
         }
 
         /// <summary>
@@ -308,6 +693,51 @@ namespace Serilog.Core
         }
 
         /// <summary>
+        /// Write a log event with the <see cref="LogEventLevel.Warning"/> level.
+        /// </summary>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <param name="propertyValue">Object positionally formatted into the message template.</param>
+        /// <example>
+        /// Log.Warning("Skipped {SkipCount} records.", skippedRecords.Length);
+        /// </example>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        public void Warning<T>(string messageTemplate, T propertyValue)
+        {
+            Write(LogEventLevel.Warning, messageTemplate, propertyValue);
+        }
+
+        /// <summary>
+        /// Write a log event with the <see cref="LogEventLevel.Warning"/> level.
+        /// </summary>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <param name="propertyValue0">Object positionally formatted into the message template.</param>
+        /// <param name="propertyValue1">Object positionally formatted into the message template.</param>
+        /// <example>
+        /// Log.Warning("Skipped {SkipCount} records.", skippedRecords.Length);
+        /// </example>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        public void Warning<T0, T1>(string messageTemplate, T0 propertyValue0, T1 propertyValue1)
+        {
+            Write(LogEventLevel.Warning, messageTemplate, propertyValue0, propertyValue1);
+        }
+
+        /// <summary>
+        /// Write a log event with the <see cref="LogEventLevel.Warning"/> level.
+        /// </summary>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <param name="propertyValue0">Object positionally formatted into the message template.</param>
+        /// <param name="propertyValue1">Object positionally formatted into the message template.</param>
+        /// <param name="propertyValue2">Object positionally formatted into the message template.</param>
+        /// <example>
+        /// Log.Warning("Skipped {SkipCount} records.", skippedRecords.Length);
+        /// </example>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        public void Warning<T0, T1, T2>(string messageTemplate, T0 propertyValue0, T1 propertyValue1, T2 propertyValue2)
+        {
+            Write(LogEventLevel.Warning, messageTemplate, propertyValue0, propertyValue1, propertyValue2);
+        }
+
+        /// <summary>
         /// Write a log event with the <see cref="LogEventLevel.Warning"/> level and associated exception.
         /// </summary>
         /// <param name="messageTemplate">Message template describing the event.</param>
@@ -318,7 +748,55 @@ namespace Serilog.Core
         [MessageTemplateFormatMethod("messageTemplate")]
         public void Warning(string messageTemplate, params object[] propertyValues)
         {
-            Warning(null, messageTemplate, propertyValues);
+            Warning((Exception)null, messageTemplate, propertyValues);
+        }
+
+        /// <summary>
+        /// Write a log event with the <see cref="LogEventLevel.Warning"/> level and associated exception.
+        /// </summary>
+        /// <param name="exception">Exception related to the event.</param>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <param name="propertyValue">Object positionally formatted into the message template.</param>
+        /// <example>
+        /// Log.Warning(ex, "Skipped {SkipCount} records.", skippedRecords.Length);
+        /// </example>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        public void Warning<T>(Exception exception, string messageTemplate, T propertyValue)
+        {
+            Write(LogEventLevel.Warning, exception, messageTemplate, propertyValue);
+        }
+
+        /// <summary>
+        /// Write a log event with the <see cref="LogEventLevel.Warning"/> level and associated exception.
+        /// </summary>
+        /// <param name="exception">Exception related to the event.</param>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <param name="propertyValue0">Object positionally formatted into the message template.</param>
+        /// <param name="propertyValue1">Object positionally formatted into the message template.</param>
+        /// <example>
+        /// Log.Warning(ex, "Skipped {SkipCount} records.", skippedRecords.Length);
+        /// </example>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        public void Warning<T0, T1>(Exception exception, string messageTemplate, T0 propertyValue0, T1 propertyValue1)
+        {
+            Write(LogEventLevel.Warning, exception, messageTemplate, propertyValue0, propertyValue1);
+        }
+
+        /// <summary>
+        /// Write a log event with the <see cref="LogEventLevel.Warning"/> level and associated exception.
+        /// </summary>
+        /// <param name="exception">Exception related to the event.</param>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <param name="propertyValue0">Object positionally formatted into the message template.</param>
+        /// <param name="propertyValue1">Object positionally formatted into the message template.</param>
+        /// <param name="propertyValue2">Object positionally formatted into the message template.</param>
+        /// <example>
+        /// Log.Warning(ex, "Skipped {SkipCount} records.", skippedRecords.Length);
+        /// </example>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        public void Warning<T0, T1, T2>(Exception exception, string messageTemplate, T0 propertyValue0, T1 propertyValue1, T2 propertyValue2)
+        {
+            Write(LogEventLevel.Warning, exception, messageTemplate, propertyValue0, propertyValue1, propertyValue2);
         }
 
         /// <summary>
@@ -337,6 +815,51 @@ namespace Serilog.Core
         }
 
         /// <summary>
+        /// Write a log event with the <see cref="LogEventLevel.Error"/> level.
+        /// </summary>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <param name="propertyValue">Object positionally formatted into the message template.</param>
+        /// <example>
+        /// Log.Error("Failed {ErrorCount} records.", brokenRecords.Length);
+        /// </example>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        public void Error<T>(string messageTemplate, T propertyValue)
+        {
+            Write(LogEventLevel.Error, messageTemplate, propertyValue);
+        }
+
+        /// <summary>
+        /// Write a log event with the <see cref="LogEventLevel.Error"/> level.
+        /// </summary>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <param name="propertyValue0">Object positionally formatted into the message template.</param>
+        /// <param name="propertyValue1">Object positionally formatted into the message template.</param>
+        /// <example>
+        /// Log.Error("Failed {ErrorCount} records.", brokenRecords.Length);
+        /// </example>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        public void Error<T0, T1>(string messageTemplate, T0 propertyValue0, T1 propertyValue1)
+        {
+            Write(LogEventLevel.Error, messageTemplate, propertyValue0, propertyValue1);
+        }
+
+        /// <summary>
+        /// Write a log event with the <see cref="LogEventLevel.Error"/> level.
+        /// </summary>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <param name="propertyValue0">Object positionally formatted into the message template.</param>
+        /// <param name="propertyValue1">Object positionally formatted into the message template.</param>
+        /// <param name="propertyValue2">Object positionally formatted into the message template.</param>
+        /// <example>
+        /// Log.Error("Failed {ErrorCount} records.", brokenRecords.Length);
+        /// </example>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        public void Error<T0, T1, T2>(string messageTemplate, T0 propertyValue0, T1 propertyValue1, T2 propertyValue2)
+        {
+            Write(LogEventLevel.Error, messageTemplate, propertyValue0, propertyValue1, propertyValue2);
+        }
+
+        /// <summary>
         /// Write a log event with the <see cref="LogEventLevel.Error"/> level and associated exception.
         /// </summary>
         /// <param name="messageTemplate">Message template describing the event.</param>
@@ -347,7 +870,55 @@ namespace Serilog.Core
         [MessageTemplateFormatMethod("messageTemplate")]
         public void Error(string messageTemplate, params object[] propertyValues)
         {
-            Error(null, messageTemplate, propertyValues);
+            Error((Exception)null, messageTemplate, propertyValues);
+        }
+
+        /// <summary>
+        /// Write a log event with the <see cref="LogEventLevel.Error"/> level and associated exception.
+        /// </summary>
+        /// <param name="exception">Exception related to the event.</param>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <param name="propertyValue">Object positionally formatted into the message template.</param>
+        /// <example>
+        /// Log.Error(ex, "Failed {ErrorCount} records.", brokenRecords.Length);
+        /// </example>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        public void Error<T>(Exception exception, string messageTemplate, T propertyValue)
+        {
+            Write(LogEventLevel.Error, exception, messageTemplate, propertyValue);
+        }
+
+        /// <summary>
+        /// Write a log event with the <see cref="LogEventLevel.Error"/> level and associated exception.
+        /// </summary>
+        /// <param name="exception">Exception related to the event.</param>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <param name="propertyValue0">Object positionally formatted into the message template.</param>
+        /// <param name="propertyValue1">Object positionally formatted into the message template.</param>
+        /// <example>
+        /// Log.Error(ex, "Failed {ErrorCount} records.", brokenRecords.Length);
+        /// </example>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        public void Error<T0, T1>(Exception exception, string messageTemplate, T0 propertyValue0, T1 propertyValue1)
+        {
+            Write(LogEventLevel.Error, exception, messageTemplate, propertyValue0, propertyValue1);
+        }
+
+        /// <summary>
+        /// Write a log event with the <see cref="LogEventLevel.Error"/> level and associated exception.
+        /// </summary>
+        /// <param name="exception">Exception related to the event.</param>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <param name="propertyValue0">Object positionally formatted into the message template.</param>
+        /// <param name="propertyValue1">Object positionally formatted into the message template.</param>
+        /// <param name="propertyValue2">Object positionally formatted into the message template.</param>
+        /// <example>
+        /// Log.Error(ex, "Failed {ErrorCount} records.", brokenRecords.Length);
+        /// </example>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        public void Error<T0, T1, T2>(Exception exception, string messageTemplate, T0 propertyValue0, T1 propertyValue1, T2 propertyValue2)
+        {
+            Write(LogEventLevel.Error, exception, messageTemplate, propertyValue0, propertyValue1, propertyValue2);
         }
 
         /// <summary>
@@ -366,6 +937,51 @@ namespace Serilog.Core
         }
 
         /// <summary>
+        /// Write a log event with the <see cref="LogEventLevel.Fatal"/> level.
+        /// </summary>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <param name="propertyValue">Object positionally formatted into the message template.</param>
+        /// <example>
+        /// Log.Fatal("Process terminating.");
+        /// </example>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        public void Fatal<T>(string messageTemplate, T propertyValue)
+        {
+            Write(LogEventLevel.Fatal, messageTemplate, propertyValue);
+        }
+
+        /// <summary>
+        /// Write a log event with the <see cref="LogEventLevel.Fatal"/> level.
+        /// </summary>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <param name="propertyValue0">Object positionally formatted into the message template.</param>
+        /// <param name="propertyValue1">Object positionally formatted into the message template.</param>
+        /// <example>
+        /// Log.Fatal("Process terminating.");
+        /// </example>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        public void Fatal<T0, T1>(string messageTemplate, T0 propertyValue0, T1 propertyValue1)
+        {
+            Write(LogEventLevel.Fatal, messageTemplate, propertyValue0, propertyValue1);
+        }
+
+        /// <summary>
+        /// Write a log event with the <see cref="LogEventLevel.Fatal"/> level.
+        /// </summary>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <param name="propertyValue0">Object positionally formatted into the message template.</param>
+        /// <param name="propertyValue1">Object positionally formatted into the message template.</param>
+        /// <param name="propertyValue2">Object positionally formatted into the message template.</param>
+        /// <example>
+        /// Log.Fatal("Process terminating.");
+        /// </example>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        public void Fatal<T0, T1, T2>(string messageTemplate, T0 propertyValue0, T1 propertyValue1, T2 propertyValue2)
+        {
+            Write(LogEventLevel.Fatal, messageTemplate, propertyValue0, propertyValue1, propertyValue2);
+        }
+
+        /// <summary>
         /// Write a log event with the <see cref="LogEventLevel.Fatal"/> level and associated exception.
         /// </summary>
         /// <param name="messageTemplate">Message template describing the event.</param>
@@ -376,7 +992,55 @@ namespace Serilog.Core
         [MessageTemplateFormatMethod("messageTemplate")]
         public void Fatal(string messageTemplate, params object[] propertyValues)
         {
-            Fatal(null, messageTemplate, propertyValues);
+            Fatal((Exception)null, messageTemplate, propertyValues);
+        }
+
+        /// <summary>
+        /// Write a log event with the <see cref="LogEventLevel.Fatal"/> level and associated exception.
+        /// </summary>
+        /// <param name="exception">Exception related to the event.</param>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <param name="propertyValue">Object positionally formatted into the message template.</param>
+        /// <example>
+        /// Log.Fatal(ex, "Process terminating.");
+        /// </example>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        public void Fatal<T>(Exception exception, string messageTemplate, T propertyValue)
+        {
+            Write(LogEventLevel.Fatal, exception, messageTemplate, propertyValue);
+        }
+
+        /// <summary>
+        /// Write a log event with the <see cref="LogEventLevel.Fatal"/> level and associated exception.
+        /// </summary>
+        /// <param name="exception">Exception related to the event.</param>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <param name="propertyValue0">Object positionally formatted into the message template.</param>
+        /// <param name="propertyValue1">Object positionally formatted into the message template.</param>
+        /// <example>
+        /// Log.Fatal(ex, "Process terminating.");
+        /// </example>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        public void Fatal<T0, T1>(Exception exception, string messageTemplate, T0 propertyValue0, T1 propertyValue1)
+        {
+            Write(LogEventLevel.Fatal, exception, messageTemplate, propertyValue0, propertyValue1);
+        }
+
+        /// <summary>
+        /// Write a log event with the <see cref="LogEventLevel.Fatal"/> level and associated exception.
+        /// </summary>
+        /// <param name="exception">Exception related to the event.</param>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <param name="propertyValue0">Object positionally formatted into the message template.</param>
+        /// <param name="propertyValue1">Object positionally formatted into the message template.</param>
+        /// <param name="propertyValue2">Object positionally formatted into the message template.</param>
+        /// <example>
+        /// Log.Fatal(ex, "Process terminating.");
+        /// </example>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        public void Fatal<T0, T1, T2>(Exception exception, string messageTemplate, T0 propertyValue0, T1 propertyValue1, T2 propertyValue2)
+        {
+            Write(LogEventLevel.Fatal, exception, messageTemplate, propertyValue0, propertyValue1, propertyValue2);
         }
 
         /// <summary>

--- a/src/Serilog/Core/Pipeline/SilentLogger.cs
+++ b/src/Serilog/Core/Pipeline/SilentLogger.cs
@@ -44,12 +44,34 @@ namespace Serilog.Core.Pipeline
         {
         }
 
-        [MessageTemplateFormatMethod("messageTemplate")]
+        public void Write<T>(LogEventLevel level, string messageTemplate, T propertyValue)
+        {
+        }
+
+        public void Write<T0, T1>(LogEventLevel level, string messageTemplate, T0 propertyValue0, T1 propertyValue1)
+        {
+        }
+
+        public void Write<T0, T1, T2>(LogEventLevel level, string messageTemplate, T0 propertyValue0, T1 propertyValue1, T2 propertyValue2)
+        {
+        }
+
         public void Write(LogEventLevel level, string messageTemplate, params object[] propertyValues)
         {
         }
 
-        [MessageTemplateFormatMethod("messageTemplate")]
+        public void Write<T>(LogEventLevel level, Exception exception, string messageTemplate, T propertyValue)
+        {
+        }
+
+        public void Write<T0, T1>(LogEventLevel level, Exception exception, string messageTemplate, T0 propertyValue0, T1 propertyValue1)
+        {
+        }
+
+        public void Write<T0, T1, T2>(LogEventLevel level, Exception exception, string messageTemplate, T0 propertyValue0, T1 propertyValue1, T2 propertyValue2)
+        {
+        }
+
         public void Write(LogEventLevel level, Exception exception, string messageTemplate, params object[] propertyValues)
         {
         }
@@ -59,62 +81,194 @@ namespace Serilog.Core.Pipeline
             return false;
         }
 
-        [MessageTemplateFormatMethod("messageTemplate")]
+        public void Verbose<T>(string messageTemplate, T propertyValue)
+        {
+        }
+
+        public void Verbose<T0, T1>(string messageTemplate, T0 propertyValue0, T1 propertyValue1)
+        {
+        }
+
+        public void Verbose<T0, T1, T2>(string messageTemplate, T0 propertyValue0, T1 propertyValue1, T2 propertyValue2)
+        {
+        }
+
         public void Verbose(string messageTemplate, params object[] propertyValues)
         {
         }
 
-        [MessageTemplateFormatMethod("messageTemplate")]
+        public void Verbose<T>(Exception exception, string messageTemplate, T propertyValue)
+        {
+        }
+
+        public void Verbose<T0, T1>(Exception exception, string messageTemplate, T0 propertyValue0, T1 propertyValue1)
+        {
+        }
+
+        public void Verbose<T0, T1, T2>(Exception exception, string messageTemplate, T0 propertyValue0, T1 propertyValue1, T2 propertyValue2)
+        {
+        }
+
         public void Verbose(Exception exception, string messageTemplate, params object[] propertyValues)
         {
         }
 
-        [MessageTemplateFormatMethod("messageTemplate")]
+        public void Debug<T>(string messageTemplate, T propertyValue)
+        {
+        }
+
+        public void Debug<T0, T1>(string messageTemplate, T0 propertyValue0, T1 propertyValue1)
+        {
+        }
+
+        public void Debug<T0, T1, T2>(string messageTemplate, T0 propertyValue0, T1 propertyValue1, T2 propertyValue2)
+        {
+        }
+
         public void Debug(string messageTemplate, params object[] propertyValues)
         {
         }
 
-        [MessageTemplateFormatMethod("messageTemplate")]
+        public void Debug<T>(Exception exception, string messageTemplate, T propertyValue)
+        {
+        }
+
+        public void Debug<T0, T1>(Exception exception, string messageTemplate, T0 propertyValue0, T1 propertyValue1)
+        {
+        }
+
+        public void Debug<T0, T1, T2>(Exception exception, string messageTemplate, T0 propertyValue0, T1 propertyValue1, T2 propertyValue2)
+        {
+        }
+
         public void Debug(Exception exception, string messageTemplate, params object[] propertyValues)
         {
         }
 
-        [MessageTemplateFormatMethod("messageTemplate")]
+        public void Information<T>(string messageTemplate, T propertyValue)
+        {
+        }
+
+        public void Information<T0, T1>(string messageTemplate, T0 propertyValue0, T1 propertyValue1)
+        {
+        }
+
+        public void Information<T0, T1, T2>(string messageTemplate, T0 propertyValue0, T1 propertyValue1, T2 propertyValue2)
+        {
+        }
+
         public void Information(string messageTemplate, params object[] propertyValues)
         {
         }
 
-        [MessageTemplateFormatMethod("messageTemplate")]
+        public void Information<T>(Exception exception, string messageTemplate, T propertyValue)
+        {
+        }
+
+        public void Information<T0, T1>(Exception exception, string messageTemplate, T0 propertyValue0, T1 propertyValue1)
+        {
+        }
+
+        public void Information<T0, T1, T2>(Exception exception, string messageTemplate, T0 propertyValue0, T1 propertyValue1, T2 propertyValue2)
+        {
+        }
+
         public void Information(Exception exception, string messageTemplate, params object[] propertyValues)
         {
         }
 
-        [MessageTemplateFormatMethod("messageTemplate")]
+        public void Warning<T>(string messageTemplate, T propertyValue)
+        {
+        }
+
+        public void Warning<T0, T1>(string messageTemplate, T0 propertyValue0, T1 propertyValue1)
+        {
+        }
+
+        public void Warning<T0, T1, T2>(string messageTemplate, T0 propertyValue0, T1 propertyValue1, T2 propertyValue2)
+        {
+        }
+
         public void Warning(string messageTemplate, params object[] propertyValues)
         {
         }
 
-        [MessageTemplateFormatMethod("messageTemplate")]
+        public void Warning<T>(Exception exception, string messageTemplate, T propertyValue)
+        {
+        }
+
+        public void Warning<T0, T1>(Exception exception, string messageTemplate, T0 propertyValue0, T1 propertyValue1)
+        {
+        }
+
+        public void Warning<T0, T1, T2>(Exception exception, string messageTemplate, T0 propertyValue0, T1 propertyValue1, T2 propertyValue2)
+        {
+        }
+
         public void Warning(Exception exception, string messageTemplate, params object[] propertyValues)
         {
         }
 
-        [MessageTemplateFormatMethod("messageTemplate")]
+        public void Error<T>(string messageTemplate, T propertyValue)
+        {
+        }
+
+        public void Error<T0, T1>(string messageTemplate, T0 propertyValue0, T1 propertyValue1)
+        {
+        }
+
+        public void Error<T0, T1, T2>(string messageTemplate, T0 propertyValue0, T1 propertyValue1, T2 propertyValue2)
+        {
+        }
+
         public void Error(string messageTemplate, params object[] propertyValues)
         {
         }
 
-        [MessageTemplateFormatMethod("messageTemplate")]
+        public void Error<T>(Exception exception, string messageTemplate, T propertyValue)
+        {
+        }
+
+        public void Error<T0, T1>(Exception exception, string messageTemplate, T0 propertyValue0, T1 propertyValue1)
+        {
+        }
+
+        public void Error<T0, T1, T2>(Exception exception, string messageTemplate, T0 propertyValue0, T1 propertyValue1, T2 propertyValue2)
+        {
+        }
+
         public void Error(Exception exception, string messageTemplate, params object[] propertyValues)
         {
         }
 
-        [MessageTemplateFormatMethod("messageTemplate")]
+        public void Fatal<T>(string messageTemplate, T propertyValue)
+        {
+        }
+
+        public void Fatal<T0, T1>(string messageTemplate, T0 propertyValue0, T1 propertyValue1)
+        {
+        }
+
+        public void Fatal<T0, T1, T2>(string messageTemplate, T0 propertyValue0, T1 propertyValue1, T2 propertyValue2)
+        {
+        }
+
         public void Fatal(string messageTemplate, params object[] propertyValues)
         {
         }
 
-        [MessageTemplateFormatMethod("messageTemplate")]
+        public void Fatal<T>(Exception exception, string messageTemplate, T propertyValue)
+        {
+        }
+
+        public void Fatal<T0, T1>(Exception exception, string messageTemplate, T0 propertyValue0, T1 propertyValue1)
+        {
+        }
+
+        public void Fatal<T0, T1, T2>(Exception exception, string messageTemplate, T0 propertyValue0, T1 propertyValue1, T2 propertyValue2)
+        {
+        }
+
         public void Fatal(Exception exception, string messageTemplate, params object[] propertyValues)
         {
         }

--- a/src/Serilog/Core/Pipeline/SilentLogger.cs
+++ b/src/Serilog/Core/Pipeline/SilentLogger.cs
@@ -44,6 +44,10 @@ namespace Serilog.Core.Pipeline
         {
         }
 
+        public void Write(LogEventLevel level, string messageTemplate)
+        {
+        }
+
         public void Write<T>(LogEventLevel level, string messageTemplate, T propertyValue)
         {
         }
@@ -57,6 +61,10 @@ namespace Serilog.Core.Pipeline
         }
 
         public void Write(LogEventLevel level, string messageTemplate, params object[] propertyValues)
+        {
+        }
+
+        public void Write(LogEventLevel level, Exception exception, string messageTemplate)
         {
         }
 
@@ -81,6 +89,10 @@ namespace Serilog.Core.Pipeline
             return false;
         }
 
+        public void Verbose(string messageTemplate)
+        {
+        }
+
         public void Verbose<T>(string messageTemplate, T propertyValue)
         {
         }
@@ -94,6 +106,10 @@ namespace Serilog.Core.Pipeline
         }
 
         public void Verbose(string messageTemplate, params object[] propertyValues)
+        {
+        }
+
+        public void Verbose(Exception exception, string messageTemplate)
         {
         }
 
@@ -113,6 +129,10 @@ namespace Serilog.Core.Pipeline
         {
         }
 
+        public void Debug(string messageTemplate)
+        {
+        }
+
         public void Debug<T>(string messageTemplate, T propertyValue)
         {
         }
@@ -126,6 +146,10 @@ namespace Serilog.Core.Pipeline
         }
 
         public void Debug(string messageTemplate, params object[] propertyValues)
+        {
+        }
+
+        public void Debug(Exception exception, string messageTemplate)
         {
         }
 
@@ -145,6 +169,10 @@ namespace Serilog.Core.Pipeline
         {
         }
 
+        public void Information(string messageTemplate)
+        {
+        }
+
         public void Information<T>(string messageTemplate, T propertyValue)
         {
         }
@@ -158,6 +186,10 @@ namespace Serilog.Core.Pipeline
         }
 
         public void Information(string messageTemplate, params object[] propertyValues)
+        {
+        }
+
+        public void Information(Exception exception, string messageTemplate)
         {
         }
 
@@ -177,6 +209,10 @@ namespace Serilog.Core.Pipeline
         {
         }
 
+        public void Warning(string messageTemplate)
+        {
+        }
+
         public void Warning<T>(string messageTemplate, T propertyValue)
         {
         }
@@ -190,6 +226,10 @@ namespace Serilog.Core.Pipeline
         }
 
         public void Warning(string messageTemplate, params object[] propertyValues)
+        {
+        }
+
+        public void Warning(Exception exception, string messageTemplate)
         {
         }
 
@@ -209,6 +249,10 @@ namespace Serilog.Core.Pipeline
         {
         }
 
+        public void Error(string messageTemplate)
+        {
+        }
+
         public void Error<T>(string messageTemplate, T propertyValue)
         {
         }
@@ -222,6 +266,10 @@ namespace Serilog.Core.Pipeline
         }
 
         public void Error(string messageTemplate, params object[] propertyValues)
+        {
+        }
+
+        public void Error(Exception exception, string messageTemplate)
         {
         }
 
@@ -241,6 +289,10 @@ namespace Serilog.Core.Pipeline
         {
         }
 
+        public void Fatal(string messageTemplate)
+        {
+        }
+
         public void Fatal<T>(string messageTemplate, T propertyValue)
         {
         }
@@ -254,6 +306,10 @@ namespace Serilog.Core.Pipeline
         }
 
         public void Fatal(string messageTemplate, params object[] propertyValues)
+        {
+        }
+
+        public void Fatal(Exception exception, string messageTemplate)
         {
         }
 

--- a/src/Serilog/ILogger.cs
+++ b/src/Serilog/ILogger.cs
@@ -76,6 +76,14 @@ namespace Serilog
         /// </summary>
         /// <param name="level">The level of the event.</param>
         /// <param name="messageTemplate">Message template describing the event.</param>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        void Write(LogEventLevel level, string messageTemplate);
+
+        /// <summary>
+        /// Write a log event with the specified level.
+        /// </summary>
+        /// <param name="level">The level of the event.</param>
+        /// <param name="messageTemplate">Message template describing the event.</param>
         /// <param name="propertyValue">Object positionally formatted into the message template.</param>
         [MessageTemplateFormatMethod("messageTemplate")]
         void Write<T>(LogEventLevel level, string messageTemplate, T propertyValue);
@@ -109,6 +117,15 @@ namespace Serilog
         /// <param name="propertyValues"></param>
         [MessageTemplateFormatMethod("messageTemplate")]
         void Write(LogEventLevel level, string messageTemplate, params object[] propertyValues);
+
+        /// <summary>
+        /// Write a log event with the specified level and associated exception.
+        /// </summary>
+        /// <param name="level">The level of the event.</param>
+        /// <param name="exception">Exception related to the event.</param>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        void Write(LogEventLevel level, Exception exception, string messageTemplate);
 
         /// <summary>
         /// Write a log event with the specified level and associated exception.
@@ -165,6 +182,16 @@ namespace Serilog
         /// Write a log event with the <see cref="LogEventLevel.Verbose"/> level.
         /// </summary>
         /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <example>
+        /// Log.Verbose("Staring into space, wondering if we're alone.");
+        /// </example>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        void Verbose(string messageTemplate);
+
+        /// <summary>
+        /// Write a log event with the <see cref="LogEventLevel.Verbose"/> level.
+        /// </summary>
+        /// <param name="messageTemplate">Message template describing the event.</param>
         /// <param name="propertyValue">Object positionally formatted into the message template.</param>
         /// <example>
         /// Log.Verbose("Staring into space, wondering if we're alone.");
@@ -207,6 +234,17 @@ namespace Serilog
         /// </example>
         [MessageTemplateFormatMethod("messageTemplate")]
         void Verbose(string messageTemplate, params object[] propertyValues);
+
+        /// <summary>
+        /// Write a log event with the <see cref="LogEventLevel.Verbose"/> level and associated exception.
+        /// </summary>
+        /// <param name="exception">Exception related to the event.</param>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <example>
+        /// Log.Verbose(ex, "Staring into space, wondering where this comet came from.");
+        /// </example>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        void Verbose(Exception exception, string messageTemplate);
 
         /// <summary>
         /// Write a log event with the <see cref="LogEventLevel.Verbose"/> level and associated exception.
@@ -263,6 +301,16 @@ namespace Serilog
         /// Write a log event with the <see cref="LogEventLevel.Debug"/> level.
         /// </summary>
         /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <example>
+        /// Log.Debug("Starting up at {StartedAt}.", DateTime.Now);
+        /// </example>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        void Debug(string messageTemplate);
+
+        /// <summary>
+        /// Write a log event with the <see cref="LogEventLevel.Debug"/> level.
+        /// </summary>
+        /// <param name="messageTemplate">Message template describing the event.</param>
         /// <param name="propertyValue">Object positionally formatted into the message template.</param>
         /// <example>
         /// Log.Debug("Starting up at {StartedAt}.", DateTime.Now);
@@ -305,6 +353,17 @@ namespace Serilog
         /// </example>
         [MessageTemplateFormatMethod("messageTemplate")]
         void Debug(string messageTemplate, params object[] propertyValues);
+
+        /// <summary>
+        /// Write a log event with the <see cref="LogEventLevel.Debug"/> level and associated exception.
+        /// </summary>
+        /// <param name="exception">Exception related to the event.</param>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <example>
+        /// Log.Debug(ex, "Swallowing a mundane exception.");
+        /// </example>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        void Debug(Exception exception, string messageTemplate);
 
         /// <summary>
         /// Write a log event with the <see cref="LogEventLevel.Debug"/> level and associated exception.
@@ -361,6 +420,16 @@ namespace Serilog
         /// Write a log event with the <see cref="LogEventLevel.Information"/> level.
         /// </summary>
         /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <example>
+        /// Log.Information("Processed {RecordCount} records in {TimeMS}.", records.Length, sw.ElapsedMilliseconds);
+        /// </example>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        void Information(string messageTemplate);
+
+        /// <summary>
+        /// Write a log event with the <see cref="LogEventLevel.Information"/> level.
+        /// </summary>
+        /// <param name="messageTemplate">Message template describing the event.</param>
         /// <param name="propertyValue">Object positionally formatted into the message template.</param>
         /// <example>
         /// Log.Information("Processed {RecordCount} records in {TimeMS}.", records.Length, sw.ElapsedMilliseconds);
@@ -403,6 +472,17 @@ namespace Serilog
         /// </example>
         [MessageTemplateFormatMethod("messageTemplate")]
         void Information(string messageTemplate, params object[] propertyValues);
+
+        /// <summary>
+        /// Write a log event with the <see cref="LogEventLevel.Information"/> level and associated exception.
+        /// </summary>
+        /// <param name="exception">Exception related to the event.</param>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <example>
+        /// Log.Information(ex, "Processed {RecordCount} records in {TimeMS}.", records.Length, sw.ElapsedMilliseconds);
+        /// </example>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        void Information(Exception exception, string messageTemplate);
 
         /// <summary>
         /// Write a log event with the <see cref="LogEventLevel.Information"/> level and associated exception.
@@ -459,6 +539,16 @@ namespace Serilog
         /// Write a log event with the <see cref="LogEventLevel.Warning"/> level.
         /// </summary>
         /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <example>
+        /// Log.Warning("Skipped {SkipCount} records.", skippedRecords.Length);
+        /// </example>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        void Warning(string messageTemplate);
+
+        /// <summary>
+        /// Write a log event with the <see cref="LogEventLevel.Warning"/> level.
+        /// </summary>
+        /// <param name="messageTemplate">Message template describing the event.</param>
         /// <param name="propertyValue">Object positionally formatted into the message template.</param>
         /// <example>
         /// Log.Warning("Skipped {SkipCount} records.", skippedRecords.Length);
@@ -501,6 +591,17 @@ namespace Serilog
         /// </example>
         [MessageTemplateFormatMethod("messageTemplate")]
         void Warning(string messageTemplate, params object[] propertyValues);
+
+        /// <summary>
+        /// Write a log event with the <see cref="LogEventLevel.Warning"/> level and associated exception.
+        /// </summary>
+        /// <param name="exception">Exception related to the event.</param>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <example>
+        /// Log.Warning(ex, "Skipped {SkipCount} records.", skippedRecords.Length);
+        /// </example>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        void Warning(Exception exception, string messageTemplate);
 
         /// <summary>
         /// Write a log event with the <see cref="LogEventLevel.Warning"/> level and associated exception.
@@ -557,6 +658,16 @@ namespace Serilog
         /// Write a log event with the <see cref="LogEventLevel.Error"/> level.
         /// </summary>
         /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <example>
+        /// Log.Error("Failed {ErrorCount} records.", brokenRecords.Length);
+        /// </example>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        void Error(string messageTemplate);
+
+        /// <summary>
+        /// Write a log event with the <see cref="LogEventLevel.Error"/> level.
+        /// </summary>
+        /// <param name="messageTemplate">Message template describing the event.</param>
         /// <param name="propertyValue">Object positionally formatted into the message template.</param>
         /// <example>
         /// Log.Error("Failed {ErrorCount} records.", brokenRecords.Length);
@@ -599,6 +710,18 @@ namespace Serilog
         /// </example>
         [MessageTemplateFormatMethod("messageTemplate")]
         void Error(string messageTemplate, params object[] propertyValues);
+
+        /// <summary>
+        /// Write a log event with the <see cref="LogEventLevel.Error"/> level and associated exception.
+        /// </summary>
+        /// <param name="exception">Exception related to the event.</param>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <example>
+        /// Log.Error(ex, "Failed {ErrorCount} records.", brokenRecords.Length);
+        /// </example>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        void Error(Exception exception, string messageTemplate);
+
 
         /// <summary>
         /// Write a log event with the <see cref="LogEventLevel.Error"/> level and associated exception.
@@ -655,6 +778,16 @@ namespace Serilog
         /// Write a log event with the <see cref="LogEventLevel.Fatal"/> level.
         /// </summary>
         /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <example>
+        /// Log.Fatal("Process terminating.");
+        /// </example>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        void Fatal(string messageTemplate);
+
+        /// <summary>
+        /// Write a log event with the <see cref="LogEventLevel.Fatal"/> level.
+        /// </summary>
+        /// <param name="messageTemplate">Message template describing the event.</param>
         /// <param name="propertyValue">Object positionally formatted into the message template.</param>
         /// <example>
         /// Log.Fatal("Process terminating.");
@@ -697,6 +830,17 @@ namespace Serilog
         /// </example>
         [MessageTemplateFormatMethod("messageTemplate")]
         void Fatal(string messageTemplate, params object[] propertyValues);
+
+        /// <summary>
+        /// Write a log event with the <see cref="LogEventLevel.Fatal"/> level and associated exception.
+        /// </summary>
+        /// <param name="exception">Exception related to the event.</param>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <example>
+        /// Log.Fatal(ex, "Process terminating.");
+        /// </example>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        void Fatal(Exception exception, string messageTemplate);
 
         /// <summary>
         /// Write a log event with the <see cref="LogEventLevel.Fatal"/> level and associated exception.

--- a/src/Serilog/ILogger.cs
+++ b/src/Serilog/ILogger.cs
@@ -75,10 +75,73 @@ namespace Serilog
         /// Write a log event with the specified level.
         /// </summary>
         /// <param name="level">The level of the event.</param>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <param name="propertyValue">Object positionally formatted into the message template.</param>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        void Write<T>(LogEventLevel level, string messageTemplate, T propertyValue);
+
+        /// <summary>
+        /// Write a log event with the specified level.
+        /// </summary>
+        /// <param name="level">The level of the event.</param>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <param name="propertyValue0">Object positionally formatted into the message template.</param>
+        /// <param name="propertyValue1">Object positionally formatted into the message template.</param>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        void Write<T0, T1>(LogEventLevel level, string messageTemplate, T0 propertyValue0, T1 propertyValue1);
+
+        /// <summary>
+        /// Write a log event with the specified level.
+        /// </summary>
+        /// <param name="level">The level of the event.</param>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <param name="propertyValue0">Object positionally formatted into the message template.</param>
+        /// <param name="propertyValue1">Object positionally formatted into the message template.</param>
+        /// <param name="propertyValue2">Object positionally formatted into the message template.</param>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        void Write<T0, T1, T2>(LogEventLevel level, string messageTemplate, T0 propertyValue0, T1 propertyValue1, T2 propertyValue2);
+
+        /// <summary>
+        /// Write a log event with the specified level.
+        /// </summary>
+        /// <param name="level">The level of the event.</param>
         /// <param name="messageTemplate"></param>
         /// <param name="propertyValues"></param>
         [MessageTemplateFormatMethod("messageTemplate")]
         void Write(LogEventLevel level, string messageTemplate, params object[] propertyValues);
+
+        /// <summary>
+        /// Write a log event with the specified level and associated exception.
+        /// </summary>
+        /// <param name="level">The level of the event.</param>
+        /// <param name="exception">Exception related to the event.</param>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <param name="propertyValue">Object positionally formatted into the message template.</param>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        void Write<T>(LogEventLevel level, Exception exception, string messageTemplate, T propertyValue);
+
+        /// <summary>
+        /// Write a log event with the specified level and associated exception.
+        /// </summary>
+        /// <param name="level">The level of the event.</param>
+        /// <param name="exception">Exception related to the event.</param>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <param name="propertyValue0">Object positionally formatted into the message template.</param>
+        /// <param name="propertyValue1">Object positionally formatted into the message template.</param>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        void Write<T0, T1>(LogEventLevel level, Exception exception, string messageTemplate, T0 propertyValue0, T1 propertyValue1);
+
+        /// <summary>
+        /// Write a log event with the specified level and associated exception.
+        /// </summary>
+        /// <param name="level">The level of the event.</param>
+        /// <param name="exception">Exception related to the event.</param>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <param name="propertyValue0">Object positionally formatted into the message template.</param>
+        /// <param name="propertyValue1">Object positionally formatted into the message template.</param>
+        /// <param name="propertyValue2">Object positionally formatted into the message template.</param>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        void Write<T0, T1, T2>(LogEventLevel level, Exception exception, string messageTemplate, T0 propertyValue0, T1 propertyValue1, T2 propertyValue2);
 
         /// <summary>
         /// Write a log event with the specified level and associated exception.
@@ -99,6 +162,42 @@ namespace Serilog
         bool IsEnabled(LogEventLevel level);
 
         /// <summary>
+        /// Write a log event with the <see cref="LogEventLevel.Verbose"/> level.
+        /// </summary>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <param name="propertyValue">Object positionally formatted into the message template.</param>
+        /// <example>
+        /// Log.Verbose("Staring into space, wondering if we're alone.");
+        /// </example>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        void Verbose<T>(string messageTemplate, T propertyValue);
+
+        /// <summary>
+        /// Write a log event with the <see cref="LogEventLevel.Verbose"/> level.
+        /// </summary>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <param name="propertyValue0">Object positionally formatted into the message template.</param>
+        /// <param name="propertyValue1">Object positionally formatted into the message template.</param>
+        /// <example>
+        /// Log.Verbose("Staring into space, wondering if we're alone.");
+        /// </example>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        void Verbose<T0, T1>(string messageTemplate, T0 propertyValue0, T1 propertyValue1);
+
+        /// <summary>
+        /// Write a log event with the <see cref="LogEventLevel.Verbose"/> level.
+        /// </summary>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <param name="propertyValue0">Object positionally formatted into the message template.</param>
+        /// <param name="propertyValue1">Object positionally formatted into the message template.</param>
+        /// <param name="propertyValue2">Object positionally formatted into the message template.</param>
+        /// <example>
+        /// Log.Verbose("Staring into space, wondering if we're alone.");
+        /// </example>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        void Verbose<T0, T1, T2>(string messageTemplate, T0 propertyValue0, T1 propertyValue1, T2 propertyValue2);
+
+        /// <summary>
         /// Write a log event with the <see cref="LogEventLevel.Verbose"/> level and associated exception.
         /// </summary>
         /// <param name="messageTemplate">Message template describing the event.</param>
@@ -114,12 +213,87 @@ namespace Serilog
         /// </summary>
         /// <param name="exception">Exception related to the event.</param>
         /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <param name="propertyValue">Object positionally formatted into the message template.</param>
+        /// <example>
+        /// Log.Verbose(ex, "Staring into space, wondering where this comet came from.");
+        /// </example>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        void Verbose<T>(Exception exception, string messageTemplate, T propertyValue);
+
+        /// <summary>
+        /// Write a log event with the <see cref="LogEventLevel.Verbose"/> level and associated exception.
+        /// </summary>
+        /// <param name="exception">Exception related to the event.</param>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <param name="propertyValue0">Object positionally formatted into the message template.</param>
+        /// <param name="propertyValue1">Object positionally formatted into the message template.</param>
+        /// <example>
+        /// Log.Verbose(ex, "Staring into space, wondering where this comet came from.");
+        /// </example>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        void Verbose<T0, T1>(Exception exception, string messageTemplate, T0 propertyValue0, T1 propertyValue1);
+
+        /// <summary>
+        /// Write a log event with the <see cref="LogEventLevel.Verbose"/> level and associated exception.
+        /// </summary>
+        /// <param name="exception">Exception related to the event.</param>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <param name="propertyValue0">Object positionally formatted into the message template.</param>
+        /// <param name="propertyValue1">Object positionally formatted into the message template.</param>
+        /// <param name="propertyValue2">Object positionally formatted into the message template.</param>
+        /// <example>
+        /// Log.Verbose(ex, "Staring into space, wondering where this comet came from.");
+        /// </example>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        void Verbose<T0, T1, T2>(Exception exception, string messageTemplate, T0 propertyValue0, T1 propertyValue1, T2 propertyValue2);
+
+        /// <summary>
+        /// Write a log event with the <see cref="LogEventLevel.Verbose"/> level and associated exception.
+        /// </summary>
+        /// <param name="exception">Exception related to the event.</param>
+        /// <param name="messageTemplate">Message template describing the event.</param>
         /// <param name="propertyValues">Objects positionally formatted into the message template.</param>
         /// <example>
         /// Log.Verbose(ex, "Staring into space, wondering where this comet came from.");
         /// </example>
         [MessageTemplateFormatMethod("messageTemplate")]
         void Verbose(Exception exception, string messageTemplate, params object[] propertyValues);
+
+        /// <summary>
+        /// Write a log event with the <see cref="LogEventLevel.Debug"/> level.
+        /// </summary>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <param name="propertyValue">Object positionally formatted into the message template.</param>
+        /// <example>
+        /// Log.Debug("Starting up at {StartedAt}.", DateTime.Now);
+        /// </example>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        void Debug<T>(string messageTemplate, T propertyValue);
+
+        /// <summary>
+        /// Write a log event with the <see cref="LogEventLevel.Debug"/> level.
+        /// </summary>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <param name="propertyValue0">Object positionally formatted into the message template.</param>
+        /// <param name="propertyValue1">Object positionally formatted into the message template.</param>
+        /// <example>
+        /// Log.Debug("Starting up at {StartedAt}.", DateTime.Now);
+        /// </example>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        void Debug<T0, T1>(string messageTemplate, T0 propertyValue0, T1 propertyValue1);
+
+        /// <summary>
+        /// Write a log event with the <see cref="LogEventLevel.Debug"/> level.
+        /// </summary>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <param name="propertyValue0">Object positionally formatted into the message template.</param>
+        /// <param name="propertyValue1">Object positionally formatted into the message template.</param>
+        /// <param name="propertyValue2">Object positionally formatted into the message template.</param>
+        /// <example>
+        /// Log.Debug("Starting up at {StartedAt}.", DateTime.Now);
+        /// </example>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        void Debug<T0, T1, T2>(string messageTemplate, T0 propertyValue0, T1 propertyValue1, T2 propertyValue2);
 
         /// <summary>
         /// Write a log event with the <see cref="LogEventLevel.Debug"/> level and associated exception.
@@ -137,12 +311,87 @@ namespace Serilog
         /// </summary>
         /// <param name="exception">Exception related to the event.</param>
         /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <param name="propertyValue">Object positionally formatted into the message template.</param>
+        /// <example>
+        /// Log.Debug(ex, "Swallowing a mundane exception.");
+        /// </example>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        void Debug<T>(Exception exception, string messageTemplate, T propertyValue);
+
+        /// <summary>
+        /// Write a log event with the <see cref="LogEventLevel.Debug"/> level and associated exception.
+        /// </summary>
+        /// <param name="exception">Exception related to the event.</param>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <param name="propertyValue0">Object positionally formatted into the message template.</param>
+        /// <param name="propertyValue1">Object positionally formatted into the message template.</param>
+        /// <example>
+        /// Log.Debug(ex, "Swallowing a mundane exception.");
+        /// </example>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        void Debug<T0, T1>(Exception exception, string messageTemplate, T0 propertyValue0, T1 propertyValue1);
+
+        /// <summary>
+        /// Write a log event with the <see cref="LogEventLevel.Debug"/> level and associated exception.
+        /// </summary>
+        /// <param name="exception">Exception related to the event.</param>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <param name="propertyValue0">Object positionally formatted into the message template.</param>
+        /// <param name="propertyValue1">Object positionally formatted into the message template.</param>
+        /// <param name="propertyValue2">Object positionally formatted into the message template.</param>
+        /// <example>
+        /// Log.Debug(ex, "Swallowing a mundane exception.");
+        /// </example>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        void Debug<T0, T1, T2>(Exception exception, string messageTemplate, T0 propertyValue0, T1 propertyValue1, T2 propertyValue2);
+
+        /// <summary>
+        /// Write a log event with the <see cref="LogEventLevel.Debug"/> level and associated exception.
+        /// </summary>
+        /// <param name="exception">Exception related to the event.</param>
+        /// <param name="messageTemplate">Message template describing the event.</param>
         /// <param name="propertyValues">Objects positionally formatted into the message template.</param>
         /// <example>
         /// Log.Debug(ex, "Swallowing a mundane exception.");
         /// </example>
         [MessageTemplateFormatMethod("messageTemplate")]
         void Debug(Exception exception, string messageTemplate, params object[] propertyValues);
+
+        /// <summary>
+        /// Write a log event with the <see cref="LogEventLevel.Information"/> level.
+        /// </summary>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <param name="propertyValue">Object positionally formatted into the message template.</param>
+        /// <example>
+        /// Log.Information("Processed {RecordCount} records in {TimeMS}.", records.Length, sw.ElapsedMilliseconds);
+        /// </example>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        void Information<T>(string messageTemplate, T propertyValue);
+
+        /// <summary>
+        /// Write a log event with the <see cref="LogEventLevel.Information"/> level.
+        /// </summary>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <param name="propertyValue0">Object positionally formatted into the message template.</param>
+        /// <param name="propertyValue1">Object positionally formatted into the message template.</param>
+        /// <example>
+        /// Log.Information("Processed {RecordCount} records in {TimeMS}.", records.Length, sw.ElapsedMilliseconds);
+        /// </example>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        void Information<T0, T1>(string messageTemplate, T0 propertyValue0, T1 propertyValue1);
+
+        /// <summary>
+        /// Write a log event with the <see cref="LogEventLevel.Information"/> level.
+        /// </summary>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <param name="propertyValue0">Object positionally formatted into the message template.</param>
+        /// <param name="propertyValue1">Object positionally formatted into the message template.</param>
+        /// <param name="propertyValue2">Object positionally formatted into the message template.</param>
+        /// <example>
+        /// Log.Information("Processed {RecordCount} records in {TimeMS}.", records.Length, sw.ElapsedMilliseconds);
+        /// </example>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        void Information<T0, T1, T2>(string messageTemplate, T0 propertyValue0, T1 propertyValue1, T2 propertyValue2);
 
         /// <summary>
         /// Write a log event with the <see cref="LogEventLevel.Information"/> level and associated exception.
@@ -160,12 +409,87 @@ namespace Serilog
         /// </summary>
         /// <param name="exception">Exception related to the event.</param>
         /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <param name="propertyValue">Object positionally formatted into the message template.</param>
+        /// <example>
+        /// Log.Information(ex, "Processed {RecordCount} records in {TimeMS}.", records.Length, sw.ElapsedMilliseconds);
+        /// </example>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        void Information<T>(Exception exception, string messageTemplate, T propertyValue);
+
+        /// <summary>
+        /// Write a log event with the <see cref="LogEventLevel.Information"/> level and associated exception.
+        /// </summary>
+        /// <param name="exception">Exception related to the event.</param>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <param name="propertyValue0">Object positionally formatted into the message template.</param>
+        /// <param name="propertyValue1">Object positionally formatted into the message template.</param>
+        /// <example>
+        /// Log.Information(ex, "Processed {RecordCount} records in {TimeMS}.", records.Length, sw.ElapsedMilliseconds);
+        /// </example>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        void Information<T0, T1>(Exception exception, string messageTemplate, T0 propertyValue0, T1 propertyValue1);
+
+        /// <summary>
+        /// Write a log event with the <see cref="LogEventLevel.Information"/> level and associated exception.
+        /// </summary>
+        /// <param name="exception">Exception related to the event.</param>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <param name="propertyValue0">Object positionally formatted into the message template.</param>
+        /// <param name="propertyValue1">Object positionally formatted into the message template.</param>
+        /// <param name="propertyValue2">Object positionally formatted into the message template.</param>
+        /// <example>
+        /// Log.Information(ex, "Processed {RecordCount} records in {TimeMS}.", records.Length, sw.ElapsedMilliseconds);
+        /// </example>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        void Information<T0, T1, T2>(Exception exception, string messageTemplate, T0 propertyValue0, T1 propertyValue1, T2 propertyValue2);
+
+        /// <summary>
+        /// Write a log event with the <see cref="LogEventLevel.Information"/> level and associated exception.
+        /// </summary>
+        /// <param name="exception">Exception related to the event.</param>
+        /// <param name="messageTemplate">Message template describing the event.</param>
         /// <param name="propertyValues">Objects positionally formatted into the message template.</param>
         /// <example>
         /// Log.Information(ex, "Processed {RecordCount} records in {TimeMS}.", records.Length, sw.ElapsedMilliseconds);
         /// </example>
         [MessageTemplateFormatMethod("messageTemplate")]
         void Information(Exception exception, string messageTemplate, params object[] propertyValues);
+
+        /// <summary>
+        /// Write a log event with the <see cref="LogEventLevel.Warning"/> level.
+        /// </summary>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <param name="propertyValue">Object positionally formatted into the message template.</param>
+        /// <example>
+        /// Log.Warning("Skipped {SkipCount} records.", skippedRecords.Length);
+        /// </example>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        void Warning<T>(string messageTemplate, T propertyValue);
+
+        /// <summary>
+        /// Write a log event with the <see cref="LogEventLevel.Warning"/> level.
+        /// </summary>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <param name="propertyValue0">Object positionally formatted into the message template.</param>
+        /// <param name="propertyValue1">Object positionally formatted into the message template.</param>
+        /// <example>
+        /// Log.Warning("Skipped {SkipCount} records.", skippedRecords.Length);
+        /// </example>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        void Warning<T0, T1>(string messageTemplate, T0 propertyValue0, T1 propertyValue1);
+
+        /// <summary>
+        /// Write a log event with the <see cref="LogEventLevel.Warning"/> level.
+        /// </summary>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <param name="propertyValue0">Object positionally formatted into the message template.</param>
+        /// <param name="propertyValue1">Object positionally formatted into the message template.</param>
+        /// <param name="propertyValue2">Object positionally formatted into the message template.</param>
+        /// <example>
+        /// Log.Warning("Skipped {SkipCount} records.", skippedRecords.Length);
+        /// </example>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        void Warning<T0, T1, T2>(string messageTemplate, T0 propertyValue0, T1 propertyValue1, T2 propertyValue2);
 
         /// <summary>
         /// Write a log event with the <see cref="LogEventLevel.Warning"/> level and associated exception.
@@ -183,12 +507,87 @@ namespace Serilog
         /// </summary>
         /// <param name="exception">Exception related to the event.</param>
         /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <param name="propertyValue">Object positionally formatted into the message template.</param>
+        /// <example>
+        /// Log.Warning(ex, "Skipped {SkipCount} records.", skippedRecords.Length);
+        /// </example>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        void Warning<T>(Exception exception, string messageTemplate, T propertyValue);
+
+        /// <summary>
+        /// Write a log event with the <see cref="LogEventLevel.Warning"/> level and associated exception.
+        /// </summary>
+        /// <param name="exception">Exception related to the event.</param>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <param name="propertyValue0">Object positionally formatted into the message template.</param>
+        /// <param name="propertyValue1">Object positionally formatted into the message template.</param>
+        /// <example>
+        /// Log.Warning(ex, "Skipped {SkipCount} records.", skippedRecords.Length);
+        /// </example>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        void Warning<T0, T1>(Exception exception, string messageTemplate, T0 propertyValue0, T1 propertyValue1);
+
+        /// <summary>
+        /// Write a log event with the <see cref="LogEventLevel.Warning"/> level and associated exception.
+        /// </summary>
+        /// <param name="exception">Exception related to the event.</param>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <param name="propertyValue0">Object positionally formatted into the message template.</param>
+        /// <param name="propertyValue1">Object positionally formatted into the message template.</param>
+        /// <param name="propertyValue2">Object positionally formatted into the message template.</param>
+        /// <example>
+        /// Log.Warning(ex, "Skipped {SkipCount} records.", skippedRecords.Length);
+        /// </example>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        void Warning<T0, T1, T2>(Exception exception, string messageTemplate, T0 propertyValue0, T1 propertyValue1, T2 propertyValue2);
+
+        /// <summary>
+        /// Write a log event with the <see cref="LogEventLevel.Warning"/> level and associated exception.
+        /// </summary>
+        /// <param name="exception">Exception related to the event.</param>
+        /// <param name="messageTemplate">Message template describing the event.</param>
         /// <param name="propertyValues">Objects positionally formatted into the message template.</param>
         /// <example>
         /// Log.Warning(ex, "Skipped {SkipCount} records.", skippedRecords.Length);
         /// </example>
         [MessageTemplateFormatMethod("messageTemplate")]
         void Warning(Exception exception, string messageTemplate, params object[] propertyValues);
+
+        /// <summary>
+        /// Write a log event with the <see cref="LogEventLevel.Error"/> level.
+        /// </summary>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <param name="propertyValue">Object positionally formatted into the message template.</param>
+        /// <example>
+        /// Log.Error("Failed {ErrorCount} records.", brokenRecords.Length);
+        /// </example>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        void Error<T>(string messageTemplate, T propertyValue);
+
+        /// <summary>
+        /// Write a log event with the <see cref="LogEventLevel.Error"/> level.
+        /// </summary>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <param name="propertyValue0">Object positionally formatted into the message template.</param>
+        /// <param name="propertyValue1">Object positionally formatted into the message template.</param>
+        /// <example>
+        /// Log.Error("Failed {ErrorCount} records.", brokenRecords.Length);
+        /// </example>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        void Error<T0, T1>(string messageTemplate, T0 propertyValue0, T1 propertyValue1);
+
+        /// <summary>
+        /// Write a log event with the <see cref="LogEventLevel.Error"/> level.
+        /// </summary>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <param name="propertyValue0">Object positionally formatted into the message template.</param>
+        /// <param name="propertyValue1">Object positionally formatted into the message template.</param>
+        /// <param name="propertyValue2">Object positionally formatted into the message template.</param>
+        /// <example>
+        /// Log.Error("Failed {ErrorCount} records.", brokenRecords.Length);
+        /// </example>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        void Error<T0, T1, T2>(string messageTemplate, T0 propertyValue0, T1 propertyValue1, T2 propertyValue2);
 
         /// <summary>
         /// Write a log event with the <see cref="LogEventLevel.Error"/> level and associated exception.
@@ -206,12 +605,87 @@ namespace Serilog
         /// </summary>
         /// <param name="exception">Exception related to the event.</param>
         /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <param name="propertyValue">Object positionally formatted into the message template.</param>
+        /// <example>
+        /// Log.Error(ex, "Failed {ErrorCount} records.", brokenRecords.Length);
+        /// </example>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        void Error<T>(Exception exception, string messageTemplate, T propertyValue);
+
+        /// <summary>
+        /// Write a log event with the <see cref="LogEventLevel.Error"/> level and associated exception.
+        /// </summary>
+        /// <param name="exception">Exception related to the event.</param>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <param name="propertyValue0">Object positionally formatted into the message template.</param>
+        /// <param name="propertyValue1">Object positionally formatted into the message template.</param>
+        /// <example>
+        /// Log.Error(ex, "Failed {ErrorCount} records.", brokenRecords.Length);
+        /// </example>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        void Error<T0, T1>(Exception exception, string messageTemplate, T0 propertyValue0, T1 propertyValue1);
+
+        /// <summary>
+        /// Write a log event with the <see cref="LogEventLevel.Error"/> level and associated exception.
+        /// </summary>
+        /// <param name="exception">Exception related to the event.</param>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <param name="propertyValue0">Object positionally formatted into the message template.</param>
+        /// <param name="propertyValue1">Object positionally formatted into the message template.</param>
+        /// <param name="propertyValue2">Object positionally formatted into the message template.</param>
+        /// <example>
+        /// Log.Error(ex, "Failed {ErrorCount} records.", brokenRecords.Length);
+        /// </example>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        void Error<T0, T1, T2>(Exception exception, string messageTemplate, T0 propertyValue0, T1 propertyValue1, T2 propertyValue2);
+
+        /// <summary>
+        /// Write a log event with the <see cref="LogEventLevel.Error"/> level and associated exception.
+        /// </summary>
+        /// <param name="exception">Exception related to the event.</param>
+        /// <param name="messageTemplate">Message template describing the event.</param>
         /// <param name="propertyValues">Objects positionally formatted into the message template.</param>
         /// <example>
         /// Log.Error(ex, "Failed {ErrorCount} records.", brokenRecords.Length);
         /// </example>
         [MessageTemplateFormatMethod("messageTemplate")]
         void Error(Exception exception, string messageTemplate, params object[] propertyValues);
+
+        /// <summary>
+        /// Write a log event with the <see cref="LogEventLevel.Fatal"/> level.
+        /// </summary>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <param name="propertyValue">Object positionally formatted into the message template.</param>
+        /// <example>
+        /// Log.Fatal("Process terminating.");
+        /// </example>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        void Fatal<T>(string messageTemplate, T propertyValue);
+
+        /// <summary>
+        /// Write a log event with the <see cref="LogEventLevel.Fatal"/> level.
+        /// </summary>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <param name="propertyValue0">Object positionally formatted into the message template.</param>
+        /// <param name="propertyValue1">Object positionally formatted into the message template.</param>
+        /// <example>
+        /// Log.Fatal("Process terminating.");
+        /// </example>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        void Fatal<T0, T1>(string messageTemplate, T0 propertyValue0, T1 propertyValue1);
+
+        /// <summary>
+        /// Write a log event with the <see cref="LogEventLevel.Fatal"/> level.
+        /// </summary>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <param name="propertyValue0">Object positionally formatted into the message template.</param>
+        /// <param name="propertyValue1">Object positionally formatted into the message template.</param>
+        /// <param name="propertyValue2">Object positionally formatted into the message template.</param>
+        /// <example>
+        /// Log.Fatal("Process terminating.");
+        /// </example>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        void Fatal<T0, T1, T2>(string messageTemplate, T0 propertyValue0, T1 propertyValue1, T2 propertyValue2);
 
         /// <summary>
         /// Write a log event with the <see cref="LogEventLevel.Fatal"/> level and associated exception.
@@ -223,6 +697,45 @@ namespace Serilog
         /// </example>
         [MessageTemplateFormatMethod("messageTemplate")]
         void Fatal(string messageTemplate, params object[] propertyValues);
+
+        /// <summary>
+        /// Write a log event with the <see cref="LogEventLevel.Fatal"/> level and associated exception.
+        /// </summary>
+        /// <param name="exception">Exception related to the event.</param>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <param name="propertyValue">Object positionally formatted into the message template.</param>
+        /// <example>
+        /// Log.Fatal(ex, "Process terminating.");
+        /// </example>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        void Fatal<T>(Exception exception, string messageTemplate, T propertyValue);
+
+        /// <summary>
+        /// Write a log event with the <see cref="LogEventLevel.Fatal"/> level and associated exception.
+        /// </summary>
+        /// <param name="exception">Exception related to the event.</param>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <param name="propertyValue0">Object positionally formatted into the message template.</param>
+        /// <param name="propertyValue1">Object positionally formatted into the message template.</param>
+        /// <example>
+        /// Log.Fatal(ex, "Process terminating.");
+        /// </example>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        void Fatal<T0, T1>(Exception exception, string messageTemplate, T0 propertyValue0, T1 propertyValue1);
+
+        /// <summary>
+        /// Write a log event with the <see cref="LogEventLevel.Fatal"/> level and associated exception.
+        /// </summary>
+        /// <param name="exception">Exception related to the event.</param>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <param name="propertyValue0">Object positionally formatted into the message template.</param>
+        /// <param name="propertyValue1">Object positionally formatted into the message template.</param>
+        /// <param name="propertyValue2">Object positionally formatted into the message template.</param>
+        /// <example>
+        /// Log.Fatal(ex, "Process terminating.");
+        /// </example>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        void Fatal<T0, T1, T2>(Exception exception, string messageTemplate, T0 propertyValue0, T1 propertyValue1, T2 propertyValue2);
 
         /// <summary>
         /// Write a log event with the <see cref="LogEventLevel.Fatal"/> level and associated exception.

--- a/src/Serilog/Log.cs
+++ b/src/Serilog/Log.cs
@@ -124,11 +124,7 @@ namespace Serilog
         [MessageTemplateFormatMethod("messageTemplate")]
         public static void Write<T>(LogEventLevel level, string messageTemplate, T propertyValue)
         {
-            // Avoid the array allocation and any boxing allocations when the level isn't enabled
-            if (Logger.IsEnabled(level))
-            {
-                Logger.Write(level, messageTemplate, new object[] { propertyValue });
-            }
+            Logger.Write(level, messageTemplate, propertyValue);
         }
 
         /// <summary>
@@ -141,11 +137,7 @@ namespace Serilog
         [MessageTemplateFormatMethod("messageTemplate")]
         public static void Write<T0, T1>(LogEventLevel level, string messageTemplate, T0 propertyValue0, T1 propertyValue1)
         {
-            // Avoid the array allocation and any boxing allocations when the level isn't enabled
-            if (Logger.IsEnabled(level))
-            {
-                Logger.Write(level, messageTemplate, new object[] { propertyValue0, propertyValue1 });
-            }
+            Logger.Write(level, messageTemplate, propertyValue0, propertyValue1);
         }
 
         /// <summary>
@@ -159,11 +151,7 @@ namespace Serilog
         [MessageTemplateFormatMethod("messageTemplate")]
         public static void Write<T0, T1, T2>(LogEventLevel level, string messageTemplate, T0 propertyValue0, T1 propertyValue1, T2 propertyValue2)
         {
-            // Avoid the array allocation and any boxing allocations when the level isn't enabled
-            if (Logger.IsEnabled(level))
-            {
-                Logger.Write(level, messageTemplate, new object[] { propertyValue0, propertyValue1, propertyValue2 });
-            }
+            Logger.Write(level, messageTemplate, propertyValue0, propertyValue1, propertyValue2);
         }
 
         /// <summary>
@@ -188,11 +176,7 @@ namespace Serilog
         [MessageTemplateFormatMethod("messageTemplate")]
         public static void Write<T>(LogEventLevel level, Exception exception, string messageTemplate, T propertyValue)
         {
-            // Avoid the array allocation and any boxing allocations when the level isn't enabled
-            if (Logger.IsEnabled(level))
-            {
-                Logger.Write(level, exception, messageTemplate, new object[] { propertyValue });
-            }
+            Logger.Write(level, exception, messageTemplate, propertyValue);
         }
 
         /// <summary>
@@ -206,11 +190,7 @@ namespace Serilog
         [MessageTemplateFormatMethod("messageTemplate")]
         public static void Write<T0, T1>(LogEventLevel level, Exception exception, string messageTemplate, T0 propertyValue0, T1 propertyValue1)
         {
-            // Avoid the array allocation and any boxing allocations when the level isn't enabled
-            if (Logger.IsEnabled(level))
-            {
-                Logger.Write(level, exception, messageTemplate, new object[] { propertyValue0, propertyValue1 });
-            }
+            Logger.Write(level, exception, messageTemplate, propertyValue0, propertyValue1);
         }
 
         /// <summary>
@@ -225,11 +205,7 @@ namespace Serilog
         [MessageTemplateFormatMethod("messageTemplate")]
         public static void Write<T0, T1, T2>(LogEventLevel level, Exception exception, string messageTemplate, T0 propertyValue0, T1 propertyValue1, T2 propertyValue2)
         {
-            // Avoid the array allocation and any boxing allocations when the level isn't enabled
-            if (Logger.IsEnabled(level))
-            {
-                Logger.Write(level, exception, messageTemplate, new object[] { propertyValue0, propertyValue1, propertyValue2 });
-            }
+            Logger.Write(level, exception, messageTemplate, propertyValue0, propertyValue1, propertyValue2);
         }
 
         /// <summary>
@@ -255,6 +231,7 @@ namespace Serilog
         {
             return Logger.IsEnabled(level);
         }
+
         /// <summary>
         /// Write a log event with the <see cref="LogEventLevel.Verbose"/> level.
         /// </summary>

--- a/src/Serilog/Log.cs
+++ b/src/Serilog/Log.cs
@@ -120,6 +120,17 @@ namespace Serilog
         /// </summary>
         /// <param name="level">The level of the event.</param>
         /// <param name="messageTemplate">Message template describing the event.</param>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        public static void Write(LogEventLevel level, string messageTemplate)
+        {
+            Logger.Write(level, messageTemplate);
+        }
+
+        /// <summary>
+        /// Write a log event with the specified level.
+        /// </summary>
+        /// <param name="level">The level of the event.</param>
+        /// <param name="messageTemplate">Message template describing the event.</param>
         /// <param name="propertyValue">Object positionally formatted into the message template.</param>
         [MessageTemplateFormatMethod("messageTemplate")]
         public static void Write<T>(LogEventLevel level, string messageTemplate, T propertyValue)
@@ -164,6 +175,18 @@ namespace Serilog
         public static void Write(LogEventLevel level, string messageTemplate, params object[] propertyValues)
         {
             Logger.Write(level, messageTemplate, propertyValues);
+        }
+
+        /// <summary>
+        /// Write a log event with the specified level and associated exception.
+        /// </summary>
+        /// <param name="level">The level of the event.</param>
+        /// <param name="exception">Exception related to the event.</param>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        public static void Write(LogEventLevel level, Exception exception, string messageTemplate)
+        {
+            Logger.Write(level, exception, messageTemplate);
         }
 
         /// <summary>
@@ -236,6 +259,19 @@ namespace Serilog
         /// Write a log event with the <see cref="LogEventLevel.Verbose"/> level.
         /// </summary>
         /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <example>
+        /// Log.Verbose("Staring into space, wondering if we're alone.");
+        /// </example>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        public static void Verbose(string messageTemplate)
+        {
+            Write(LogEventLevel.Verbose, messageTemplate);
+        }
+
+        /// <summary>
+        /// Write a log event with the <see cref="LogEventLevel.Verbose"/> level.
+        /// </summary>
+        /// <param name="messageTemplate">Message template describing the event.</param>
         /// <param name="propertyValue">Object positionally formatted into the message template.</param>
         /// <example>
         /// Log.Verbose("Staring into space, wondering if we're alone.");
@@ -289,6 +325,20 @@ namespace Serilog
         public static void Verbose(string messageTemplate, params object[] propertyValues)
         {
             Logger.Verbose(messageTemplate, propertyValues);
+        }
+
+        /// <summary>
+        /// Write a log event with the <see cref="LogEventLevel.Verbose"/> level and associated exception.
+        /// </summary>
+        /// <param name="exception">Exception related to the event.</param>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <example>
+        /// Log.Verbose(ex, "Staring into space, wondering where this comet came from.");
+        /// </example>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        public static void Verbose(Exception exception, string messageTemplate)
+        {
+            Write(LogEventLevel.Verbose, exception, messageTemplate);
         }
 
         /// <summary>
@@ -358,6 +408,19 @@ namespace Serilog
         /// Write a log event with the <see cref="LogEventLevel.Debug"/> level.
         /// </summary>
         /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <example>
+        /// Log.Debug("Starting up at {StartedAt}.", DateTime.Now);
+        /// </example>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        public static void Debug(string messageTemplate)
+        {
+            Write(LogEventLevel.Debug, messageTemplate);
+        }
+
+        /// <summary>
+        /// Write a log event with the <see cref="LogEventLevel.Debug"/> level.
+        /// </summary>
+        /// <param name="messageTemplate">Message template describing the event.</param>
         /// <param name="propertyValue">Object positionally formatted into the message template.</param>
         /// <example>
         /// Log.Debug("Starting up at {StartedAt}.", DateTime.Now);
@@ -411,6 +474,20 @@ namespace Serilog
         public static void Debug(string messageTemplate, params object[] propertyValues)
         {
             Logger.Debug(messageTemplate, propertyValues);
+        }
+
+        /// <summary>
+        /// Write a log event with the <see cref="LogEventLevel.Debug"/> level and associated exception.
+        /// </summary>
+        /// <param name="exception">Exception related to the event.</param>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <example>
+        /// Log.Debug(ex, "Swallowing a mundane exception.");
+        /// </example>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        public static void Debug(Exception exception, string messageTemplate)
+        {
+            Write(LogEventLevel.Debug, exception, messageTemplate);
         }
 
         /// <summary>
@@ -480,6 +557,19 @@ namespace Serilog
         /// Write a log event with the <see cref="LogEventLevel.Information"/> level.
         /// </summary>
         /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <example>
+        /// Log.Information("Processed {RecordCount} records in {TimeMS}.", records.Length, sw.ElapsedMilliseconds);
+        /// </example>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        public static void Information(string messageTemplate)
+        {
+            Write(LogEventLevel.Information, messageTemplate);
+        }
+
+        /// <summary>
+        /// Write a log event with the <see cref="LogEventLevel.Information"/> level.
+        /// </summary>
+        /// <param name="messageTemplate">Message template describing the event.</param>
         /// <param name="propertyValue">Object positionally formatted into the message template.</param>
         /// <example>
         /// Log.Information("Processed {RecordCount} records in {TimeMS}.", records.Length, sw.ElapsedMilliseconds);
@@ -533,6 +623,20 @@ namespace Serilog
         public static void Information(string messageTemplate, params object[] propertyValues)
         {
             Logger.Information(messageTemplate, propertyValues);
+        }
+
+        /// <summary>
+        /// Write a log event with the <see cref="LogEventLevel.Information"/> level and associated exception.
+        /// </summary>
+        /// <param name="exception">Exception related to the event.</param>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <example>
+        /// Log.Information(ex, "Processed {RecordCount} records in {TimeMS}.", records.Length, sw.ElapsedMilliseconds);
+        /// </example>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        public static void Information(Exception exception, string messageTemplate)
+        {
+            Write(LogEventLevel.Information, exception, messageTemplate);
         }
 
         /// <summary>
@@ -602,6 +706,19 @@ namespace Serilog
         /// Write a log event with the <see cref="LogEventLevel.Warning"/> level.
         /// </summary>
         /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <example>
+        /// Log.Warning("Skipped {SkipCount} records.", skippedRecords.Length);
+        /// </example>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        public static void Warning(string messageTemplate)
+        {
+            Write(LogEventLevel.Warning, messageTemplate);
+        }
+
+        /// <summary>
+        /// Write a log event with the <see cref="LogEventLevel.Warning"/> level.
+        /// </summary>
+        /// <param name="messageTemplate">Message template describing the event.</param>
         /// <param name="propertyValue">Object positionally formatted into the message template.</param>
         /// <example>
         /// Log.Warning("Skipped {SkipCount} records.", skippedRecords.Length);
@@ -611,7 +728,7 @@ namespace Serilog
         {
             Write(LogEventLevel.Warning, messageTemplate, propertyValue);
         }
-
+        
         /// <summary>
         /// Write a log event with the <see cref="LogEventLevel.Warning"/> level.
         /// </summary>
@@ -655,6 +772,20 @@ namespace Serilog
         public static void Warning(string messageTemplate, params object[] propertyValues)
         {
             Logger.Warning(messageTemplate, propertyValues);
+        }
+
+        /// <summary>
+        /// Write a log event with the <see cref="LogEventLevel.Warning"/> level and associated exception.
+        /// </summary>
+        /// <param name="exception">Exception related to the event.</param>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <example>
+        /// Log.Warning(ex, "Skipped {SkipCount} records.", skippedRecords.Length);
+        /// </example>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        public static void Warning(Exception exception, string messageTemplate)
+        {
+            Write(LogEventLevel.Warning, exception, messageTemplate);
         }
 
         /// <summary>
@@ -724,6 +855,19 @@ namespace Serilog
         /// Write a log event with the <see cref="LogEventLevel.Error"/> level.
         /// </summary>
         /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <example>
+        /// Log.Error("Failed {ErrorCount} records.", brokenRecords.Length);
+        /// </example>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        public static void Error(string messageTemplate)
+        {
+            Write(LogEventLevel.Error, messageTemplate);
+        }
+
+        /// <summary>
+        /// Write a log event with the <see cref="LogEventLevel.Error"/> level.
+        /// </summary>
+        /// <param name="messageTemplate">Message template describing the event.</param>
         /// <param name="propertyValue">Object positionally formatted into the message template.</param>
         /// <example>
         /// Log.Error("Failed {ErrorCount} records.", brokenRecords.Length);
@@ -777,6 +921,20 @@ namespace Serilog
         public static void Error(string messageTemplate, params object[] propertyValues)
         {
             Logger.Error(messageTemplate, propertyValues);
+        }
+
+        /// <summary>
+        /// Write a log event with the <see cref="LogEventLevel.Error"/> level and associated exception.
+        /// </summary>
+        /// <param name="exception">Exception related to the event.</param>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <example>
+        /// Log.Error(ex, "Failed {ErrorCount} records.", brokenRecords.Length);
+        /// </example>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        public static void Error(Exception exception, string messageTemplate)
+        {
+            Write(LogEventLevel.Error, exception, messageTemplate);
         }
 
         /// <summary>
@@ -846,6 +1004,19 @@ namespace Serilog
         /// Write a log event with the <see cref="LogEventLevel.Fatal"/> level.
         /// </summary>
         /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <example>
+        /// Log.Fatal("Process terminating.");
+        /// </example>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        public static void Fatal(string messageTemplate)
+        {
+            Write(LogEventLevel.Fatal, messageTemplate);
+        }
+
+        /// <summary>
+        /// Write a log event with the <see cref="LogEventLevel.Fatal"/> level.
+        /// </summary>
+        /// <param name="messageTemplate">Message template describing the event.</param>
         /// <param name="propertyValue">Object positionally formatted into the message template.</param>
         /// <example>
         /// Log.Fatal("Process terminating.");
@@ -899,6 +1070,20 @@ namespace Serilog
         public static void Fatal(string messageTemplate, params object[] propertyValues)
         {
             Logger.Fatal(messageTemplate, propertyValues);
+        }
+
+        /// <summary>
+        /// Write a log event with the <see cref="LogEventLevel.Fatal"/> level and associated exception.
+        /// </summary>
+        /// <param name="exception">Exception related to the event.</param>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <example>
+        /// Log.Fatal(ex, "Process terminating.");
+        /// </example>
+        [MessageTemplateFormatMethod("messageTemplate")]
+        public static void Fatal(Exception exception, string messageTemplate)
+        {
+            Write(LogEventLevel.Fatal, exception, messageTemplate);
         }
 
         /// <summary>

--- a/test/Serilog.Tests/Support/DisposableLogger.cs
+++ b/test/Serilog.Tests/Support/DisposableLogger.cs
@@ -323,5 +323,75 @@ namespace Serilog.Tests.Support
         {
             throw new NotImplementedException();
         }
+
+        public void Write(LogEventLevel level, string messageTemplate)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Write(LogEventLevel level, Exception exception, string messageTemplate)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Verbose(string messageTemplate)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Verbose(Exception exception, string messageTemplate)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Debug(string messageTemplate)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Debug(Exception exception, string messageTemplate)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Information(string messageTemplate)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Information(Exception exception, string messageTemplate)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Warning(string messageTemplate)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Warning(Exception exception, string messageTemplate)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Error(string messageTemplate)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Error(Exception exception, string messageTemplate)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Fatal(string messageTemplate)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Fatal(Exception exception, string messageTemplate)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/test/Serilog.Tests/Support/DisposableLogger.cs
+++ b/test/Serilog.Tests/Support/DisposableLogger.cs
@@ -5,7 +5,7 @@ using Serilog.Events;
 
 namespace Serilog.Tests.Support
 {
-    public class DisposableLogger : ILogger, IDisposable
+    public class DisposableLogger : Serilog.ILogger, IDisposable
     {
         public bool Disposed { get; set; }
 
@@ -110,6 +110,216 @@ namespace Serilog.Tests.Support
         }
 
         public void Fatal(Exception exception, string messageTemplate, params object[] propertyValues)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Write<T>(LogEventLevel level, string messageTemplate, T propertyValue)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Write<T0, T1>(LogEventLevel level, string messageTemplate, T0 propertyValue0, T1 propertyValue1)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Write<T0, T1, T2>(LogEventLevel level, string messageTemplate, T0 propertyValue0, T1 propertyValue1, T2 propertyValue2)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Write<T>(LogEventLevel level, Exception exception, string messageTemplate, T propertyValue)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Write<T0, T1>(LogEventLevel level, Exception exception, string messageTemplate, T0 propertyValue0, T1 propertyValue1)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Write<T0, T1, T2>(LogEventLevel level, Exception exception, string messageTemplate, T0 propertyValue0, T1 propertyValue1, T2 propertyValue2)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Verbose<T>(string messageTemplate, T propertyValue)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Verbose<T0, T1>(string messageTemplate, T0 propertyValue0, T1 propertyValue1)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Verbose<T0, T1, T2>(string messageTemplate, T0 propertyValue0, T1 propertyValue1, T2 propertyValue2)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Verbose<T>(Exception exception, string messageTemplate, T propertyValue)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Verbose<T0, T1>(Exception exception, string messageTemplate, T0 propertyValue0, T1 propertyValue1)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Verbose<T0, T1, T2>(Exception exception, string messageTemplate, T0 propertyValue0, T1 propertyValue1, T2 propertyValue2)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Debug<T>(string messageTemplate, T propertyValue)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Debug<T0, T1>(string messageTemplate, T0 propertyValue0, T1 propertyValue1)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Debug<T0, T1, T2>(string messageTemplate, T0 propertyValue0, T1 propertyValue1, T2 propertyValue2)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Debug<T>(Exception exception, string messageTemplate, T propertyValue)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Debug<T0, T1>(Exception exception, string messageTemplate, T0 propertyValue0, T1 propertyValue1)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Debug<T0, T1, T2>(Exception exception, string messageTemplate, T0 propertyValue0, T1 propertyValue1, T2 propertyValue2)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Information<T>(string messageTemplate, T propertyValue)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Information<T0, T1>(string messageTemplate, T0 propertyValue0, T1 propertyValue1)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Information<T0, T1, T2>(string messageTemplate, T0 propertyValue0, T1 propertyValue1, T2 propertyValue2)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Information<T>(Exception exception, string messageTemplate, T propertyValue)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Information<T0, T1>(Exception exception, string messageTemplate, T0 propertyValue0, T1 propertyValue1)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Information<T0, T1, T2>(Exception exception, string messageTemplate, T0 propertyValue0, T1 propertyValue1, T2 propertyValue2)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Warning<T>(string messageTemplate, T propertyValue)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Warning<T0, T1>(string messageTemplate, T0 propertyValue0, T1 propertyValue1)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Warning<T0, T1, T2>(string messageTemplate, T0 propertyValue0, T1 propertyValue1, T2 propertyValue2)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Warning<T>(Exception exception, string messageTemplate, T propertyValue)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Warning<T0, T1>(Exception exception, string messageTemplate, T0 propertyValue0, T1 propertyValue1)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Warning<T0, T1, T2>(Exception exception, string messageTemplate, T0 propertyValue0, T1 propertyValue1, T2 propertyValue2)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Error<T>(string messageTemplate, T propertyValue)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Error<T0, T1>(string messageTemplate, T0 propertyValue0, T1 propertyValue1)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Error<T0, T1, T2>(string messageTemplate, T0 propertyValue0, T1 propertyValue1, T2 propertyValue2)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Error<T>(Exception exception, string messageTemplate, T propertyValue)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Error<T0, T1>(Exception exception, string messageTemplate, T0 propertyValue0, T1 propertyValue1)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Error<T0, T1, T2>(Exception exception, string messageTemplate, T0 propertyValue0, T1 propertyValue1, T2 propertyValue2)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Fatal<T>(string messageTemplate, T propertyValue)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Fatal<T0, T1>(string messageTemplate, T0 propertyValue0, T1 propertyValue1)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Fatal<T0, T1, T2>(string messageTemplate, T0 propertyValue0, T1 propertyValue1, T2 propertyValue2)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Fatal<T>(Exception exception, string messageTemplate, T propertyValue)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Fatal<T0, T1>(Exception exception, string messageTemplate, T0 propertyValue0, T1 propertyValue1)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Fatal<T0, T1, T2>(Exception exception, string messageTemplate, T0 propertyValue0, T1 propertyValue1, T2 propertyValue2)
         {
             throw new NotImplementedException();
         }


### PR DESCRIPTION
#585 

## Breaking change

Adds many methods to ILogger.

## Description

Removes one `params` array allocation per call, and potentially one boxing allocation per argument, for all `ILogger` methods of three or fewer parameters when logging for that level is off.

```csharp
            var logger = new LoggerConfiguration()
                .WriteTo.Sink(new DelegatingSink(e => { }))
                .CreateLogger();

            var sw = System.Diagnostics.Stopwatch.StartNew();

            for (var i = 0; i < 10000000; ++i)
            {
                logger.Debug("Iteration {I}", i);
            }

            Console.WriteLine(sw.Elapsed);
```

Before: 0.153 seconds; after: 0.016 seconds.


Notes:

Ridiculously large and tedious change, needs another pair of eyes on it :-)