### PR TITLE
Use ENV vars to set versions for AppVeyor and Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ env:
   matrix: 
     - CLI_VERSION=1.0.0-preview2-003121
     - CLI_INSTALL_SCRIPT_VERSION=rel/1.0.0-preview2
-    - CLI_INSTALL_SCRIPT_URI="https://raw.githubusercontent.com/dotnet/cli/$CLI_INSTALL_SCRIPT_VERSION/scripts/obtain/dotnet-install.sh"
+    - CLI_INSTALL_SCRIPT_URI=https://raw.githubusercontent.com/dotnet/cli/$CLI_INSTALL_SCRIPT_VERSION/scripts/obtain/dotnet-install.sh
 
 matrix:
   allow_failures:
@@ -34,7 +34,8 @@ matrix:
 before_install:
   - if test "$TRAVIS_OS_NAME" == "osx"; then brew update; brew install openssl; brew link --force openssl; fi
   # Download script to install dotnet cli
-  - if test "$CLI_OBTAIN_URL" == ""; then export CLI_OBTAIN_URL="$CLI_INSTALL_SCRIPT_URI"; fi
+  - if test "$CLI_OBTAIN_URL" == ""; then export CLI_OBTAIN_URL=$CLI_INSTALL_SCRIPT_URI; fi
+  - echo $CLI_OBTAIN_URL
   - curl -L --create-dirs $CLI_OBTAIN_URL -o ./scripts/obtain/install.sh
   - find ./scripts -name "*.sh" -exec chmod +x {} \;
   - export DOTNET_INSTALL_DIR="$PWD/.dotnetcli"

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ matrix:
 before_install:
   - if test "$TRAVIS_OS_NAME" == "osx"; then brew update; brew install openssl; brew link --force openssl; fi
   # Download script to install dotnet cli
-  - if test "$CLI_OBTAIN_URL" == ""; then export CLI_OBTAIN_URL=$CLI_INSTALL_SCRIPT_URI; fi
+  - if test "$CLI_OBTAIN_URL" == ""; then export CLI_OBTAIN_URL="https://raw.githubusercontent.com/dotnet/cli/$CLI_INSTALL_SCRIPT_VERSION/scripts/obtain/dotnet-install.sh"; fi
   - echo $CLI_OBTAIN_URL
   - curl -L --create-dirs $CLI_OBTAIN_URL -o ./scripts/obtain/install.sh
   - find ./scripts -name "*.sh" -exec chmod +x {} \;

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,8 @@ os:
 env:
   matrix: 
     - CLI_VERSION=1.0.0-preview2-003121
-    - CLI_VERSION=Latest
+    - CLI_INSTALL_SCRIPT_VERSION=rel/1.0.0-preview2
+    - CLI_INSTALL_SCRIPT_URI="https://raw.githubusercontent.com/dotnet/cli/$CLI_INSTALL_SCRIPT_VERSION/scripts/obtain/dotnet-install.sh"
 
 matrix:
   allow_failures:
@@ -33,7 +34,7 @@ matrix:
 before_install:
   - if test "$TRAVIS_OS_NAME" == "osx"; then brew update; brew install openssl; brew link --force openssl; fi
   # Download script to install dotnet cli
-  - if test "$CLI_OBTAIN_URL" == ""; then export CLI_OBTAIN_URL="https://raw.githubusercontent.com/dotnet/cli/rel/1.0.0-preview2/scripts/obtain/dotnet-install.sh"; fi
+  - if test "$CLI_OBTAIN_URL" == ""; then export CLI_OBTAIN_URL="$CLI_INSTALL_SCRIPT_URI"; fi
   - curl -L --create-dirs $CLI_OBTAIN_URL -o ./scripts/obtain/install.sh
   - find ./scripts -name "*.sh" -exec chmod +x {} \;
   - export DOTNET_INSTALL_DIR="$PWD/.dotnetcli"

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,8 +24,7 @@ os:
 env:
   matrix: 
     - CLI_VERSION=1.0.0-preview2-003121
-    - CLI_INSTALL_SCRIPT_VERSION=rel/1.0.0-preview2
-    - CLI_INSTALL_SCRIPT_URI=https://raw.githubusercontent.com/dotnet/cli/$CLI_INSTALL_SCRIPT_VERSION/scripts/obtain/dotnet-install.sh
+    - CLI_VERSION=Latest
 
 matrix:
   allow_failures:
@@ -34,7 +33,58 @@ matrix:
 before_install:
   - if test "$TRAVIS_OS_NAME" == "osx"; then brew update; brew install openssl; brew link --force openssl; fi
   # Download script to install dotnet cli
