### PR TITLE
Support `audit-to` in key-value and thus in <appSettings> settings

### DIFF
--- a/src/Serilog/project.json
+++ b/src/Serilog/project.json
@@ -1,5 +1,5 @@
 ﻿{
-  "version": "2.2.2-*",
+  "version": "2.3.0-*",
 
   "description": "Simple .NET logging with fully-structured events",
   "authors": [ "Serilog Contributors" ],

--- a/test/Serilog.PerformanceTests/Serilog.PerformanceTests.xproj
+++ b/test/Serilog.PerformanceTests/Serilog.PerformanceTests.xproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
@@ -14,5 +14,8 @@
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>
   </PropertyGroup>
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
   <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.targets" Condition="'$(VSToolsPath)' != ''" />
 </Project>

--- a/test/Serilog.Tests/Serilog.Tests.xproj
+++ b/test/Serilog.Tests/Serilog.Tests.xproj
@@ -14,5 +14,8 @@
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>
   </PropertyGroup>
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
   <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.targets" Condition="'$(VSToolsPath)' != ''" />
 </Project>

--- a/test/Serilog.Tests/project.json
+++ b/test/Serilog.Tests/project.json
@@ -12,16 +12,6 @@
     "keyFile": "../../assets/Serilog.snk"
   },
   "frameworks": {
-    "net4.5.2": {
-      "buildOptions": {
-        "define": [ "APPDOMAIN", "REMOTING", "GETCURRENTMETHOD" ]
-      }
-    },
-    "net4.6": {
-      "buildOptions": {
-        "define": [ "ASYNCLOCAL", "APPDOMAIN", "GETCURRENTMETHOD" ]
-      }
-    },
     "netcoreapp1.0": {
       "define": [ "ASYNCLOCAL" ],
       "dependencies": {
@@ -34,6 +24,16 @@
         "dnxcore50",
         "portable-net45+win8"
       ]
+    },
+    "net4.5.2": {
+      "buildOptions": {
+        "define": [ "APPDOMAIN", "REMOTING", "GETCURRENTMETHOD" ]
+      }
+    },
+    "net4.6": {
+      "buildOptions": {
+        "define": [ "ASYNCLOCAL", "APPDOMAIN", "GETCURRENTMETHOD" ]
+      }
     }
   }
 }

--- a/test/TestDummies/DummyLoggerConfigurationExtensions.cs
+++ b/test/TestDummies/DummyLoggerConfigurationExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using Serilog;
 using Serilog.Events;
 using Serilog.Formatting;
@@ -14,22 +15,32 @@ namespace TestDummies
         }
 
         public static LoggerConfiguration DummyRollingFile(
-            LoggerSinkConfiguration loggerSinkConfiguration,
+            this LoggerSinkConfiguration loggerSinkConfiguration,
             string pathFormat,
             LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
             string outputTemplate = null,
             IFormatProvider formatProvider = null)
         {
-            return null;
+            return loggerSinkConfiguration.Sink(new DummyRollingFileSink(), restrictedToMinimumLevel);
         }
 
         public static LoggerConfiguration DummyRollingFile(
-            LoggerSinkConfiguration loggerSinkConfiguration,
+            this LoggerSinkConfiguration loggerSinkConfiguration,
             ITextFormatter formatter,
             string pathFormat,
             LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum)
         {
-            return null;
+            return loggerSinkConfiguration.Sink(new DummyRollingFileSink(), restrictedToMinimumLevel);
+        }
+
+        public static LoggerConfiguration DummyRollingFile(
+            this LoggerAuditSinkConfiguration loggerSinkConfiguration,
+            string pathFormat,
+            LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
+            string outputTemplate = null,
+            IFormatProvider formatProvider = null)
+        {
+            return loggerSinkConfiguration.Sink(new DummyRollingFileAuditSink(), restrictedToMinimumLevel);
         }
     }
 }

--- a/test/TestDummies/DummyRollingFileAuditSink.cs
+++ b/test/TestDummies/DummyRollingFileAuditSink.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using Serilog.Core;
+using Serilog.Events;
+
+namespace TestDummies
+{
+    public class DummyRollingFileAuditSink : ILogEventSink
+    {
+        [ThreadStatic]
+        public static List<LogEvent> Emitted = new List<LogEvent>();
+
+        public void Emit(LogEvent logEvent)
+        {
+            Emitted.Add(logEvent);
+        }
+    }
+}

--- a/test/TestDummies/DummyRollingFileSink.cs
+++ b/test/TestDummies/DummyRollingFileSink.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using Serilog.Core;
+using Serilog.Events;
+
+namespace TestDummies
+{
+    public class DummyRollingFileSink : ILogEventSink
+    {
+        [ThreadStatic]
+        public static List<LogEvent> Emitted = new List<LogEvent>();
+
+        public void Emit(LogEvent logEvent)
+        {
+            Emitted.Add(logEvent);
+        }
+    }
+}


### PR DESCRIPTION
I'd somehow assumed this only needed downstream <appSettings> support, but of course the key-value pair settings are implemented in Serilog directly.

This PR enables:

```xml
  <add key="serilog:audit-to:File.path" value="C:\\auditfile.txt" />
```

and so-on.