### PR TITLE
Refactor key-value settings to consistently apply configuration methods

### DIFF
--- a/src/Serilog/Settings/KeyValuePairs/CallableConfigurationMethodFinder.cs
+++ b/src/Serilog/Settings/KeyValuePairs/CallableConfigurationMethodFinder.cs
@@ -1,0 +1,52 @@
+﻿// Copyright 2013-2015 Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Serilog.Configuration;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+
+namespace Serilog.Settings.KeyValuePairs
+{
+    static class CallableConfigurationMethodFinder
+    {
+        internal static LoggerConfiguration FromLogContext(LoggerEnrichmentConfiguration loggerEnrichmentConfiguration)
+        {
+            return loggerEnrichmentConfiguration.FromLogContext();
+        }
+
+        static readonly MethodInfo SurrogateFromLogContextConfigurationMethod = typeof(CallableConfigurationMethodFinder).GetTypeInfo().DeclaredMethods.Single(m => m.Name == nameof(FromLogContext));
+
+        internal static IList<MethodInfo> FindConfigurationMethods(IEnumerable<Assembly> configurationAssemblies, Type configType)
+        {
+            var methods = configurationAssemblies
+                .SelectMany(a => a.ExportedTypes
+                    .Select(t => t.GetTypeInfo())
+                    .Where(t => t.IsSealed && t.IsAbstract && !t.IsNested))
+                .SelectMany(t => t.DeclaredMethods)
+                .Where(m => m.IsStatic && m.IsPublic && m.IsDefined(typeof(ExtensionAttribute), false))
+                .Where(m => m.GetParameters()[0].ParameterType == configType)
+                .ToList();
+
+            // Unlike the other configuration methods, FromLogContext is an instance method rather than an extension. This
+            // hack ensures we find it.
+            if (configType == typeof(LoggerEnrichmentConfiguration))
+                methods.Add(SurrogateFromLogContextConfigurationMethod);
+
+            return methods;
+        }
+    }
+}

--- a/src/Serilog/Settings/KeyValuePairs/KeyValuePairSettings.cs
+++ b/src/Serilog/Settings/KeyValuePairs/KeyValuePairSettings.cs
@@ -16,7 +16,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Text.RegularExpressions;
 using Serilog.Configuration;
 using Serilog.Events;
@@ -31,22 +30,39 @@ namespace Serilog.Settings.KeyValuePairs
         const string MinimumLevelDirective = "minimum-level";
         const string EnrichWithDirective = "enrich";
         const string EnrichWithPropertyDirective = "enrich:with-property";
+        const string FilterDirective = "filter";
 
         const string UsingDirectiveFullFormPrefix = "using:";
-        const string EnrichWithEventEnricherPrefix = "enrich:";
         const string EnrichWithPropertyDirectivePrefix = "enrich:with-property:";
         const string MinimumLevelOverrideDirectivePrefix = "minimum-level:override:";
 
-        const string AuditOrWriteToDirectiveRegex = @"^(?<directive>audit-to|write-to):(?<method>[A-Za-z0-9]*)(\.(?<argument>[A-Za-z0-9]*)){0,1}$";
+        const string CallableDirectiveRegex = @"^(?<directive>audit-to|write-to|enrich|filter):(?<method>[A-Za-z0-9]*)(\.(?<argument>[A-Za-z0-9]*)){0,1}$";
 
-        readonly string[] _supportedDirectives =
+        static readonly string[] _supportedDirectives =
         {
             UsingDirective,
             AuditToDirective,
             WriteToDirective,
             MinimumLevelDirective,
             EnrichWithPropertyDirective,
-            EnrichWithDirective
+            EnrichWithDirective,
+            FilterDirective
+        };
+
+        static readonly Dictionary<string, Type> CallableDirectiveReceiverTypes = new Dictionary<string, Type>
+        {
+            ["audit-to"] = typeof(LoggerAuditSinkConfiguration),
+            ["write-to"] = typeof(LoggerSinkConfiguration),
+            ["enrich"] = typeof(LoggerEnrichmentConfiguration),
+            ["filter"] = typeof(LoggerFilterConfiguration)
+        };
+
+        static readonly Dictionary<Type, Func<LoggerConfiguration, object>> CallableDirectiveReceivers = new Dictionary<Type, Func<LoggerConfiguration, object>>
+        {
+            [typeof(LoggerAuditSinkConfiguration)] = lc => lc.AuditTo,
+            [typeof(LoggerSinkConfiguration)] = lc => lc.WriteTo,
+            [typeof(LoggerEnrichmentConfiguration)] = lc => lc.Enrich,
+            [typeof(LoggerFilterConfiguration)] = lc => lc.Filter
         };
 
         readonly Dictionary<string, string> _settings;
