### PR TITLE
Enable(action) for SelfLog

### DIFF
--- a/src/Serilog/Debugging/SelfLog.cs
+++ b/src/Serilog/Debugging/SelfLog.cs
@@ -23,6 +23,8 @@ namespace Serilog.Debugging
     /// </summary>
     public static class SelfLog
     {
+        static readonly Action<string> _output;
+
         /// <summary>
         /// The output mechanism for self-log events.
         /// </summary>
@@ -30,7 +32,29 @@ namespace Serilog.Debugging
         /// SelfLog.Out = Console.Error;
         /// </example>
         // ReSharper disable once MemberCanBePrivate.Global, UnusedAutoPropertyAccessor.Global
-        public static TextWriter Out { get; set; }
+        [Obsolete("Use SetOutput() instead")]
+        public static TextWriter Out
+        {
+            set
+            {
+                if (value == null)
+                {
+                    SetOutput(null);
+                }
+                else
+                {
+                    SetOutput(m =>
+                    {
+                        value.WriteLine(DateTime.UtcNow.ToString("o") + " " + m);
+                        value.Flush();
+                    });
+                }
+            }
+        }
+
+        public static void SetOutput(Action<string> output)
+        {
+        }
 
         /// <summary>
         /// Write a message to the self-log.
@@ -41,11 +65,10 @@ namespace Serilog.Debugging
         /// <param name="arg2">Third argument, if supplied.</param>
         public static void WriteLine(string format, object arg0 = null, object arg1 = null, object arg2 = null)
         {
-            var o = Out;
+            var o = _output;
             if (o != null)
             {
-                o.WriteLine(DateTime.Now.ToString("s") + " " + format, arg0, arg1, arg2);
-                o.Flush();
+                o(string.Format(format, arg0, arg1, arg2));
             }
         }
     }

--- a/src/Serilog/Debugging/SelfLog.cs
+++ b/src/Serilog/Debugging/SelfLog.cs
@@ -26,7 +26,7 @@ namespace Serilog.Debugging
         static Action<string> _output;
 
         /// <summary>
-        /// The output mechanism for self-log events.
+        /// The output mechanism for self-log messages.
         /// </summary>
         /// <example>
         /// SelfLog.Out = Console.Error;
@@ -45,10 +45,10 @@ namespace Serilog.Debugging
         }
 
         /// <summary>
-        /// Set the output mechanism for self-log events.
+        /// Set the output mechanism for self-log messages.
         /// </summary>
         /// <param name="output">A synchronized <see cref="TextWriter"/> to which
-        /// self-log events will be written.</param>
+        /// self-log messages will be written.</param>
         // ReSharper disable once MemberCanBePrivate.Global
         public static void Enable(TextWriter output)
         {
@@ -62,7 +62,7 @@ namespace Serilog.Debugging
         }
 
         /// <summary>
-        /// Set the output mechanism for self-log events.
+        /// Set the output mechanism for self-log messages.
         /// </summary>
         /// <param name="output">An action to invoke with self-log messages.</param>
         /// // ReSharper disable once MemberCanBePrivate.Global

--- a/test/Serilog.Tests/Debugging/SelfLogTests.cs
+++ b/test/Serilog.Tests/Debugging/SelfLogTests.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Serilog.Debugging;
+using Xunit;
+
+namespace Serilog.Tests.Debugging
+{
+    public class SelfLogTests
+    {
+        [ThreadStatic]
+        static List<string> Messages;
+        
+        [Fact]
+        public void MessagesAreWrittenWhenOutputIsSet()
+        {
+            Messages = new List<string>();
+            SelfLog.Enable(m =>
+            {
+                Messages = Messages ?? new List<string>();
+                Messages.Add(m);
+            });
+
+            SelfLog.WriteLine("Hello {0} {1} {2}", 0, 1, 2);
+            Assert.True(Messages.Any(m => m.EndsWith("Hello 0 1 2")));
+
+            // Better to do this here than in another test, since at this point
+            // we've confirmed there's actually something to disable.
+            var count = Messages.Count;
+            SelfLog.Disable();
+            SelfLog.WriteLine("Unwritten");
+            Assert.Equal(Messages.Count, count);
+        }
+    }
+}


### PR DESCRIPTION
The `TextWriter`-based `SelfLog.Out` is hard to use on remote machines because there's no clear 'action' on which a freshly-written self-log event can be sent across the network. This patch obsoletes `Out` and replaces it with `Enable(Action<string>)`, `Enable(TextWriter)` and `Disable()`.

```csharp
// Old code
SelfLog.Out = file;

// New code
SelfLog.Enable(file);

// or
SelfLog.Enable(m => SendToSantaClaus(m));
```
