### PR TITLE
Fixes #815 - increasing level through overrides

### DIFF
--- a/src/Serilog/Core/Logger.cs
+++ b/src/Serilog/Core/Logger.cs
@@ -19,6 +19,8 @@ using Serilog.Debugging;
 using Serilog.Events;
 using Serilog.Parameters;
 
+#pragma warning disable Serilog004 // Constant MessageTemplate verifier
+
 namespace Serilog.Core
 {
     /// <summary>
@@ -388,7 +390,10 @@ namespace Serilog.Core
         void ILogEventSink.Emit(LogEvent logEvent)
         {
             if (logEvent == null) throw new ArgumentNullException(nameof(logEvent));
-            Write(logEvent);
+
+            // Bypasses the level check so that child loggers
+            // using this one as a sink can increase verbosity.
+            Dispatch(logEvent);
         }
 
         void Dispatch(LogEvent logEvent)

--- a/test/Serilog.Tests/LoggerConfigurationTests.cs
+++ b/test/Serilog.Tests/LoggerConfigurationTests.cs
@@ -329,7 +329,7 @@ namespace Serilog.Tests
         }
 
         [Fact]
-        public void LevelOverridesArePropagated()
+        public void LevelOverridesUpArePropagated()
         {
             var sink = new CollectingSink();
 
@@ -344,6 +344,24 @@ namespace Serilog.Tests
             logger.ForContext<LoggerConfigurationTests>().Write(Some.InformationEvent());
 
             Assert.Equal(2, sink.Events.Count);
+        }
+
+        [Fact]
+        public void LevelOverridesDownArePropagated()
+        {
+            var sink = new CollectingSink();
+
+            var logger = new LoggerConfiguration()
+                .MinimumLevel.Error()
+                .MinimumLevel.Override("Microsoft", LogEventLevel.Debug)
+                .WriteTo.Sink(sink)
+                .CreateLogger();
+
+            logger.Write(Some.InformationEvent());
+            logger.ForContext(Serilog.Core.Constants.SourceContextPropertyName, "Microsoft.AspNet.Something").Write(Some.InformationEvent());
+            logger.ForContext<LoggerConfigurationTests>().Write(Some.InformationEvent());
+
+            Assert.Equal(1, sink.Events.Count);
         }
     }
 }

--- a/test/Serilog.Tests/LoggerConfigurationTests.cs
+++ b/test/Serilog.Tests/LoggerConfigurationTests.cs
@@ -329,7 +329,7 @@ namespace Serilog.Tests
         }
 
         [Fact]
-        public void LevelOverridesUpArePropagated()
+        public void HigherMinimumLevelOverridesArePropagated()
         {
             var sink = new CollectingSink();
 
@@ -347,7 +347,7 @@ namespace Serilog.Tests
         }
 
         [Fact]
-        public void LevelOverridesDownArePropagated()
+        public void LowerMinimumLevelOverridesArePropagated()
         {
             var sink = new CollectingSink();
 


### PR DESCRIPTION
This allows child loggers to increase verbosity, by bypassing the minimum level check in `Logger`'s (explicit) implementation of `ILogEventSink.Emit()`.

The approach taken here means that if a logger is cast to `ILogEventSink` clients of the logger could effectively do the same thing. If this is deemed an issue we could add a new internal interface to connect the logger chain instead of `ILogEventSink`, but in practice since `WriteTo.Logger()` uses `ILogger.Write()` there's no scenario today where this will be observable.