@@ -90,65 +106,41 @@ namespace Serilog.Settings.KeyValuePairs
                 }
             }
 
-            var splitWriteTo = new Regex(AuditOrWriteToDirectiveRegex);
+            var matchCallables = new Regex(CallableDirectiveRegex);
 
-            var sinkDirectives = (from wt in directives
-                                  where splitWriteTo.IsMatch(wt.Key)
-                                  let match = splitWriteTo.Match(wt.Key)
-                                  select new
+            var callableDirectives = (from wt in directives
+                                      where matchCallables.IsMatch(wt.Key)
+                                      let match = matchCallables.Match(wt.Key)
+                                      select new
                                       {
-                                          Directive = match.Groups["directive"].Value,
-                                          Call = new MethodArgumentValue
+                                          ReceiverType = CallableDirectiveReceiverTypes[match.Groups["directive"].Value],
+                                          Call = new ConfigurationMethodCall
                                           {
-                                              Method = match.Groups["method"].Value,
-                                              Argument = match.Groups["argument"].Value,
+                                              MethodName = match.Groups["method"].Value,
+                                              ArgumentName = match.Groups["argument"].Value,
                                               Value = wt.Value
                                           }
-                                      }).ToList(); 
+                                      }).ToList();
 
-            var eventEnricherDirectives = (from er in directives
-                                           where er.Key.StartsWith(EnrichWithEventEnricherPrefix) && !er.Key.StartsWith(EnrichWithPropertyDirectivePrefix) && er.Key.Length > EnrichWithEventEnricherPrefix.Length
-                                           let match = er.Key.Substring(EnrichWithEventEnricherPrefix.Length)
-                                           let call = new MethodArgumentValue
-                                           {
-                                               Method = match
-                                           }
-                                           group call by call.Method).ToList();
-
-            if (sinkDirectives.Any() || eventEnricherDirectives.Any())
+            if (callableDirectives.Any())
             {
                 var configurationAssemblies = LoadConfigurationAssemblies(directives);
 
-                var writeToDirectives = sinkDirectives
-                    .Where(d => d.Directive == WriteToDirective)
-                    .Select(d => d.Call)
-                    .GroupBy(call => call.Method)
-                    .ToList();
-
-                if (writeToDirectives.Any())
+                foreach (var receiverGroup in callableDirectives.GroupBy(d => d.ReceiverType))
                 {
-                    ApplyDirectives(writeToDirectives, FindWriteToSinkConfigurationMethods(configurationAssemblies), loggerConfiguration.WriteTo);
-                }
+                    var methods = CallableConfigurationMethodFinder.FindConfigurationMethods(configurationAssemblies, receiverGroup.Key);
 
-                var auditToDirectives = sinkDirectives
-                    .Where(d => d.Directive == AuditToDirective)
-                    .Select(d => d.Call)
-                    .GroupBy(call => call.Method)
-                    .ToList();
+                    var calls = receiverGroup
+                        .Select(d => d.Call)
+                        .GroupBy(call => call.MethodName)
+                        .ToList();
 
-                if (auditToDirectives.Any())
-                {
-                    ApplyDirectives(auditToDirectives, FindAuditToSinkConfigurationMethods(configurationAssemblies), loggerConfiguration.AuditTo);
-                }
-
-                if (eventEnricherDirectives.Any())
-                {
-                    ApplyDirectives(eventEnricherDirectives, FindEventEnricherConfigurationMethods(configurationAssemblies), loggerConfiguration.Enrich);
+                    ApplyDirectives(calls, methods, CallableDirectiveReceivers[receiverGroup.Key](loggerConfiguration));
                 }
             }
         }
 
