### PR TITLE
Convention tests for log level write methods in Serilog.Core.Logger

### DIFF
--- a/test/Serilog.Tests/Core/LoggerTests.cs
+++ b/test/Serilog.Tests/Core/LoggerTests.cs
@@ -9,6 +9,7 @@ using Serilog.Tests.Support;
 using System.Reflection;
 using Xunit.Sdk;
 using System.Text.RegularExpressions;
+using System.Text;
 
 namespace Serilog.Tests.Core
 {
@@ -120,44 +121,17 @@ namespace Serilog.Tests.Core
             Assert.Equal("World", property.Value.LiteralValue());
         }
 
-		[Fact]
-		public void VerboseMethodsMatchConvention()
+		[Theory]
+		[InlineData(LogEventLevel.Verbose)]
+		[InlineData(LogEventLevel.Debug)]
+		[InlineData(LogEventLevel.Information)]
+		[InlineData(LogEventLevel.Warning)]
+		[InlineData(LogEventLevel.Error)]
+		[InlineData(LogEventLevel.Fatal)]
+		public void ValidateConventionForMethodSet(LogEventLevel level)
 		{
-			ValidateConventionForMethodSet("Verbose");
-		}
+			var setName = level.ToString();
 
-		[Fact]
-		public void DebugMethodsMatchConvention()
-		{
-			ValidateConventionForMethodSet("Debug");
-		}
-
-		[Fact]
-		public void InformationMethodsMatchConvention()
-		{
-			ValidateConventionForMethodSet("Information");
-		}
-
-		[Fact]
-		public void WarningMethodsMatchConvention()
-		{
-			ValidateConventionForMethodSet("Warning");
-		}
-
-		[Fact]
-		public void ErrorMethodsMatchConvention()
-		{
-			ValidateConventionForMethodSet("Error");
-		}
-
-		[Fact]
-		public void FatalMethodsMatchConvention()
-		{
-			ValidateConventionForMethodSet("Fatal");
-		}
-
-		private void ValidateConventionForMethodSet(string setName)
-		{
 			var methodSet = typeof(Logger).GetMethods().Where(method => method.Name == setName);
 
 			var testMethods = typeof(LoggerTests).GetRuntimeMethods()
@@ -177,207 +151,251 @@ namespace Serilog.Tests.Core
 
 				var signatureMatch = false;
 
-				foreach (var test in testMethods)
+				var report = new StringBuilder();
+
+				foreach (var testMethod in testMethods)
 				{
 					try
 					{
-						test.Invoke(this, new object[] { method });
+						testMethod.Invoke(this, new object[] { method, level });
 
 						signatureMatch = true;
 
 						break;
 					}
 					catch (Exception e)
-					when (e is TargetInvocationException
-							&& ((TargetInvocationException)e).GetBaseException() is XunitException)
+						when (e is TargetInvocationException
+							&& (e as TargetInvocationException).GetBaseException() is XunitException)
 					{
+						var xunitException = (XunitException)(e as TargetInvocationException).GetBaseException();
+
+						if (xunitException.Data.Contains("IsSignatureAssertionFailure"))
+						{
+							report.AppendLine($"{testMethod.Name} Signature Mismatch on: {method} with: {xunitException.Message}");
+						}
+						else
+						{
+							report.AppendLine($"{testMethod.Name} Invocation Failure on: {method} with: {xunitException.UserMessage}");
+						}
+
 						continue;
 					}
 				}
 
-				Assert.True(signatureMatch, $"{method} did not match any known convention");
+				Assert.True(signatureMatch, $"{method} did not match any known convention\n" + report.ToString());
 			}
 		}
 
-
 		// Method0 (string messageTemplate) : void
-		private void ValidateMethod0(MethodInfo method)
+		void ValidateMethod0(MethodInfo method, LogEventLevel level)
 		{
 			VerifyMethodSignature(method, expectedArgCount: 1);
 
-			GetLoggerAndInvoke(method, "message");
+			GetLoggerAndInvoke(method, level, "message");
 		}
 
 		// Method1<T> (string messageTemplate, T propertyValue) : void
-		private void ValidateMethod1(MethodInfo method)
+		void ValidateMethod1(MethodInfo method, LogEventLevel level)
 		{
 			VerifyMethodSignature(method, isGeneric: true, expectedArgCount: 2);
 
-			GetLoggerAndInvokeGeneric(method, new Type[] { typeof(string) }, "message", "value0");
+			GetLoggerAndInvokeGeneric(method, level, new Type[] { typeof(string) }, "message", "value0");
 		}
 
 		// Method2<T0, T1> (string messageTemplate, T0 propertyValue0, T1 propertyValue1) : void
