### PR TITLE
Dispose audit sinks on ILogger.Dispose()

### DIFF
--- a/src/Serilog/LoggerConfiguration.cs
+++ b/src/Serilog/LoggerConfiguration.cs
@@ -139,6 +139,9 @@ namespace Serilog
             {
                 foreach (var disposable in _logEventSinks.OfType<IDisposable>())
                     disposable.Dispose();
+
+                foreach (var disposable in _auditSinks.OfType<IDisposable>())
+                    disposable.Dispose();
             };
 
             ILogEventSink sink = new SafeAggregateSink(_logEventSinks);

--- a/src/Serilog/LoggerConfiguration.cs
+++ b/src/Serilog/LoggerConfiguration.cs
@@ -137,10 +137,7 @@ namespace Serilog
 
             Action dispose = () =>
             {
-                foreach (var disposable in _logEventSinks.OfType<IDisposable>())
-                    disposable.Dispose();
-
-                foreach (var disposable in _auditSinks.OfType<IDisposable>())
+                foreach (var disposable in _logEventSinks.Concat(_auditSinks).OfType<IDisposable>())
                     disposable.Dispose();
             };
 

--- a/test/Serilog.Tests/Core/AuditSinkTests.cs
+++ b/test/Serilog.Tests/Core/AuditSinkTests.cs
@@ -1,0 +1,100 @@
+﻿using System;
+using System.Reflection;
+using Serilog.Tests.Support;
+using Xunit;
+
+namespace Serilog.Tests.Core
+{
+    public class AuditSinkTests
+    {
+        [Fact]
+        public void ExceptionsThrownByAuditSinksArePropagated()
+        {
+            var logger = new LoggerConfiguration()
+                .AuditTo.Sink(new DelegatingSink(e => { throw new Exception("Boom!"); }))
+                .CreateLogger();
+
+            Assert.Throws<AggregateException>(() => logger.Write(Some.InformationEvent()));
+        }
+
+        [Fact]
+        public void ExceptionsThrownByFiltersArePropagatedIfAuditingEnabled()
+        {
+            var logger = new LoggerConfiguration()
+                .AuditTo.Sink(new DelegatingSink(e => { }))
+                .Filter.ByExcluding(e => { throw new Exception("Boom!"); })
+                .CreateLogger();
+
+            Assert.Throws<Exception>(() => logger.Write(Some.InformationEvent()));
+        }
+
+        [Fact]
+        public void ExceptionsThrownByAuditSinksArePropagatedFromChildLoggers()
+        {
+            var logger = new LoggerConfiguration()
+                .AuditTo.Sink(new DelegatingSink(e => { throw new Exception("Boom!"); }))
+                .CreateLogger();
+
+            Assert.Throws<AggregateException>(() => logger
+                .ForContext<LoggerConfigurationTests>()
+                .Write(Some.InformationEvent()));
+        }
+
+        [Fact]
+        public void ExceptionsThrownByDestructuringPoliciesArePropagatedIfAuditingEnabled()
+        {
+            var logger = new LoggerConfiguration()
+                .AuditTo.Sink(new CollectingSink())
+                .Destructure.ByTransforming<Value>(v => { throw new Exception("Boom!"); })
+                .CreateLogger();
+
+            Assert.Throws<Exception>(() => logger.Information("{@Value}", new Value()));
+        }
+
+        [Fact]
+        public void ExceptionsThrownByPropertyAccessorsAreNotPropagated()
+        {
+            var logger = new LoggerConfiguration()
+                .WriteTo.Sink(new CollectingSink())
+                .CreateLogger();
+
+            logger.Information("{@Value}", new ThrowingProperty());
+
+            Assert.True(true, "No exception reached the caller");
+        }
+
+        [Fact]
+        public void ExceptionsThrownByPropertyAccessorsArePropagatedIfAuditingEnabled()
+        {
+            var logger = new LoggerConfiguration()
+                .AuditTo.Sink(new CollectingSink())
+                .CreateLogger();
+
+            Assert.Throws<TargetInvocationException>(() => logger.Information("{@Value}", new ThrowingProperty()));
+        }
+
+        [Fact]
+        public void SinkIsDisposedWhenLoggerDisposed()
+        {
+            var tracker = new DisposeTrackingSink();
+            var logger = new LoggerConfiguration()
+                .AuditTo.Sink(tracker)
+                .CreateLogger();
+
+            logger.Dispose();
+
+            Assert.True(tracker.IsDisposed);
+        }
+
+        class Value { }
+
+        class ThrowingProperty
+        {
+            // ReSharper disable once UnusedMember.Local
+            public string Property
+            {
+                get { throw new Exception("Boom!"); }
+            }
+        }
+    }
+}