-        static void ApplyDirectives(List<IGrouping<string, MethodArgumentValue>> directives, IList<MethodInfo> configurationMethods, object loggerConfigMethod)
+        static void ApplyDirectives(List<IGrouping<string, ConfigurationMethodCall>> directives, IList<MethodInfo> configurationMethods, object loggerConfigMethod)
         {
             foreach (var directiveInfo in directives)
             {
@@ -158,8 +150,8 @@ namespace Serilog.Settings.KeyValuePairs
                 {
 
                     var call = (from p in target.GetParameters().Skip(1)
-                                let directive = directiveInfo.FirstOrDefault(s => s.Argument == p.Name)
-                                select directive == null ? p.DefaultValue : ConvertToType(directive.Value, p.ParameterType)).ToList();
+                                let directive = directiveInfo.FirstOrDefault(s => s.ArgumentName == p.Name)
+                                select directive == null ? p.DefaultValue : SettingValueConversions.ConvertToType(directive.Value, p.ParameterType)).ToList();
 
                     call.Insert(0, loggerConfigMethod);
 
@@ -168,12 +160,12 @@ namespace Serilog.Settings.KeyValuePairs
             }
         }
 
-        internal static MethodInfo SelectConfigurationMethod(IEnumerable<MethodInfo> candidateMethods, string name, IEnumerable<MethodArgumentValue> suppliedArgumentValues)
+        internal static MethodInfo SelectConfigurationMethod(IEnumerable<MethodInfo> candidateMethods, string name, IEnumerable<ConfigurationMethodCall> suppliedArgumentValues)
         {
             return candidateMethods
                 .Where(m => m.Name == name &&
-                            m.GetParameters().Skip(1).All(p => p.HasDefaultValue || suppliedArgumentValues.Any(s => s.Argument == p.Name)))
-                .OrderByDescending(m => m.GetParameters().Count(p => suppliedArgumentValues.Any(s => s.Argument == p.Name)))
+                            m.GetParameters().Skip(1).All(p => p.HasDefaultValue || suppliedArgumentValues.Any(s => s.ArgumentName == p.Name)))
+                .OrderByDescending(m => m.GetParameters().Count(p => suppliedArgumentValues.Any(s => s.ArgumentName == p.Name)))
                 .FirstOrDefault();
         }
 
@@ -193,102 +185,10 @@ namespace Serilog.Settings.KeyValuePairs
             return configurationAssemblies.Distinct();
         }
 
-        static Dictionary<Type, Func<string, object>> ExtendedTypeConversions = new Dictionary<Type, Func<string, object>>
-            {
-                { typeof(Uri), s => new Uri(s) },
-                { typeof(TimeSpan), s => TimeSpan.Parse(s) }
-            };
-
-        internal static object ConvertToType(string value, Type toType)
+        internal class ConfigurationMethodCall
         {
-            var toTypeInfo = toType.GetTypeInfo();
-            if (toTypeInfo.IsGenericType && toType.GetGenericTypeDefinition() == typeof(Nullable<>))
-            {
-                if (string.IsNullOrEmpty(value))
-                    return null;
-
-                // unwrap Nullable<> type since we're not handling null situations
-                toType = toTypeInfo.GenericTypeArguments[0];
-                toTypeInfo = toType.GetTypeInfo();
-            }
-
-            if (toTypeInfo.IsEnum)
-                return Enum.Parse(toType, value);
-
-            var convertor = ExtendedTypeConversions
-                .Where(t => t.Key.GetTypeInfo().IsAssignableFrom(toTypeInfo))
-                .Select(t => t.Value)
-                .FirstOrDefault();
-
-            if (convertor != null)
-                return convertor(value);
-
-            if (toTypeInfo.IsInterface && !string.IsNullOrWhiteSpace(value))
-            {
-                var type = Type.GetType(value.Trim(), throwOnError: false);
-                if (type != null)
-                {
-                    var ctor = type.GetTypeInfo().DeclaredConstructors.FirstOrDefault(ci =>
-                    {
-                        var parameters = ci.GetParameters();
-                        return parameters.Length == 0 || parameters.All(pi => pi.HasDefaultValue);
-                    });
-
-                    if (ctor == null)
-                        throw new InvalidOperationException($"A default constructor was not found on {type.FullName}.");
-
-                    var call = ctor.GetParameters().Select(pi => pi.DefaultValue).ToArray();
-                    return ctor.Invoke(call);
-                }
-            }
-
-            return Convert.ChangeType(value, toType);
-        }
-
-        internal static IList<MethodInfo> FindWriteToSinkConfigurationMethods(IEnumerable<Assembly> configurationAssemblies)
-        {
-            return FindConfigurationMethods(configurationAssemblies, typeof(LoggerSinkConfiguration));
-        }
-
-        internal static IList<MethodInfo> FindAuditToSinkConfigurationMethods(IEnumerable<Assembly> configurationAssemblies)
-        {
-            return FindConfigurationMethods(configurationAssemblies, typeof(LoggerAuditSinkConfiguration));
-        }
-
-        // Unlike the other configuration methods, FromLogContext is an instance method rather than an extension.
-
-        internal static LoggerConfiguration FromLogContext(LoggerEnrichmentConfiguration loggerEnrichmentConfiguration)
-        {
-            return loggerEnrichmentConfiguration.FromLogContext();
-        }
-
-        static readonly MethodInfo SurrogateFromLogContextConfigurationMethod = typeof(KeyValuePairSettings).GetTypeInfo().DeclaredMethods.Single(m => m.Name == "FromLogContext");
-
-        internal static IList<MethodInfo> FindEventEnricherConfigurationMethods(IEnumerable<Assembly> configurationAssemblies)
-        {
-            var found = FindConfigurationMethods(configurationAssemblies, typeof(LoggerEnrichmentConfiguration));
-            if (configurationAssemblies.Contains(typeof(LoggerEnrichmentConfiguration).GetTypeInfo().Assembly))
-                found.Add(SurrogateFromLogContextConfigurationMethod);
-
-            return found;
-        }
-
-        internal static IList<MethodInfo> FindConfigurationMethods(IEnumerable<Assembly> configurationAssemblies, Type configType)
-        {
-            return configurationAssemblies
-                .SelectMany(a => a.ExportedTypes
-                    .Select(t => t.GetTypeInfo())
-                    .Where(t => t.IsSealed && t.IsAbstract && !t.IsNested))
-                .SelectMany(t => t.DeclaredMethods)
-                .Where(m => m.IsStatic && m.IsPublic && m.IsDefined(typeof(ExtensionAttribute), false))
-                .Where(m => m.GetParameters()[0].ParameterType == configType)
-                .ToList();
-        }
-
-        internal class MethodArgumentValue
-        {
-            public string Method { get; set; }
-            public string Argument { get; set; }
+            public string MethodName { get; set; }
+            public string ArgumentName { get; set; }
             public string Value { get; set; }
         }
     }

