### PR TITLE
Use AsyncLocal rather than LogicalCallContext on .NET 4.6

### DIFF
--- a/src/Serilog/project.json
+++ b/src/Serilog/project.json
@@ -22,6 +22,11 @@
         "define": [ "REMOTING" ]
       }
     },
+    "net4.6": {
+      "buildOptions": {
+        "define": [ "ASYNCLOCAL" ]
+      }
+    },
     "netstandard1.0": {
       "dependencies": {
         "Microsoft.CSharp": "4.0.1",

--- a/test/Serilog.Tests/Context/LogContextTests.cs
+++ b/test/Serilog.Tests/Context/LogContextTests.cs
@@ -3,9 +3,11 @@ using Serilog.Context;
 using Serilog.Events;
 using Serilog.Core.Enrichers;
 using Serilog.Tests.Support;
-#if REMOTING
+#if APPDOMAIN
 using System;
 using System.IO;
+#endif
+#if REMOTING
 using System.Runtime.Remoting.Messaging;
 #endif
 using System.Threading;
@@ -155,7 +157,7 @@ namespace Serilog.Tests.Context
 #endif
     }
 
-#if REMOTING
+#if REMOTING || APPDOMAIN
     public class RemotelyCallable : MarshalByRefObject
     {
         public bool IsCallable()

--- a/test/Serilog.Tests/project.json
+++ b/test/Serilog.Tests/project.json
@@ -17,6 +17,11 @@
         "define": [ "APPDOMAIN", "REMOTING", "GETCURRENTMETHOD" ]
       }
     },
+    "net4.6": {
+      "buildOptions": {
+        "define": [ "ASYNCLOCAL", "APPDOMAIN", "GETCURRENTMETHOD" ]
+      }
+    },
     "netcoreapp1.0": {
       "define": [ "ASYNCLOCAL" ],
       "dependencies": {


### PR DESCRIPTION
Back `LogContext` with the newer `AsyncLocal` where available (NET 4.6+) to avoid remoting issues. #835.