### PR TITLE
ILogger API conformance fixes in Serilog.Log

### DIFF
--- a/src/Serilog/Log.cs
+++ b/src/Serilog/Log.cs
@@ -81,7 +81,7 @@ namespace Serilog
         /// </summary>
         /// <param name="enrichers">Enrichers that apply in the context.</param>
         /// <returns>A logger that will enrich log events as specified.</returns>
-        public static ILogger ForContext(IEnumerable<ILogEventEnricher> enrichers)
+        public static ILogger ForContext(ILogEventEnricher[] enrichers)
         {
             return Logger.ForContext(enrichers);
         }

--- a/src/Serilog/Log.cs
+++ b/src/Serilog/Log.cs
@@ -81,7 +81,7 @@ namespace Serilog
         /// </summary>
         /// <param name="enrichers">Enrichers that apply in the context.</param>
         /// <returns>A logger that will enrich log events as specified.</returns>
-        public static ILogger ForContext(ILogEventEnricher[] enrichers)
+        public static ILogger ForContext(IEnumerable<ILogEventEnricher> enrichers)
         {
             return Logger.ForContext(enrichers);
         }
@@ -1184,6 +1184,22 @@ namespace Serilog
         public static bool BindMessageTemplate(string messageTemplate, object[] propertyValues, out MessageTemplate parsedTemplate, out IEnumerable<LogEventProperty> boundProperties)
         {
             return Logger.BindMessageTemplate(messageTemplate, propertyValues, out parsedTemplate, out boundProperties);
+        }
+
+        /// <summary>
+        /// Uses configured scalar conversion and destructuring rules to bind a property value to its captured
+        /// representation.
+        /// </summary>
+        /// <returns>True if the property could be bound, otherwise false (<summary>ILogger</summary>
+        /// <param name="propertyName">The name of the property. Must be non-empty.</param>
+        /// <param name="value">The property value.</param>
+        /// <param name="destructureObjects">If true, the value will be serialized as a structured
+        /// object if possible; if false, the object will be recorded as a scalar or simple array.</param>
+        /// <param name="property">The resulting property.</param>
+        /// methods never throw exceptions).</returns>
+        public static bool BindProperty(string propertyName, object value, bool destructureObjects, out LogEventProperty property)
+        {
+            return Logger.BindProperty(propertyName, value, destructureObjects, out property);
         }
     }
 }


### PR DESCRIPTION
I found several differences in `Serilog.Log` versus the `Serilog.ILogger` interface. This PR brings `Serilog.Log` into parity with `Serilog.ILogger`.  

1.   `ForContext` method that takes multiple `ILogEventEnricher` takes an array versus `IEnumerable<ILogEventEnricher>` in `Serilog.ILogger`. This changes it so that it takes an `IEnumerable<ILogEventEnricher>`.

`ILogger ForContext(ILogEventEnricher[] enrichers)`  -->
  `ILogger ForContext(IEnumerable<IlogEventEnricher> enrichers)`

2. Adds a `BindProperty` method to `Serilog.Log` 

 `public static bool BindProperty(string propertyName, object value, bool destructureObjects, out LogEventProperty property)`