### PR TITLE
A more informative and welcoming README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,110 @@
-#Serilog [![Build status](https://ci.appveyor.com/api/projects/status/b9rm3l7kduryjgcj/branch/master?svg=true)](https://ci.appveyor.com/project/serilog/serilog/branch/master)  [![NuGet Version](http://img.shields.io/nuget/v/Serilog.svg?style=flat)](https://www.nuget.org/packages/Serilog/) [![Rager Releases](http://rager.io/badge.svg?url=https%3A%2F%2Fwww.nuget.org%2Fpackages%2FSerilog%2F)](http://rager.io/projects/search?badge=1&query=nuget.org/packages/Serilog/) [![Join the chat at https://gitter.im/serilog/serilog](https://img.shields.io/gitter/room/serilog/serilog.svg)](https://gitter.im/serilog/serilog)
+#Serilog [![Build status](https://ci.appveyor.com/api/projects/status/b9rm3l7kduryjgcj/branch/master?svg=true)](https://ci.appveyor.com/project/serilog/serilog/branch/master)  [![NuGet Version](http://img.shields.io/nuget/v/Serilog.svg?style=flat)](https://www.nuget.org/packages/Serilog/) [![Rager Releases](http://rager.io/badge.svg?url=https%3A%2F%2Fwww.nuget.org%2Fpackages%2FSerilog%2F)](http://rager.io/projects/search?badge=1&query=nuget.org/packages/Serilog/) [![Join the chat at https://gitter.im/serilog/serilog](https://img.shields.io/gitter/room/serilog/serilog.svg)](https://gitter.im/serilog/serilog) [![Stack Overflow](https://img.shields.io/badge/stackoverflow-serilog-orange.svg)](http://stackoverflow.com/questions/tagged/serilog)
 
-Serilog combines the best features of traditional and structured diagnostic logging in an easy-to-use package.
+Serilog is a diagnostic logging library for .NET applications. It is easy to set up, has a clean API, and runs on all recent .NET platforms. While it's useful in even the simplest applications, Serilog's support for structured logging shines when instrumenting complex, distributed, and asynchronous applications and systems.
 
