### PR TITLE
Support setting values of interface types where a fully-qualified type name is supplied

### DIFF
--- a/src/Serilog/Settings/KeyValuePairs/KeyValuePairSettings.cs
+++ b/src/Serilog/Settings/KeyValuePairs/KeyValuePairSettings.cs
@@ -189,10 +189,10 @@ namespace Serilog.Settings.KeyValuePairs
 
             if (toTypeInfo.IsInterface && !string.IsNullOrWhiteSpace(value))
             {
-                var type = Type.GetType(value.Trim(), throwOnError: false).GetTypeInfo();
+                var type = Type.GetType(value.Trim(), throwOnError: false);
                 if (type != null)
                 {
-                    var ctor = type.DeclaredConstructors.FirstOrDefault(ci =>
+                    var ctor = type.GetTypeInfo().DeclaredConstructors.FirstOrDefault(ci =>
                     {
                         var parameters = ci.GetParameters();
                         return parameters.Length == 0 || parameters.All(pi => pi.HasDefaultValue);

--- a/src/Serilog/Settings/KeyValuePairs/KeyValuePairSettings.cs
+++ b/src/Serilog/Settings/KeyValuePairs/KeyValuePairSettings.cs
@@ -14,9 +14,11 @@
 
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Text.RegularExpressions;
 using Serilog.Configuration;
 using Serilog.Events;
@@ -155,6 +157,12 @@ namespace Serilog.Settings.KeyValuePairs
             return configurationAssemblies.Distinct();
         }
 
+        static Dictionary<Type, Func<string, object>> ExtendedTypeConversions = new Dictionary<Type, Func<string, object>>
+            {
+                { typeof(Uri), s => new Uri(s) },
+                { typeof(TimeSpan), s => TimeSpan.Parse(s) }
+            };
+
         internal static object ConvertToType(string value, Type toType)
         {
             var toTypeInfo = toType.GetTypeInfo();
@@ -171,18 +179,34 @@ namespace Serilog.Settings.KeyValuePairs
             if (toTypeInfo.IsEnum)
                 return Enum.Parse(toType, value);
 
-            var extendedTypeConversions = new Dictionary<Type, Func<string, object>>
-            {
-                { typeof(Uri), s => new Uri(s) },
-                { typeof(TimeSpan), s => TimeSpan.Parse(s) }
-            };
-
-            var convertor = extendedTypeConversions
+            var convertor = ExtendedTypeConversions
                 .Where(t => t.Key.GetTypeInfo().IsAssignableFrom(toTypeInfo))
                 .Select(t => t.Value)
                 .FirstOrDefault();
 
-            return convertor == null ? Convert.ChangeType(value, toType) : convertor(value);
+            if (convertor != null)
+                return convertor(value);
+
+            if (toTypeInfo.IsInterface && !string.IsNullOrWhiteSpace(value))
+            {
+                var type = Type.GetType(value.Trim(), throwOnError: false).GetTypeInfo();
+                if (type != null)
+                {
+                    var ctor = type.DeclaredConstructors.FirstOrDefault(ci =>
+                    {
+                        var parameters = ci.GetParameters();
+                        return parameters.Length == 0 || parameters.All(pi => pi.HasDefaultValue);
+                    });
+
+                    if (ctor == null)
+                        throw new InvalidOperationException($"A default constructor was not found on {type.FullName}.");
+
+                    var call = ctor.GetParameters().Select(pi => pi.DefaultValue).ToArray();
+                    return ctor.Invoke(call);
+                }
+            }
+
+            return Convert.ChangeType(value, toType);
         }
 
         internal static IList<MethodInfo> FindSinkConfigurationMethods(IEnumerable<Assembly> configurationAssemblies)

--- a/test/Serilog.Tests/Settings/KeyValuePairSettingsTests.cs
+++ b/test/Serilog.Tests/Settings/KeyValuePairSettingsTests.cs
@@ -7,6 +7,9 @@ using Serilog.Settings.KeyValuePairs;
 using Serilog.Tests.Support;
 using Serilog.Enrichers;
 using TestDummies;
+using Serilog.Formatting;
+using Serilog.Formatting.Json;
+using Serilog.Tests.Formatting.Json;
 
 namespace Serilog.Tests.AppSettings.Tests
 {
@@ -90,6 +93,14 @@ namespace Serilog.Tests.AppSettings.Tests
 
             Assert.NotNull(evt);
             Assert.Equal("Test", evt.Properties["App"].LiteralValue());
+        }
+
+
+        [Fact]
+        public void StringValuesConvertToDefaultInstancesIfTargetIsInterface()
+        {
+            var result = (object)KeyValuePairSettings.ConvertToType("Serilog.Formatting.Json.JsonFormatter", typeof(ITextFormatter));
+            Assert.IsType<JsonFormatter>(result);
         }
     }
 }


### PR DESCRIPTION
How to specify JSON format for file/rolling file output [is](http://stackoverflow.com/questions/37787339/controlling-settings-for-serilog-in-app-config) [an](http://stackoverflow.com/questions/37794854/how-to-set-formatprovider-property-in-serilog-from-app-config-file) [FAQ](http://stackoverflow.com/questions/32053859/how-to-specify-jsonformatter-in-web-config-for-serilog).

[Serilog.Sinks.Json](https://github.com/nblumhardt/serilog-sinks-json) helps but feels like a hacky workaround.

This PR adds the infrastructure that will allow sinks to use configuration like:

```xml
<add key="serilog:write-to:RollingFile.textFormatter" value="Serilog.Formatting.Json.JsonFormatter" />
```

This won't light up until the sinks add configuration overloads with appropriate parameters, but at least moves us towards having support built-in for this.