### PR TITLE
Switch from ,n level width specifiers to :tn

### DIFF
--- a/src/Serilog/Formatting/Display/MessageTemplateTextFormatter.cs
+++ b/src/Serilog/Formatting/Display/MessageTemplateTextFormatter.cs
@@ -82,7 +82,6 @@ namespace Serilog.Formatting.Display
                 // rendering and support some additional formats: 'u' for uppercase
                 // and 'w' for lowercase.
                 var sv = propertyValue as ScalarValue;
-                LogEventLevelValue lelv;
                 if (sv != null && sv.Value is string)
                 {
                     var overridden = new Dictionary<string, LogEventPropertyValue>
@@ -91,10 +90,6 @@ namespace Serilog.Formatting.Display
                     };
 
                     token.Render(overridden, output, _formatProvider);
-                }
-                else if ((lelv = (propertyValue as LogEventLevelValue)) != null)
-                {
-                    lelv.Render(output, pt.Alignment, pt.Format);
                 }
                 else
                 {

--- a/test/Serilog.Tests/Formatting/Display/MessageTemplateTextFormatterTests.cs
+++ b/test/Serilog.Tests/Formatting/Display/MessageTemplateTextFormatterTests.cs
@@ -60,13 +60,13 @@ namespace Serilog.Tests.Formatting.Display
         [InlineData(LogEventLevel.Verbose, 5, "Verbo")]
         [InlineData(LogEventLevel.Verbose, 6, "Verbos")]
         [InlineData(LogEventLevel.Verbose, 7, "Verbose")]
-        [InlineData(LogEventLevel.Verbose, 8, " Verbose")]
+        [InlineData(LogEventLevel.Verbose, 8, "Verbose")]
         [InlineData(LogEventLevel.Debug, 1, "D")]
         [InlineData(LogEventLevel.Debug, 2, "De")]
         [InlineData(LogEventLevel.Debug, 3, "Dbg")]
         [InlineData(LogEventLevel.Debug, 4, "Dbug")]
         [InlineData(LogEventLevel.Debug, 5, "Debug")]
-        [InlineData(LogEventLevel.Debug, 6, " Debug")]
+        [InlineData(LogEventLevel.Debug, 6, "Debug")]
         [InlineData(LogEventLevel.Information, 1, "I")]
         [InlineData(LogEventLevel.Information, 2, "In")]
         [InlineData(LogEventLevel.Information, 3, "Inf")]
@@ -78,19 +78,19 @@ namespace Serilog.Tests.Formatting.Display
         [InlineData(LogEventLevel.Information, 9, "Informati")]
         [InlineData(LogEventLevel.Information, 10, "Informatio")]
         [InlineData(LogEventLevel.Information, 11, "Information")]
-        [InlineData(LogEventLevel.Information, 12, " Information")]
+        [InlineData(LogEventLevel.Information, 12, "Information")]
         [InlineData(LogEventLevel.Error, 1, "E")]
         [InlineData(LogEventLevel.Error, 2, "Er")]
         [InlineData(LogEventLevel.Error, 3, "Err")]
         [InlineData(LogEventLevel.Error, 4, "Eror")]
         [InlineData(LogEventLevel.Error, 5, "Error")]
-        [InlineData(LogEventLevel.Error, 6, " Error")]
+        [InlineData(LogEventLevel.Error, 6, "Error")]
         [InlineData(LogEventLevel.Fatal, 1, "F")]
         [InlineData(LogEventLevel.Fatal, 2, "Fa")]
         [InlineData(LogEventLevel.Fatal, 3, "Ftl")]
         [InlineData(LogEventLevel.Fatal, 4, "Fatl")]
         [InlineData(LogEventLevel.Fatal, 5, "Fatal")]
-        [InlineData(LogEventLevel.Fatal, 6, " Fatal")]
+        [InlineData(LogEventLevel.Fatal, 6, "Fatal")]
         [InlineData(LogEventLevel.Warning, 1, "W")]
         [InlineData(LogEventLevel.Warning, 2, "Wn")]
         [InlineData(LogEventLevel.Warning, 3, "Wrn")]
@@ -98,13 +98,13 @@ namespace Serilog.Tests.Formatting.Display
         [InlineData(LogEventLevel.Warning, 5, "Warni")]
         [InlineData(LogEventLevel.Warning, 6, "Warnin")]
         [InlineData(LogEventLevel.Warning, 7, "Warning")]
-        [InlineData(LogEventLevel.Warning, 8, " Warning")]
+        [InlineData(LogEventLevel.Warning, 8, "Warning")]
         public void FixedLengthLevelIsSupported(
             LogEventLevel level,
-            int length, 
+            int width, 
             string expected)
         {
-            var formatter = new MessageTemplateTextFormatter($"{{Level,{length}}}", CultureInfo.InvariantCulture);
+            var formatter = new MessageTemplateTextFormatter($"{{Level:t{width}}}", CultureInfo.InvariantCulture);
             var evt = DelegatingSink.GetLogEvent(l => l.Write(level, "Hello"));
             var sw = new StringWriter();
             formatter.Format(evt, sw);
@@ -114,7 +114,7 @@ namespace Serilog.Tests.Formatting.Display
         [Fact]
         public void FixedLengthLevelSupportsUpperCasing()
         {
-            var formatter = new MessageTemplateTextFormatter("{Level,3:u}", CultureInfo.InvariantCulture);
+            var formatter = new MessageTemplateTextFormatter("{Level:u3}", CultureInfo.InvariantCulture);
             var evt = DelegatingSink.GetLogEvent(l => l.Information("Hello"));
             var sw = new StringWriter();
             formatter.Format(evt, sw);
@@ -124,7 +124,7 @@ namespace Serilog.Tests.Formatting.Display
         [Fact]
         public void FixedLengthLevelSupportsLowerCasing()
         {
-            var formatter = new MessageTemplateTextFormatter("{Level,3:w}", CultureInfo.InvariantCulture);
+            var formatter = new MessageTemplateTextFormatter("{Level:w3}", CultureInfo.InvariantCulture);
             var evt = DelegatingSink.GetLogEvent(l => l.Information("Hello"));
             var sw = new StringWriter();
             formatter.Format(evt, sw);
@@ -139,6 +139,16 @@ namespace Serilog.Tests.Formatting.Display
             var sw = new StringWriter();
             formatter.Format(evt, sw);
             Assert.Equal("Information", sw.ToString());
+        }
+
+        [Fact]
+        public void AligmentAndWidthCanBeCombined()
+        {
+            var formatter = new MessageTemplateTextFormatter("{Level,5:w3}", CultureInfo.InvariantCulture);
+            var evt = DelegatingSink.GetLogEvent(l => l.Information("Hello"));
+            var sw = new StringWriter();
+            formatter.Format(evt, sw);
+            Assert.Equal("  inf", sw.ToString());
         }
     }
 }


### PR DESCRIPTION
2.0 introduced support for short level names like `INF`, `inf` and so-on in output templates.

We initially used `,n` width specifiers, e.g. `"{Level,3:u}"` to generate a three-character uppercase level name. This required some deviation from the `IFormattable`-style formatting we use elsewhere, and is at odds with how `,n` padding values normally work in format strings.

This PR instead opts for a scheme matching e.g. how `Int32` hex formats specify width. The equivalent of the three-character uppercase example is `"{Level:u3}"`.

Lowercase is supported with `w`, e.g. `:w3` for three-character lowercase, and title case like `Inf` can be achieved using a `t` prefix, e.g. `:t3`.

Widths from 1 to 99 are handled, but values greater than 10 don't have any effect on the current set of level names.

While not particularly useful, this also has the advantage of making a format like `"{Level,5:w3}"` work sensibly (five-character padded, three-character lowercase level name). Staying as close as possible to .NET format string semantics is a good guideline for us to follow.

(Note, this feature only applies to output templates as supported e.g. when rendering to the console - not message templates in general.)

Closes #765.