-		private void ValidateMethod2(MethodInfo method)
+		void ValidateMethod2(MethodInfo method, LogEventLevel level)
 		{
 			VerifyMethodSignature(method, isGeneric: true, expectedArgCount: 3);
 
-			GetLoggerAndInvokeGeneric(method, new Type[] { typeof(string), typeof(string) },
+			GetLoggerAndInvokeGeneric(method, level, new Type[] { typeof(string), typeof(string) },
 				"message", "value0", "value1");
 		}
 
 		// Method3<T0, T1, T2> (string messageTemplate, T0 propertyValue0, T1 propertyValue1, T2 propertyValue2) : void
-		private void ValidateMethod3(MethodInfo method)
+		void ValidateMethod3(MethodInfo method, LogEventLevel level)
 		{
 			VerifyMethodSignature(method, isGeneric: true, expectedArgCount: 4);
 
-			GetLoggerAndInvokeGeneric(method, new Type[] { typeof(string), typeof(string), typeof(string) },
+			GetLoggerAndInvokeGeneric(method, level, new Type[] { typeof(string), typeof(string), typeof(string) },
 				"message", "value0", "value1", "value2");
 		}
 
 		// Method4 (string messageTemplate, params object[] propertyValues) : void
-		private void ValidateMethod4(MethodInfo method)
+		void ValidateMethod4(MethodInfo method, LogEventLevel level)
 		{
 			VerifyMethodSignature(method, expectedArgCount: 2);
 
-			GetLoggerAndInvoke(method, "message", new object[] { "value0", "value1", "value2" });
+			GetLoggerAndInvoke(method, level, "message", new object[] { "value0", "value1", "value2" });
 		}
 
 		// Method5 (Exception exception, string messageTemplate) : void
-		private void ValidateMethod5(MethodInfo method)
+		void ValidateMethod5(MethodInfo method, LogEventLevel level)
 		{
 			VerifyMethodSignature(method, hasExceptionArg: true, expectedArgCount: 2);
 
-			GetLoggerAndInvoke(method, new Exception("test"), "message");
+			GetLoggerAndInvoke(method, level, new Exception("test"), "message");
 		}
 
 		// Method6<T> (Exception exception, string messageTemplate, T propertyValue) : void
-		private void ValidateMethod6(MethodInfo method)
+		void ValidateMethod6(MethodInfo method, LogEventLevel level)
 		{
 			VerifyMethodSignature(method, hasExceptionArg: true, isGeneric: true, expectedArgCount: 3);
 
-			GetLoggerAndInvokeGeneric(method, new Type[] { typeof(string) }, new Exception("test"), "message", "value0");
+			GetLoggerAndInvokeGeneric(method, level, new Type[] { typeof(string) }, new Exception("test"), "message", "value0");
 		}
 
 		// Method7<T0, T1> (Exception exception, string messageTemplate, T0 propertyValue0, T1 propertyValue1) : void
-		private void ValidateMethod7(MethodInfo method)
+		void ValidateMethod7(MethodInfo method, LogEventLevel level)
 		{
 			VerifyMethodSignature(method, hasExceptionArg: true, isGeneric: true, expectedArgCount: 4);
 
-			GetLoggerAndInvokeGeneric(method, new Type[] { typeof(string), typeof(string) },
+			GetLoggerAndInvokeGeneric(method, level, new Type[] { typeof(string), typeof(string) },
 				new Exception("test"), "message", "value0", "value1");
 		}
 
 		// Method8<T0, T1, T2> (Exception exception, string messageTemplate, T0 propertyValue0, T1 propertyValue1, T2 propertyValue2) : void
-		private void ValidateMethod8(MethodInfo method)
+		void ValidateMethod8(MethodInfo method, LogEventLevel level)
 		{
 			VerifyMethodSignature(method, hasExceptionArg: true, isGeneric: true, expectedArgCount: 5);
 
-			var typeOfString = typeof(string);
-
-			GetLoggerAndInvokeGeneric(method, new Type[] { typeof(string), typeof(string), typeof(string) },
+			GetLoggerAndInvokeGeneric(method, level, new Type[] { typeof(string), typeof(string), typeof(string) },
 				new Exception("test"), "message", "value0", "value1", "value2");
 		}
 
 		// Method9 (Exception exception, string messageTemplate, params object[] propertyValues) : void
-		private void ValidateMethod9(MethodInfo method)
+		void ValidateMethod9(MethodInfo method, LogEventLevel level)
 		{
 			VerifyMethodSignature(method, hasExceptionArg: true, expectedArgCount: 3);
 
-			GetLoggerAndInvoke(method, new Exception("test"), "message", new object[] { "value0", "value1", "value2" });
+			GetLoggerAndInvoke(method, level, new Exception("test"), "message", new object[] { "value0", "value1", "value2" });
 		}
 
-		private static void GetLoggerAndInvoke(MethodInfo method, params object[] parameters)
+		static void GetLoggerAndInvoke(MethodInfo method, LogEventLevel level, params object[] parameters)
 		{
-			var logger = new LoggerConfiguration().CreateLogger();
+			var sink = new CollectingSink();
+
+			var logger = new LoggerConfiguration()
+				.MinimumLevel.Verbose()
+				.WriteTo.Sink(sink)
+				.CreateLogger();
 
 			method.Invoke(logger, parameters);
+
+			Assert.Equal(1, sink.Events.Count);
+
+			var evt = sink.Events.Single();
+
+			Assert.Equal(level, evt.Level);
 		}
 
-		private static void GetLoggerAndInvokeGeneric(MethodInfo method, Type[] typeArgs, params object[] parameters)
+		static void GetLoggerAndInvokeGeneric(MethodInfo method, LogEventLevel level, Type[] typeArgs, params object[] parameters)
 		{
-			var logger = new LoggerConfiguration().CreateLogger();
+			var sink = new CollectingSink();
+
+			var logger = new LoggerConfiguration()
+				.MinimumLevel.Verbose()
+				.WriteTo.Sink(sink)
+				.CreateLogger();
 
 			method.MakeGenericMethod(typeArgs).Invoke(logger, parameters);
+
+			Assert.Equal(1, sink.Events.Count);
+
+			var evt = sink.Events.Single();
+
+			Assert.Equal(level, evt.Level);
 		}
 
 		// parameters will always be ordered so single evaluation method will work
-		private static void VerifyMethodSignature(MethodInfo method, bool hasExceptionArg = false, bool isGeneric = false, int expectedArgCount = 1)
+		static void VerifyMethodSignature(MethodInfo method, bool hasExceptionArg = false, bool isGeneric = false, int expectedArgCount = 1)
 		{
-			var parameters = method.GetParameters();
-
-			Assert.Equal(parameters.Length, expectedArgCount);
-
-			int index = 0;
-
-			if (hasExceptionArg) //verify exception arg type and name
+			try
 			{
-				Assert.Equal(parameters[index].ParameterType, typeof(Exception));
+				var parameters = method.GetParameters();
 
-				Assert.Equal(parameters[index].Name, "exception");
+				Assert.Equal(parameters.Length, expectedArgCount);
 
-				index++;
-			}
+				int index = 0;
 
-			//check message template argument
-			Assert.Equal(parameters[index].ParameterType, typeof(string));
-
-			Assert.Equal(parameters[index].Name, "messageTemplate");
-
-			index++;
-
-			if (isGeneric) //validate type arguments, generic parameters, and cross-reference
-			{
-				Assert.True(method.IsGenericMethod);
-
-				var genericTypeArgs = method.GetGenericArguments();
-
-				//multiple generic argument convention T0...Tx : T0 propertyValue0... Tx propertyValueX
-				if (genericTypeArgs.Length > 1)
+				// exceptions always come before messageTemplate string
+				if (hasExceptionArg) //verify exception argument type and name
 				{
-					for (int i = 0; i < genericTypeArgs.Length; i++, index++)
-					{
-						Assert.Equal(genericTypeArgs[i].Name, $"T{i}");
+					Assert.Equal(parameters[index].ParameterType, typeof(Exception));
 
-						var genericConstraints = genericTypeArgs[i].GetTypeInfo().GetGenericParameterConstraints();
-
-						Assert.Empty(genericConstraints);
-
-						Assert.Equal(parameters[index].Name, $"propertyValue{i}");
-
-						Assert.Equal(parameters[index].ParameterType, genericTypeArgs[i]);
-					}
-				}
-				else //single generic argument convention T : T propertyValue
-				{
-					var genericTypeArg = genericTypeArgs[0];
-
-					Assert.Equal(genericTypeArg.Name, "T");
-
-					var genericConstraints = genericTypeArg.GetTypeInfo().GetGenericParameterConstraints();
-
-					Assert.Empty(genericConstraints);
-
-					Assert.Equal(parameters[index].Name, "propertyValue");
-
-					Assert.Equal(genericTypeArg, parameters[index].ParameterType);
+					Assert.Equal(parameters[index].Name, "exception");
 
 					index++;
 				}
+
+				//check for message template string argument
+				Assert.Equal(parameters[index].ParameterType, typeof(string));
+
+				Assert.Equal(parameters[index].Name, "messageTemplate");
+
+				index++;
+
+				if (isGeneric) //validate type arguments, generic parameters, and cross-reference
+				{
+					Assert.True(method.IsGenericMethod);
+
+					var genericTypeArgs = method.GetGenericArguments();
+
+					//multiple generic argument convention T0...Tx : T0 propertyValue0... Tx propertyValueX
+					if (genericTypeArgs.Length > 1)
+					{
+						for (int i = 0; i < genericTypeArgs.Length; i++, index++)
+						{
+							Assert.Equal(genericTypeArgs[i].Name, $"T{i}");
+
+							var genericConstraints = genericTypeArgs[i].GetTypeInfo().GetGenericParameterConstraints();
+
+							Assert.Empty(genericConstraints);
+
+							Assert.Equal(parameters[index].Name, $"propertyValue{i}");
+
+							Assert.Equal(parameters[index].ParameterType, genericTypeArgs[i]);
+						}
+					}
+					else //single generic argument convention T : T propertyValue
+					{
+						var genericTypeArg = genericTypeArgs[0];
+
+						Assert.Equal(genericTypeArg.Name, "T");
+
+						var genericConstraints = genericTypeArg.GetTypeInfo().GetGenericParameterConstraints();
+
+						Assert.Empty(genericConstraints);
+
+						Assert.Equal(parameters[index].Name, "propertyValue");
+
+						Assert.Equal(genericTypeArg, parameters[index].ParameterType);
+
+						index++;
+					}
+				}
+
+				//check for params argument: params object[] propertyValues
+				//params argument currently has to be the last argument, and generic methods don't have params argument
+				if (!isGeneric && (parameters.Length - index) == 1)
+				{
+					var paramsArrayArg = parameters[index];
+
+					// params array attribute should never have derived/inherited classes
+					var paramsAttr = parameters[index].GetCustomAttribute(typeof(ParamArrayAttribute), inherit: false);
+
+					Assert.NotNull(paramsAttr);
+
+					Assert.Equal(paramsArrayArg.ParameterType, typeof(object[]));
+
+					Assert.Equal(paramsArrayArg.Name, "propertyValues");
+				}
 			}
-
-			//check for params argument
-			//params args currently have to be the last argument, and generics don't have params arg
-			if (!isGeneric && (parameters.Length - index) == 1)
+			catch (XunitException e)
 			{
-				var paramsArrayArg = parameters[index];
+				// mark xunit assertion failures
+				e.Data.Add("IsSignatureAssertionFailure", true);
 
-				var paramsAttr = parameters[index].GetCustomAttribute(typeof(ParamArrayAttribute), inherit: false);
-
-				Assert.NotNull(paramsAttr);
-
-				Assert.Equal(paramsArrayArg.ParameterType, typeof(object[]));
-
-				Assert.Equal(paramsArrayArg.Name, "propertyValues");
+				throw e;
 			}
 		}
 	}


### PR DESCRIPTION
As proposed in #878, tests that check the convention of the log level wrapper methods in` Serilog.Core.Logger`. The tests reflect over the methods in `Serilog.Core.Logger` , that match known log level names. Then the methods and their parameters are checked against several rules that match the signatures listed below. If a method matches a know signature, it is invoked with some arbitrary data. If a method does not match a know signature, the test for its log level group fails with the unmatched method printed out as an error message.

```
Method0 (string messageTemplate) : void
Method1<T> (string messageTemplate, T propertyValue) : void
Method2<T0, T1> (string messageTemplate, T0 propertyValue0, T1 propertyValue1) : void
Method3<T0, T1, T2> (string messageTemplate, T0 propertyValue0, T1 propertyValue1, T2 propertyValue2) : void
Method4 (string messageTemplate, params object[] propertyValues) : void
Method5 (Exception exception, string messageTemplate) : void
Method6<T> (Exception exception, string messageTemplate, T propertyValue) : void
Method7<T0, T1> (Exception exception, string messageTemplate, T0 propertyValue0, T1 propertyValue1) : void
Method8<T0, T1, T2> (Exception exception, string messageTemplate, T0 propertyValue0, T1 propertyValue1, T2 propertyValue2) : void
Method9 (Exception exception, string messageTemplate, params object[] propertyValues) : void
```