-  - if test "$CLI_OBTAIN_URL" == ""; then export CLI_OBTAIN_URL="https://raw.githubusercontent.com/dotnet/cli/$CLI_INSTALL_SCRIPT_VERSION/scripts/obtain/dotnet-install.sh"; fi
+  - if test "$CLI_OBTAIN_URL" == ""; then export CLI_OBTAIN_URL="https://raw.githubusercontent.com/dotnet/cli/rel/1.0.0-preview2/scripts/obtain/dotnet-install.sh"; fi
+  - curl -L --create-dirs $CLI_OBTAIN_URL -o ./scripts/obtain/install.sh
+  - find ./scripts -name "*.sh" -exec chmod +x {} \;
+  - export DOTNET_INSTALL_DIR="$PWD/.dotnetcli"
+  # use bash to workaround bug https://github.com/dotnet/cli/issues/1725
+  - sudo bash ./scripts/obtain/install.sh --channel "preview" --version "$CLI_VERSION" --install-dir "$DOTNET_INSTALL_DIR" --no-path
+  # add dotnet to PATH
+  - export PATH="$DOTNET_INSTALL_DIR:$PATH"
+
+script:
+  - ./build.sh
+
+
+
+
+
+language: csharp
+
+#dotnet cli require Ubuntu 14.04
+sudo: required
+dist: trusty
+
+#dotnet cli require OSX 10.10
+osx_image: xcode7.1
+
+addons:
+  apt:
+    packages:
+    - gettext
+    - libcurl4-openssl-dev
+    - libicu-dev
+    - libssl-dev
+    - libunwind8
+    - zlib1g
+
+os:
+  - osx
+  - linux
+
+env:
+  matrix: 
+    - CLI_VERSION=1.0.0-preview2-003121 CLI_INSTALL_SCRIPT_VERSION=rel/1.0.0-preview2 CLI_INSTALL_SCRIPT_URI=https://raw.githubusercontent.com/dotnet/cli/$CLI_INSTALL_SCRIPT_VERSION/scripts/obtain/dotnet-install.sh
+    - CLI_VERSION=1.0.0-preview2-003121 CLI_INSTALL_SCRIPT_VERSION=rel/1.0.0-preview2 CLI_INSTALL_SCRIPT_URI=https://raw.githubusercontent.com/dotnet/cli/$CLI_INSTALL_SCRIPT_VERSION/scripts/obtain/dotnet-install.sh
+
+matrix:
+  allow_failures:
+    - env: CLI_VERSION=Latest
+
+before_install:
+  - if test "$TRAVIS_OS_NAME" == "osx"; then brew update; brew install openssl; brew link --force openssl; fi
+  # Download script to install dotnet cli
+  - if test "$CLI_OBTAIN_URL" == ""; then export CLI_OBTAIN_URL=$CLI_INSTALL_SCRIPT_URI; fi
   - echo $CLI_OBTAIN_URL
   - curl -L --create-dirs $CLI_OBTAIN_URL -o ./scripts/obtain/install.sh
   - find ./scripts -name "*.sh" -exec chmod +x {} \;

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,9 +4,12 @@ image: Visual Studio 2015
 configuration: Release
 install:
   - ps: mkdir -Force ".\build\" | Out-Null
-  - ps: Invoke-WebRequest "https://raw.githubusercontent.com/dotnet/cli/rel/1.0.0-preview2/scripts/obtain/dotnet-install.ps1" -OutFile ".\build\installcli.ps1"
+  - ps: $env:CLI_INSTALL_SCRIPT_VERSION = "rel/1.0.0-preview2"
+  - ps: $env:CLI_VERSION = "1.0.0-preview2-003121"
+  - ps: $env:CLI_INSTALL_SCRIPT_URI = "https://raw.githubusercontent.com/dotnet/cli/{0}/scripts/obtain/dotnet-install.ps1" -f $env:CLI_INSTALL_SCRIPT_VERSION
+  - ps: Invoke-WebRequest "$env:CLI_INSTALL_SCRIPT_URI" -OutFile ".\build\installcli.ps1" 
   - ps: $env:DOTNET_INSTALL_DIR = "$pwd\.dotnetcli"
-  - ps: '& .\build\installcli.ps1 -InstallDir "$env:DOTNET_INSTALL_DIR" -NoPath -Version 1.0.0-preview2-003121'
+  - ps: '& .\build\installcli.ps1 -InstallDir "$env:DOTNET_INSTALL_DIR" -NoPath -Version "$env:CLI_VERSION"'
   - ps: $env:Path = "$env:DOTNET_INSTALL_DIR;$env:Path"
 build_script:
 - ps: ./Build.ps1


### PR DESCRIPTION
For the future changes and ease of understanding, this is an attempt to move version into ENV vars.

* Uses branch from dotnet/cli to target install script.