--- a/src/Serilog/Settings/KeyValuePairs/SettingValueConversions.cs
+++ b/src/Serilog/Settings/KeyValuePairs/SettingValueConversions.cs
@@ -1,0 +1,76 @@
+﻿// Copyright 2013-2015 Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+namespace Serilog.Settings.KeyValuePairs
+{
+    class SettingValueConversions
+    {
+        static Dictionary<Type, Func<string, object>> ExtendedTypeConversions = new Dictionary<Type, Func<string, object>>
+            {
+                { typeof(Uri), s => new Uri(s) },
+                { typeof(TimeSpan), s => TimeSpan.Parse(s) }
+            };
+
+        public static object ConvertToType(string value, Type toType)
+        {
+            var toTypeInfo = toType.GetTypeInfo();
+            if (toTypeInfo.IsGenericType && toType.GetGenericTypeDefinition() == typeof(Nullable<>))
+            {
+                if (string.IsNullOrEmpty(value))
+                    return null;
+
+                // unwrap Nullable<> type since we're not handling null situations
+                toType = toTypeInfo.GenericTypeArguments[0];
+                toTypeInfo = toType.GetTypeInfo();
+            }
+
+            if (toTypeInfo.IsEnum)
+                return Enum.Parse(toType, value);
+
+            var convertor = ExtendedTypeConversions
+                .Where(t => t.Key.GetTypeInfo().IsAssignableFrom(toTypeInfo))
+                .Select(t => t.Value)
+                .FirstOrDefault();
+
+            if (convertor != null)
+                return convertor(value);
+
+            if (toTypeInfo.IsInterface && !string.IsNullOrWhiteSpace(value))
+            {
+                var type = Type.GetType(value.Trim(), throwOnError: false);
+                if (type != null)
+                {
+                    var ctor = type.GetTypeInfo().DeclaredConstructors.FirstOrDefault(ci =>
+                    {
+                        var parameters = ci.GetParameters();
+                        return parameters.Length == 0 || parameters.All(pi => pi.HasDefaultValue);
+                    });
+
+                    if (ctor == null)
+                        throw new InvalidOperationException($"A default constructor was not found on {type.FullName}.");
+
+                    var call = ctor.GetParameters().Select(pi => pi.DefaultValue).ToArray();
+                    return ctor.Invoke(call);
+                }
+            }
+
+            return Convert.ChangeType(value, toType);
+        }
+    }
+}

