### PR TITLE
Ensure the per-AppDomain LogContext property name is unique across processes

### DIFF
--- a/src/Serilog/Context/LogContext.cs
+++ b/src/Serilog/Context/LogContext.cs
@@ -54,7 +54,7 @@ namespace Serilog.Context
 #if ASYNCLOCAL
         static readonly AsyncLocal<ImmutableStack<ILogEventEnricher>> Data = new AsyncLocal<ImmutableStack<ILogEventEnricher>>();
 #elif REMOTING
-        static readonly string DataSlotName = typeof(LogContext).FullName + "@AppDomain" + AppDomain.CurrentDomain.Id;
+        static readonly string DataSlotName = typeof(LogContext).FullName + "@" + Guid.NewGuid();
 #else // DOTNET_51
         [ThreadStatic]
         static ImmutableStack<ILogEventEnricher> Data;


### PR DESCRIPTION
`AppDomain.CurrentDomain.Id` will always return `1` in the default/entry appdomain, so the existing mitigation for remoting the log context won't work across processes.

Fixes #835
