### PR TITLE
Include AssemblyInformationalVersion attribute to the with commit hash

### DIFF
--- a/Build.ps1
+++ b/Build.ps1
@@ -15,7 +15,8 @@ $suffix = @{ $true = ""; $false = "$($branch.Substring(0, [math]::Min(10,$branch
 $commitHash = $(git rev-parse --short HEAD)
 $buildSuffix = @{ $true = "$($suffix)-$($commitHash)"; $false = "$($branch)-$($commitHash)" }[$suffix -ne ""]
 
-echo "build: Version suffix is $suffix"
+echo "build: Package version suffix is $suffix"
+echo "build: Build version suffix is $buildSuffix" 
 
 foreach ($src in ls src/*) {
     Push-Location $src

--- a/Build.ps1
+++ b/Build.ps1
@@ -12,6 +12,8 @@ if(Test-Path .\artifacts) {
 $branch = @{ $true = $env:APPVEYOR_REPO_BRANCH; $false = $(git symbolic-ref --short -q HEAD) }[$env:APPVEYOR_REPO_BRANCH -ne $NULL];
 $revision = @{ $true = "{0:00000}" -f [convert]::ToInt32("0" + $env:APPVEYOR_BUILD_NUMBER, 10); $false = "local" }[$env:APPVEYOR_BUILD_NUMBER -ne $NULL];
 $suffix = @{ $true = ""; $false = "$($branch.Substring(0, [math]::Min(10,$branch.Length)))-$revision"}[$branch -eq "master" -and $revision -ne "local"]
+$commitHash = $(git rev-parse --short HEAD)
+$buildSuffix = @{ $true = "$($suffix)-$($commitHash)"; $false = "$($branch)-$($commitHash)" }[$suffix -ne ""]
 
 echo "build: Version suffix is $suffix"
 
@@ -20,7 +22,8 @@ foreach ($src in ls src/*) {
 
 	echo "build: Packaging project in $src"
 
-    & dotnet pack -c Release -o ..\..\artifacts --version-suffix=$suffix
+    & dotnet build -c Release --version-suffix=$buildSuffix
+    & dotnet pack -c Release -o ..\..\artifacts --version-suffix=$suffix --no-build
     if($LASTEXITCODE -ne 0) { exit 1 }    
 
     Pop-Location


### PR DESCRIPTION
- fixes [#784](https://github.com/serilog/serilog/issues/784), related ES'[#49](https://github.com/serilog/serilog-sinks-elasticsearch/issues/49)

By default `--version-suffix` of `dotnet-pack` command flows to `--version-suffix` of `dotnet-build` command.

 To overcome this `pr`'s propose  is to use `--no-build` switch on `dotnet-pack` so `--version-suffix` of `dotnet-pack` will affect only package/nuspec version. And `--version-suffix` of `dotnet-build` will only affect desired `AssemblyInformationalVersion`. 

The result is that
- when building on `master`  `AssemblyInformationalVersion` will look like `2.4.0-master-g3ff4af` and nuspec version will be **2.4.0**
- when building on `dev` `AssemblyInformationalVersion` will look like `2.4.0-dev-000042-g3ff4af` and nuspec version will be **2.4.0-dev-000042**

(see `AppVeyor`'s [artifacts](https://ci.appveyor.com/project/serilog/serilog/build/764/artifacts))

Also tested on `msbuild`-alpha tools - works as expected so this should work on a long run..
