### PR TITLE
Improve message template construction performance

### DIFF
--- a/src/Serilog/Events/MessageTemplate.cs
+++ b/src/Serilog/Events/MessageTemplate.cs
@@ -86,11 +86,11 @@ namespace Serilog.Events
         /// <summary>
         /// Similar to <see cref="Enumerable.OfType{TResult}"/>, but faster.
         /// </summary>
-        private static TResult[] GetElementsOfTypeToArray<TResult>(System.Collections.IList tokens)
+        private static TResult[] GetElementsOfTypeToArray<TResult>(object[] tokens)
             where TResult: class
         {
-            var result = new List<TResult>(tokens.Count / 2);
-            for (var i = 0; i < tokens.Count; i++)
+            var result = new List<TResult>(tokens.Length / 2);
+            for (var i = 0; i < tokens.Length; i++)
             {
                 var token = tokens[i] as TResult;
                 if (token != null)

--- a/src/Serilog/Events/MessageTemplate.cs
+++ b/src/Serilog/Events/MessageTemplate.cs
@@ -86,7 +86,7 @@ namespace Serilog.Events
         /// <summary>
         /// Similar to <see cref="Enumerable.OfType{TResult}"/>, but faster.
         /// </summary>
-        private static TResult[] GetElementsOfTypeToArray<TResult>(object[] tokens)
+        static TResult[] GetElementsOfTypeToArray<TResult>(object[] tokens)
             where TResult: class
         {
             var result = new List<TResult>(tokens.Length / 2);

--- a/src/Serilog/Events/MessageTemplate.cs
+++ b/src/Serilog/Events/MessageTemplate.cs
@@ -56,7 +56,7 @@ namespace Serilog.Events
             Text = text;
             _tokens = tokens.ToArray();
 
-            var propertyTokens = _tokens.OfType<PropertyToken>().ToArray();
+            var propertyTokens = GetElementsOfTypeToArray<PropertyToken>(_tokens);
             if (propertyTokens.Length != 0)
             {
                 var allPositional = true;
@@ -81,6 +81,24 @@ namespace Serilog.Events
                     NamedProperties = propertyTokens;
                 }
             }
+        }
+
+        /// <summary>
+        /// Similar to <see cref="Enumerable.OfType{TResult}"/>, but faster.
+        /// </summary>
+        private static TResult[] GetElementsOfTypeToArray<TResult>(System.Collections.IList tokens)
+            where TResult: class
+        {
+            var result = new List<TResult>(tokens.Count / 2);
+            for (var i = 0; i < tokens.Count; i++)
+            {
+                var token = tokens[i] as TResult;
+                if (token != null)
+                {
+                    result.Add(token);
+                }
+            }
+            return result.ToArray();
         }
 
         /// <summary>


### PR DESCRIPTION
By using a new method, similar to `Enumerable.OfType<TResult>` but faster.

My tests show it's ~2X or ~3X faster.