### PR TITLE
Enable builds for OSX on Travis #824

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,45 +1,14 @@
 language: csharp
 
-#dotnet cli require Ubuntu 14.04
-sudo: required
-dist: trusty
-
-#dotnet cli require OSX 10.10
-osx_image: xcode7.1
-
-addons:
-  apt:
-    packages:
-    - gettext
-    - libcurl4-openssl-dev
-    - libicu-dev
-    - libssl-dev
-    - libunwind8
-    - zlib1g
-
-os:
-  - linux
-
-env:
-  matrix: 
-    - CLI_VERSION=1.0.0-preview2-003121
-    - CLI_VERSION=Latest
-
 matrix:
-  allow_failures:
-    - env: CLI_VERSION=Latest
-
-before_install:
-  - if test "$TRAVIS_OS_NAME" == "osx"; then brew update; brew install openssl; brew link --force openssl; fi
-  # Download script to install dotnet cli
-  - if test "$CLI_OBTAIN_URL" == ""; then export CLI_OBTAIN_URL="https://raw.githubusercontent.com/dotnet/cli/rel/1.0.0-preview2/scripts/obtain/dotnet-install.sh"; fi
-  - curl -L --create-dirs $CLI_OBTAIN_URL -o ./scripts/obtain/install.sh
-  - find ./scripts -name "*.sh" -exec chmod +x {} \;
-  - export DOTNET_INSTALL_DIR="$PWD/.dotnetcli"
-  # use bash to workaround bug https://github.com/dotnet/cli/issues/1725
-  - sudo bash ./scripts/obtain/install.sh --channel "preview" --version "$CLI_VERSION" --install-dir "$DOTNET_INSTALL_DIR" --no-path
-  # add dotnet to PATH
-  - export PATH="$DOTNET_INSTALL_DIR:$PATH"
+  include:
+    - os: linux # Ubuntu 14.04
+      dist: trusty
+      sudo: required
+      dotnet: 1.0.0-preview2-003121
+    - os: osx # OSX 10.11
+      osx_image: xcode7.2
+      dotnet: 1.0.0-preview2-003121
 
 script:
   - ./build.sh


### PR DESCRIPTION
Entire rework of Travis builds for #824.

* Changed to use Travis OSX example from dotnet/docs. See  [details](https://github.com/dotnet/docs/blob/master/.travis.yml) here.

Alternative is to slightly update previous build config as seen [here](https://github.com/merbla/serilog/blob/enable-osx-for-travis/.travis.yml).