--- a/test/Serilog.Tests/LoggerConfigurationTests.cs
+++ b/test/Serilog.Tests/LoggerConfigurationTests.cs
@@ -554,39 +554,6 @@ namespace Serilog.Tests
             Assert.True(true, "No exception reached the caller");
         }
 
-        [Fact]
-        public void ExceptionsThrownByAuditSinksArePropagated()
-        {
-            var logger = new LoggerConfiguration()
-                .AuditTo.Sink(new DelegatingSink(e => { throw new Exception("Boom!"); }))
-                .CreateLogger();
-
-            Assert.Throws<AggregateException>(() => logger.Write(Some.InformationEvent()));
-        }
-
-        [Fact]
-        public void ExceptionsThrownByFiltersArePropagatedIfAuditingEnabled()
-        {
-            var logger = new LoggerConfiguration()
-                .AuditTo.Sink(new DelegatingSink(e => { }))
-                .Filter.ByExcluding(e => { throw new Exception("Boom!"); })
-                .CreateLogger();
-
-            Assert.Throws<Exception>(() => logger.Write(Some.InformationEvent()));
-        }
-
-        [Fact]
-        public void ExceptionsThrownByAuditSinksArePropagatedFromChildLoggers()
-        {
-            var logger = new LoggerConfiguration()
-                .AuditTo.Sink(new DelegatingSink(e => { throw new Exception("Boom!"); }))
-                .CreateLogger();
-
-            Assert.Throws<AggregateException>(() => logger
-                .ForContext<LoggerConfigurationTests>()
-                .Write(Some.InformationEvent()));
-        }
-
         class Value { }
 
         [Fact]
@@ -602,17 +569,6 @@ namespace Serilog.Tests
             Assert.True(true, "No exception reached the caller");
         }
 
-        [Fact]
-        public void ExceptionsThrownByDestructuringPoliciesArePropagatedIfAuditingEnabled()
-        {
-            var logger = new LoggerConfiguration()
-                .AuditTo.Sink(new CollectingSink())
-                .Destructure.ByTransforming<Value>(v => { throw new Exception("Boom!"); })
-                .CreateLogger();
-
-            Assert.Throws<Exception>(() => logger.Information("{@Value}", new Value()));
-        }
-
         class ThrowingProperty
         {
             // ReSharper disable once UnusedMember.Local
@@ -620,28 +576,6 @@ namespace Serilog.Tests
             {
                 get { throw new Exception("Boom!"); }
             }
-        }
-
-        [Fact]
-        public void ExceptionsThrownByPropertyAccessorsAreNotPropagated()
-        {
-            var logger = new LoggerConfiguration()
-                .WriteTo.Sink(new CollectingSink())
-                .CreateLogger();
-
-            logger.Information("{@Value}", new ThrowingProperty());
-
-            Assert.True(true, "No exception reached the caller");
-        }
-
-        [Fact]
-        public void ExceptionsThrownByPropertyAccessorsArePropagatedIfAuditingEnabled()
-        {
-            var logger = new LoggerConfiguration()
-                .AuditTo.Sink(new CollectingSink())
-                .CreateLogger();
-
-            Assert.Throws<TargetInvocationException>(() => logger.Information("{@Value}", new ThrowingProperty()));
         }
     }
 }


### PR DESCRIPTION
Also added test to cover this and moved audit sink related tests to a separate collection.