--- a/test/Serilog.Tests/Settings/CallableConfigurationMethodFinderTests.cs
+++ b/test/Serilog.Tests/Settings/CallableConfigurationMethodFinderTests.cs
@@ -1,0 +1,30 @@
+﻿using Serilog.Configuration;
+using Serilog.Settings.KeyValuePairs;
+using System.Linq;
+using System.Reflection;
+using TestDummies;
+using Xunit;
+
+namespace Serilog.Tests.Settings
+{
+    public class CallableConfigurationMethodFinderTests
+    {
+        [Fact]
+        public void FindsEnricherSpecificConfigurationMethods()
+        {
+            var eventEnrichers = CallableConfigurationMethodFinder
+                .FindConfigurationMethods(new[]
+                {
+                    typeof(Log).GetTypeInfo().Assembly,
+                    typeof(DummyThreadIdEnricher).GetTypeInfo().Assembly
+                }, typeof(LoggerEnrichmentConfiguration))
+                .Select(m => m.Name)
+                .Distinct()
+                .ToList();
+
+
+            Assert.True(eventEnrichers.Contains("FromLogContext"));
+            Assert.True(eventEnrichers.Contains("WithDummyThreadId"));
+        }
+    }
+}

--- a/test/Serilog.Tests/Settings/KeyValuePairSettingsTests.cs
+++ b/test/Serilog.Tests/Settings/KeyValuePairSettingsTests.cs
@@ -18,41 +18,6 @@ namespace Serilog.Tests.Settings
     public class KeyValuePairSettingsTests
     {
         [Fact]
-        public void ConvertibleValuesConvertToTIfTargetIsNullable()
-        {
-            var result = (int?)KeyValuePairSettings.ConvertToType("3", typeof(int?));
-            Assert.True(result == 3);
-        }
-
-        [Fact]
-        public void NullValuesConvertToNullIfTargetIsNullable()
-        {
-            var result = (int?)KeyValuePairSettings.ConvertToType(null, typeof(int?));
-            Assert.True(result == null);
-        }
-
-        [Fact]
-        public void EmptyStringValuesConvertToNullIfTargetIsNullable()
-        {
-            var result = (int?)KeyValuePairSettings.ConvertToType("", typeof(int?));
-            Assert.True(result == null);
-        }
-
-        [Fact]
-        public void ValuesConvertToNullableTimeSpan()
-        {
-            var result = (System.TimeSpan?)KeyValuePairSettings.ConvertToType("00:01:00", typeof(System.TimeSpan?));
-            Assert.Equal(System.TimeSpan.FromMinutes(1), result);
-        }
-
-        [Fact]
-        public void ValuesConvertToEnumMembers()
-        {
-            var result = (LogEventLevel)KeyValuePairSettings.ConvertToType("Information", typeof(LogEventLevel));
-            Assert.Equal(LogEventLevel.Information, result);
-        }
-
-        [Fact]
         public void FindsConfigurationAssemblies()
         {
             var configurationAssemblies = KeyValuePairSettings.LoadConfigurationAssemblies(new Dictionary<string, string>()).ToList();
@@ -60,24 +25,6 @@ namespace Serilog.Tests.Settings
             // The core Serilog assembly is always considered
             Assert.Equal(1, configurationAssemblies.Count);
         } 
-
-        [Fact]
-        public void FindsEventEnrichersWithinAnAssembly()
-        {
-            var eventEnrichers = KeyValuePairSettings
-                .FindEventEnricherConfigurationMethods(new[]
-                {
-                    typeof(Log).GetTypeInfo().Assembly,
-                    typeof(DummyThreadIdEnricher).GetTypeInfo().Assembly
-                })
-                .Select(m => m.Name)
-                .Distinct()
-                .ToList();
-
-            
-            Assert.True(eventEnrichers.Contains("FromLogContext"));
-            Assert.True(eventEnrichers.Contains("WithDummyThreadId"));
-        }
 
         [Fact]
         public void PropertyEnrichmentIsApplied()
@@ -97,14 +44,6 @@ namespace Serilog.Tests.Settings
             Assert.Equal("Test", evt.Properties["App"].LiteralValue());
         }
 
