### PR TITLE
Use env vars for clarity. Also ensure OSX and *nix using same version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,6 @@ os:
 env:
   matrix: 
     - CLI_VERSION=1.0.0-preview2-003121 CLI_INSTALL_SCRIPT_VERSION=rel/1.0.0-preview2 CLI_INSTALL_SCRIPT_URI=https://raw.githubusercontent.com/dotnet/cli/$CLI_INSTALL_SCRIPT_VERSION/scripts/obtain/dotnet-install.sh
-    - CLI_VERSION=1.0.0-preview2-003121 CLI_INSTALL_SCRIPT_VERSION=rel/1.0.0-preview2 CLI_INSTALL_SCRIPT_URI=https://raw.githubusercontent.com/dotnet/cli/$CLI_INSTALL_SCRIPT_VERSION/scripts/obtain/dotnet-install.sh
 
 matrix:
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,8 +23,8 @@ os:
 
 env:
   matrix: 
-    - CLI_VERSION=1.0.0-preview2-003121
-    - CLI_VERSION=Latest
+    - CLI_VERSION=1.0.0-preview2-003121 CLI_INSTALL_SCRIPT_VERSION=rel/1.0.0-preview2 CLI_INSTALL_SCRIPT_URI=https://raw.githubusercontent.com/dotnet/cli/$CLI_INSTALL_SCRIPT_VERSION/scripts/obtain/dotnet-install.sh
+    - CLI_VERSION=1.0.0-preview2-003121 CLI_INSTALL_SCRIPT_VERSION=rel/1.0.0-preview2 CLI_INSTALL_SCRIPT_URI=https://raw.githubusercontent.com/dotnet/cli/$CLI_INSTALL_SCRIPT_VERSION/scripts/obtain/dotnet-install.sh
 
 matrix:
   allow_failures:
@@ -33,7 +33,8 @@ matrix:
 before_install:
   - if test "$TRAVIS_OS_NAME" == "osx"; then brew update; brew install openssl; brew link --force openssl; fi
   # Download script to install dotnet cli
-  - if test "$CLI_OBTAIN_URL" == ""; then export CLI_OBTAIN_URL="https://raw.githubusercontent.com/dotnet/cli/rel/1.0.0-preview2/scripts/obtain/dotnet-install.sh"; fi
+  - if test "$CLI_OBTAIN_URL" == ""; then export CLI_OBTAIN_URL=$CLI_INSTALL_SCRIPT_URI; fi
+  - echo $CLI_OBTAIN_URL
   - curl -L --create-dirs $CLI_OBTAIN_URL -o ./scripts/obtain/install.sh
   - find ./scripts -name "*.sh" -exec chmod +x {} \;
   - export DOTNET_INSTALL_DIR="$PWD/.dotnetcli"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,9 +4,12 @@ image: Visual Studio 2015
 configuration: Release
 install:
   - ps: mkdir -Force ".\build\" | Out-Null
-  - ps: Invoke-WebRequest "https://raw.githubusercontent.com/dotnet/cli/rel/1.0.0-preview2/scripts/obtain/dotnet-install.ps1" -OutFile ".\build\installcli.ps1"
+  - ps: $env:CLI_INSTALL_SCRIPT_VERSION = "rel/1.0.0-preview2"
+  - ps: $env:CLI_VERSION = "1.0.0-preview2-003121"
+  - ps: $env:CLI_INSTALL_SCRIPT_URI = "https://raw.githubusercontent.com/dotnet/cli/{0}/scripts/obtain/dotnet-install.ps1" -f $env:CLI_INSTALL_SCRIPT_VERSION
+  - ps: Invoke-WebRequest "$env:CLI_INSTALL_SCRIPT_URI" -OutFile ".\build\installcli.ps1" 
   - ps: $env:DOTNET_INSTALL_DIR = "$pwd\.dotnetcli"
-  - ps: '& .\build\installcli.ps1 -InstallDir "$env:DOTNET_INSTALL_DIR" -NoPath -Version 1.0.0-preview2-003121'
+  - ps: '& .\build\installcli.ps1 -InstallDir "$env:DOTNET_INSTALL_DIR" -NoPath -Version "$env:CLI_VERSION"'
   - ps: $env:Path = "$env:DOTNET_INSTALL_DIR;$env:Path"
 build_script:
 - ps: ./Build.ps1


### PR DESCRIPTION
Previous PRs based on `dev`. 

* Specify version explicitly on all builds.
* Ensure that OSX and Nix are using `1.0.0-preview2-003121` (Currently inconsistent)
* Specify branch e.g. `rel/1.0.0-preview2` as location to source scripts.