-* **[2.0 Upgrade Guide](https://github.com/serilog/serilog/wiki/2.x-Upgrade-Guide)** and [Release Notes](https://github.com/serilog/serilog/blob/dev/CHANGES.md)
-* [Homepage](http://serilog.net)
-* [Documentation](https://github.com/serilog/serilog/wiki)
+[![Serilog](https://serilog.net/images/serilog-180px.png)](https://serilog.net)
 
-Would you like to help make Serilog even better? We keep a list of issues that are approachable for newcomers under the [up-for-grabs](https://github.com/serilog/serilog/issues?labels=up-for-grabs&state=open) label!
+Like many other libraries for .NET, Serilog provides diagnostic logging to [files](https://github.com/serilog/serilog-sinks-rollingfile), the [console](https://github.com/serilog/serilog-sinks-literate), and [many other outputs](https://github.com/serilog/serilog/wiki/Provided-Sinks).
+
+```csharp
+var log = new LoggerConfiguration()
+    .WriteTo.LiterateConsole()
+    .WriteTo.RollingFile("log-{Date}.txt")
+    .CreateLogger();
+
+log.Information("Hello, Serilog!");
+```
+
+Unlike other logging libraries, Serilog is built from the ground up to record _structured event data_.
+
+```csharp
+var position = new { Latitude = 25, Longitude = 134 };
+var elapsedMs = 34;
+
+log.Information("Processed {@Position} in {Elapsed} ms.", position, elapsedMs);
+```
+
+Serilog uses [message templates](https://messagetemplates.org), a simple DSL that extends .NET format strings with named, as well as positional, parameters. Instead of formatting events immediately into text, Serilog captures the values associated with each named parameter.
+
+The example above records two properties, `Position` and `Elapsed`, in the log event. The `@` operator in front of `Position` tells Serilog to _serialize_ the object passed in, rather than convert it using `ToString()`. Serilog's deep and rich support for structured event data opens up a huge range of diagnostic possibilities not available when using traditional loggers.
+
+Rendered into [JSON format](https://github.com/serilog/serilog-formatting-compact) for example, these properties appear alongside the timestamp, level, and message like:
+
+```json
+{"Position": {"Latitude": 25, "Longitude": 134}, "Elapsed": 34}
+```
+
+Back-ends that are capable of recording structured event data make log searches and analysis possible without log parsing or regular expressions.
+
+Supporting structured data doesn't mean giving up text: when Serilog writes events to files or the console, the template and properties are rendred into friendly human-readable text just like a traditional logging library would produce:
+
+```
+09:14:22 [INF] Processed { Latitude: 25, Longitude: 134 } in 34 ms.
+```
+
+> **Upgrading from Serilog 1.x?** Check out the [2.0 Upgrade Guide](https://github.com/serilog/serilog/wiki/2.x-Upgrade-Guide) and [Release Notes](https://github.com/serilog/serilog/blob/dev/CHANGES.md).
+
+### Features
+
+ * **Community-backed and actively developed**
+ * Format-based logging API with familiar [levels](https://github.com/serilog/serilog/wiki/Configuration-Basics#minimum-level) like `Debug`, `Information`, `Warning`, `Error`, and so-on
+ * Discoverable C# configuration syntax and optional [XML](https://github.com/serilog/serilog-settings-appsettings) or [JSON](https://github.com/serilog/serilog-settings-configuration) configuration support
+ * Efficient when enabled, extremely low overhead when a logging level is switched off
+ * Best-in-class .NET Core support, including a [provider for _Microsoft.Extensions.Logging_](https://github.com/serilog/serilog-extensions-logging)
+ * Support for a [huge range of sinks](https://github.com/serilog/serilog/wiki/Provided-Sinks), including files, the console, on-premises and cloud-based log servers, databases, and message queues
+ * Sophisticated [enrichment](https://github.com/serilog/serilog/wiki/Enrichment) of log events with contextual information, including scoped (`LogContext`) properties, thread and process identifiers, and domain-specific correlation ids such as `HttpRequestId`
+ * Zero-shared-state `Logger` objects, with an optional global static `Log` class
+ * Format-agnostic logging pipeline that can emit events in plain text, JSON, in-memory `LogEvent` objects (including [Rx pipelines](https://github.com/serilog/serilog-sinks-observable)) and other formats
+
+### Getting started
+
+Serilog is installed from NuGet. To view log events, one or more sinks need to be installed as well, here we'll use the pretty-printing "literate" console sink, and a rolling file set:
+
+```
+Install-Package Serilog
+Install-Package Serilog.Sinks.Literate
+Install-Package Serilog.Sinks.RollingFile
+```
+
+The simplest way to set up Serilog is using the static `Log` class. A `LoggerConfiguration` is used to create and assign the default logger.
+
+```csharp
+public class Program
+{
+    public static void Main()
+    {
+        Log.Logger = new LoggerConfiguration()
+            .MinimumLevel.Information()
+            .WriteTo.LiterateConsole()
+            .WriteTo.RollingFile("log-{Date}.txt")
+            .CreateLogger();
+    }
+}
+```
+
+
+Find more, including a runnable example application, under the [Getting Started topic](https://github.com/serilog/serilog/wiki/Getting-Started) in the [documentation](https://github.com/serilog/serilog/wiki/).
+
+### Getting help
+
+To learn more about Serilog, check out the [documentation](https://github.com/serilog/serilog/wiki) - you'll find information there on the most common scenarios. If Serilog isn't working the way you expect, you may find the [troubleshooting guide](https://github.com/serilog/serilog/wiki/Debugging-and-Diagnostics) useful.
+
+Serilog has an active and helpful community who are happy to help point you in the right direction or work through any issues you might encounter. You can get in touch via:
+
+ * [Stack Overflow](http://stackoverflow.com/questions/tagged/serilog) - this is the best place to start if you have a question
+ * Our [issue tracker](https://github.com/serilog/serilog/issues) here on GitHub
+ * [Gitter chat](https://gitter.im/serilog/serilog)
+ * The [#serilog tag on Twitter](https://twitter.com/search?q=%23serilog)
+
+### Contributing
+
+Would you like to help make Serilog even better? We keep a list of issues that are approachable for newcomers under the [up-for-grabs](https://github.com/serilog/serilog/issues?labels=up-for-grabs&state=open) label. Before starting work on a pull request, we suggest commenting on, or raising, an issue on the issue tracker so that we can help and coordinate efforts.
+
+### Detailed build status
 
 Branch  | AppVeyor | Travis
 ------------- | ------------- |-------------
 dev | [![Build status](https://ci.appveyor.com/api/projects/status/b9rm3l7kduryjgcj/branch/dev?svg=true)](https://ci.appveyor.com/project/serilog/serilog/branch/dev)  | [![Build Status](https://travis-ci.org/serilog/serilog.svg?branch=dev)](https://travis-ci.org/serilog/serilog) 
 master | [![Build status](https://ci.appveyor.com/api/projects/status/b9rm3l7kduryjgcj/branch/master?svg=true)](https://ci.appveyor.com/project/serilog/serilog/branch/master) | [![Build Status](https://travis-ci.org/serilog/serilog.svg?branch=master)](https://travis-ci.org/serilog/serilog) 
 
-_Copyright &copy; 2013-2016 Serilog Contributors - Provided under the [Apache License, Version 2.0](http://apache.org/licenses/LICENSE-2.0.html). Needle and thread logo a derivative of work by [Kenneth Appiah](http://www.kensets.com/)._
+_Serilog is copyright &copy; 2013-2016 Serilog Contributors - Provided under the [Apache License, Version 2.0](http://apache.org/licenses/LICENSE-2.0.html). Needle and thread logo a derivative of work by [Kenneth Appiah](http://www.kensets.com/)._

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 #Serilog [![Build status](https://ci.appveyor.com/api/projects/status/b9rm3l7kduryjgcj/branch/master?svg=true)](https://ci.appveyor.com/project/serilog/serilog/branch/master)  [![NuGet Version](http://img.shields.io/nuget/v/Serilog.svg?style=flat)](https://www.nuget.org/packages/Serilog/) [![Rager Releases](http://rager.io/badge.svg?url=https%3A%2F%2Fwww.nuget.org%2Fpackages%2FSerilog%2F)](http://rager.io/projects/search?badge=1&query=nuget.org/packages/Serilog/) [![Join the chat at https://gitter.im/serilog/serilog](https://img.shields.io/gitter/room/serilog/serilog.svg)](https://gitter.im/serilog/serilog) [![Stack Overflow](https://img.shields.io/badge/stackoverflow-serilog-orange.svg)](http://stackoverflow.com/questions/tagged/serilog)
 
-Serilog is a diagnostic logging library for .NET applications. It is easy to set up, has a clean API, and runs on all recent .NET platforms. While it's useful in even the simplest applications, Serilog's support for structured logging shines when instrumenting complex, distributed, and asynchronous applications and systems.
+Serilog is a diagnostic logging library for .NET applications. It is easy to set up, has a clean API, and runs on all recent .NET platforms. While it's useful even in the simplest applications, Serilog's support for structured logging shines when instrumenting complex, distributed, and asynchronous applications and systems.
 
 [![Serilog](https://serilog.net/images/serilog-180px.png)](https://serilog.net)
 
@@ -24,7 +24,7 @@ var elapsedMs = 34;
 log.Information("Processed {@Position} in {Elapsed} ms.", position, elapsedMs);
 ```
 
-Serilog uses [message templates](https://messagetemplates.org), a simple DSL that extends .NET format strings with named, as well as positional, parameters. Instead of formatting events immediately into text, Serilog captures the values associated with each named parameter.
+Serilog uses [message templates](https://messagetemplates.org), a simple DSL that extends .NET format strings with _named_ as well as positional parameters. Instead of formatting events immediately into text, Serilog captures the values associated with each named parameter.
 
 The example above records two properties, `Position` and `Elapsed`, in the log event. The `@` operator in front of `Position` tells Serilog to _serialize_ the object passed in, rather than convert it using `ToString()`. Serilog's deep and rich support for structured event data opens up a huge range of diagnostic possibilities not available when using traditional loggers.
 
@@ -36,7 +36,7 @@ Rendered into [JSON format](https://github.com/serilog/serilog-formatting-compac
 
 Back-ends that are capable of recording structured event data make log searches and analysis possible without log parsing or regular expressions.
 
-Supporting structured data doesn't mean giving up text: when Serilog writes events to files or the console, the template and properties are rendred into friendly human-readable text just like a traditional logging library would produce:
+Supporting structured data doesn't mean giving up text: when Serilog writes events to files or the console, the template and properties are rendered into friendly human-readable text just like a traditional logging library would produce:
 
 ```
 09:14:22 [INF] Processed { Latitude: 25, Longitude: 134 } in 34 ms.
@@ -51,7 +51,7 @@ Supporting structured data doesn't mean giving up text: when Serilog writes even
  * Discoverable C# configuration syntax and optional [XML](https://github.com/serilog/serilog-settings-appsettings) or [JSON](https://github.com/serilog/serilog-settings-configuration) configuration support
  * Efficient when enabled, extremely low overhead when a logging level is switched off
  * Best-in-class .NET Core support, including a [provider for _Microsoft.Extensions.Logging_](https://github.com/serilog/serilog-extensions-logging)
- * Support for a [huge range of sinks](https://github.com/serilog/serilog/wiki/Provided-Sinks), including files, the console, on-premises and cloud-based log servers, databases, and message queues
+ * Support for a [comprehensive range of sinks](https://github.com/serilog/serilog/wiki/Provided-Sinks), including files, the console, on-premises and cloud-based log servers, databases, and message queues
  * Sophisticated [enrichment](https://github.com/serilog/serilog/wiki/Enrichment) of log events with contextual information, including scoped (`LogContext`) properties, thread and process identifiers, and domain-specific correlation ids such as `HttpRequestId`
  * Zero-shared-state `Logger` objects, with an optional global static `Log` class
  * Format-agnostic logging pipeline that can emit events in plain text, JSON, in-memory `LogEvent` objects (including [Rx pipelines](https://github.com/serilog/serilog-sinks-observable)) and other formats


### PR DESCRIPTION
I've had a shot at revamping the README.

When I check out a new library, the README is the first thing I look at. While our current README has links to all sorts of useful documentation, people will only bother clicking through and reading it if they can confirm Serilog matches what they're looking for first.

I think it'd be great to make this even more comprehensive, but this should at least be a decent starting point. Feedback welcome! :-)

[Rendered](https://github.com/nblumhardt/serilog/blob/fc900ba5d906d15445787a756f0e4c98eba81bd0/README.md)