### PR TITLE
fix for Issue #885, formatting floating point special values NaN/PositiveInfinity/NegativeInfinity as JSON strings and unit tests

### DIFF
--- a/src/Serilog/Formatting/Json/JsonValueFormatter.cs
+++ b/src/Serilog/Formatting/Json/JsonValueFormatter.cs
@@ -231,7 +231,7 @@ namespace Serilog.Formatting.Json
 		{
 			if (float.IsNaN(value) || float.IsInfinity(value))
 			{
-				FormatStringValue(value.ToString(), output);
+				FormatStringValue(value.ToString(CultureInfo.InvariantCulture), output);
 				return;
 			}
 
@@ -242,7 +242,7 @@ namespace Serilog.Formatting.Json
 		{
 			if (double.IsNaN(value) || double.IsInfinity(value))
 			{
-				FormatStringValue(value.ToString(), output);
+				FormatStringValue(value.ToString(CultureInfo.InvariantCulture), output);
 				return;
 			}
 

--- a/src/Serilog/Formatting/Json/JsonValueFormatter.cs
+++ b/src/Serilog/Formatting/Json/JsonValueFormatter.cs
@@ -182,18 +182,17 @@ namespace Serilog.Formatting.Json
                     return;
                 }
 
-                if (value is double || value is float)
-                {
-					if ((value is double && (double.IsNaN((double)value) || double.IsInfinity((double)value)))
-						|| (value is float && (float.IsNaN((float)value) || float.IsInfinity((float)value))))
-					{
-						FormatStringValue(value.ToString(), output);
-						return;
-					}
+				if (value is double)
+				{
+					FormatDoubleValue((double)value, output);
+					return;
+				}
 
-					FormatApproximateNumericValue((IFormattable)value, output);
-                    return;
-                }
+				if (value is float)
+				{
+					FormatFloatValue((float)value, output);
+					return;
+				}
 
                 if (value is bool)
                 {
@@ -228,10 +227,27 @@ namespace Serilog.Formatting.Json
             output.Write(value ? "true" : "false");
         }
 
-        static void FormatApproximateNumericValue(IFormattable value, TextWriter output)
-        {
-            output.Write(value.ToString("R", CultureInfo.InvariantCulture));
-        }
+		static void FormatFloatValue(float value, TextWriter output)
+		{
+			if (float.IsNaN(value) || float.IsInfinity(value))
+			{
+				FormatStringValue(value.ToString(), output);
+				return;
+			}
+
+			output.Write(value.ToString("R", CultureInfo.InvariantCulture));
+		}
+
+		static void FormatDoubleValue(double value, TextWriter output)
+		{
+			if (double.IsNaN(value) || double.IsInfinity(value))
+			{
+				FormatStringValue(value.ToString(), output);
+				return;
+			}
+
+			output.Write(value.ToString("R", CultureInfo.InvariantCulture));
+		}
 
         static void FormatExactNumericValue(IFormattable value, TextWriter output)
         {

--- a/src/Serilog/Formatting/Json/JsonValueFormatter.cs
+++ b/src/Serilog/Formatting/Json/JsonValueFormatter.cs
@@ -184,7 +184,14 @@ namespace Serilog.Formatting.Json
 
                 if (value is double || value is float)
                 {
-                    FormatApproximateNumericValue((IFormattable)value, output);
+					if ((value is double && (double.IsNaN((double)value) || double.IsInfinity((double)value)))
+						|| (value is float && (float.IsNaN((float)value) || float.IsInfinity((float)value))))
+					{
+						FormatStringValue(value.ToString(), output);
+						return;
+					}
+
+					FormatApproximateNumericValue((IFormattable)value, output);
                     return;
                 }
 

--- a/test/Serilog.Tests/Formatting/Json/JsonValueFormatterTests.cs
+++ b/test/Serilog.Tests/Formatting/Json/JsonValueFormatterTests.cs
@@ -49,7 +49,33 @@ namespace Serilog.Tests.Formatting.Json
             JsonLiteralTypesAreFormatted(123.45, "123.45");
         }
 
-        [Fact]
+		[Fact]
+		public void DoubleSpecialsFormatAsString()
+		{
+			string format = "\"{0}\"";
+
+			JsonLiteralTypesAreFormatted(double.NaN, string.Format(format, double.NaN));
+			JsonLiteralTypesAreFormatted(double.PositiveInfinity, string.Format(format, double.PositiveInfinity));
+			JsonLiteralTypesAreFormatted(double.NegativeInfinity, string.Format(format, double.NegativeInfinity));
+		}
+
+		[Fact]
+		public void FloatFormatsAsNumber()
+		{
+			JsonLiteralTypesAreFormatted(123.45f, "123.45");
+		}
+
+		[Fact]
+		public void FloatSpecialsFormatAsString()
+		{
+			string format = "\"{0}\"";
+
+			JsonLiteralTypesAreFormatted(float.NaN, string.Format(format, float.NaN));
+			JsonLiteralTypesAreFormatted(float.PositiveInfinity, string.Format(format, float.PositiveInfinity));
+			JsonLiteralTypesAreFormatted(float.NegativeInfinity, string.Format(format, float.NegativeInfinity));
+		}
+
+		[Fact]
         public void DecimalFormatsAsNumber()
         {
             JsonLiteralTypesAreFormatted(123.45m, "123.45");

--- a/test/Serilog.Tests/Formatting/Json/JsonValueFormatterTests.cs
+++ b/test/Serilog.Tests/Formatting/Json/JsonValueFormatterTests.cs
@@ -52,13 +52,11 @@ namespace Serilog.Tests.Formatting.Json
 		[Fact]
 		public void DoubleSpecialsFormatAsString()
 		{
-			string format = "\"{0}\"";
-
-			JsonLiteralTypesAreFormatted(double.NaN, string.Format(format, double.NaN));
-			JsonLiteralTypesAreFormatted(double.PositiveInfinity, string.Format(format, double.PositiveInfinity));
-			JsonLiteralTypesAreFormatted(double.NegativeInfinity, string.Format(format, double.NegativeInfinity));
+			JsonLiteralTypesAreFormatted(double.NaN, "\"NaN\"");
+			JsonLiteralTypesAreFormatted(double.PositiveInfinity, "\"Infinity\"");
+			JsonLiteralTypesAreFormatted(double.NegativeInfinity, "\"-Infinity\"");
 		}
-
+		
 		[Fact]
 		public void FloatFormatsAsNumber()
 		{
@@ -68,11 +66,9 @@ namespace Serilog.Tests.Formatting.Json
 		[Fact]
 		public void FloatSpecialsFormatAsString()
 		{
-			string format = "\"{0}\"";
-
-			JsonLiteralTypesAreFormatted(float.NaN, string.Format(format, float.NaN));
-			JsonLiteralTypesAreFormatted(float.PositiveInfinity, string.Format(format, float.PositiveInfinity));
-			JsonLiteralTypesAreFormatted(float.NegativeInfinity, string.Format(format, float.NegativeInfinity));
+			JsonLiteralTypesAreFormatted(float.NaN, "\"NaN\"");
+			JsonLiteralTypesAreFormatted(float.PositiveInfinity, "\"Infinity\"");
+			JsonLiteralTypesAreFormatted(float.NegativeInfinity, "\"-Infinity\"");
 		}
 
 		[Fact]


### PR DESCRIPTION
This fixes issue #885 where special floating point values are not properly formatted as JSON.

 It adds an if statement to the JSON value formatter that catches the special values and formats them as JSON strings. In addition, it adds several unit tests that check if the special values are being formatted as JSON strings.