-
-        [Fact]
-        public void StringValuesConvertToDefaultInstancesIfTargetIsInterface()
-        {
-            var result = (object)KeyValuePairSettings.ConvertToType("Serilog.Formatting.Json.JsonFormatter", typeof(ITextFormatter));
-            Assert.IsType<JsonFormatter>(result);
-        }
-
         [Fact]
         public void CallableMethodsAreSelected()
         {
@@ -112,7 +51,7 @@ namespace Serilog.Tests.Settings
             Assert.Equal(2, options.Count(mi => mi.Name == "DummyRollingFile"));
             var suppliedArguments = new[]
             {
-                new KeyValuePairSettings.MethodArgumentValue { Method = "DummyRollingFile", Argument = "pathFormat", Value = "C:\\" },
+                new KeyValuePairSettings.ConfigurationMethodCall { MethodName = "DummyRollingFile", ArgumentName = "pathFormat", Value = "C:\\" },
             };
 
             var selected = KeyValuePairSettings.SelectConfigurationMethod(options, "DummyRollingFile", suppliedArguments);
@@ -126,8 +65,8 @@ namespace Serilog.Tests.Settings
             Assert.Equal(2, options.Count(mi => mi.Name == "DummyRollingFile"));
             var suppliedArguments = new[]
             {
-                new KeyValuePairSettings.MethodArgumentValue { Method = "DummyRollingFile", Argument = "pathFormat", Value = "C:\\" },
-                new KeyValuePairSettings.MethodArgumentValue { Method = "DummyRollingFile", Argument = "formatter", Value = "SomeFormatter, SomeAssembly" }
+                new KeyValuePairSettings.ConfigurationMethodCall { MethodName = "DummyRollingFile", ArgumentName = "pathFormat", Value = "C:\\" },
+                new KeyValuePairSettings.ConfigurationMethodCall { MethodName = "DummyRollingFile", ArgumentName = "formatter", Value = "SomeFormatter, SomeAssembly" }
             };
 
             var selected = KeyValuePairSettings.SelectConfigurationMethod(options, "DummyRollingFile", suppliedArguments);

--- a/test/Serilog.Tests/Settings/SettingValueConversionsTests.cs
+++ b/test/Serilog.Tests/Settings/SettingValueConversionsTests.cs
@@ -1,0 +1,53 @@
+﻿using Serilog.Events;
+using Serilog.Formatting;
+using Serilog.Formatting.Json;
+using Serilog.Settings.KeyValuePairs;
+using Xunit;
+
+namespace Serilog.Tests.Settings
+{
+    public class SettingValueConversionsTests
+    {
+        [Fact]
+        public void ConvertibleValuesConvertToTIfTargetIsNullable()
+        {
+            var result = (int?)SettingValueConversions.ConvertToType("3", typeof(int?));
+            Assert.True(result == 3);
+        }
+
+        [Fact]
+        public void NullValuesConvertToNullIfTargetIsNullable()
+        {
+            var result = (int?)SettingValueConversions.ConvertToType(null, typeof(int?));
+            Assert.True(result == null);
+        }
+
+        [Fact]
+        public void EmptyStringValuesConvertToNullIfTargetIsNullable()
+        {
+            var result = (int?)SettingValueConversions.ConvertToType("", typeof(int?));
+            Assert.True(result == null);
+        }
+
+        [Fact]
+        public void ValuesConvertToNullableTimeSpan()
+        {
+            var result = (System.TimeSpan?)SettingValueConversions.ConvertToType("00:01:00", typeof(System.TimeSpan?));
+            Assert.Equal(System.TimeSpan.FromMinutes(1), result);
+        }
+
+        [Fact]
+        public void ValuesConvertToEnumMembers()
+        {
+            var result = (LogEventLevel)SettingValueConversions.ConvertToType("Information", typeof(LogEventLevel));
+            Assert.Equal(LogEventLevel.Information, result);
+        }
+
+        [Fact]
+        public void StringValuesConvertToDefaultInstancesIfTargetIsInterface()
+        {
+            var result = (object)SettingValueConversions.ConvertToType("Serilog.Formatting.Json.JsonFormatter", typeof(ITextFormatter));
+            Assert.IsType<JsonFormatter>(result);
+        }
+    }
+}


### PR DESCRIPTION
Enables `serilog:filter:Xyz` configuration directives. Cleaned up the code as much as possible in the process, so that `audit-to`, `write-to`, `enrich` and `filter` are consistently handled. Still some cleanup possible, but we're in better shape now :-)

Would support #924.