### PR TITLE
Use dotnet core sdk 1.0.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,13 +5,11 @@ matrix:
     - os: linux # Ubuntu 14.04
       dist: trusty
       sudo: required
-      dotnet: 1.0.0-preview2-003121
-      CLI_VERSION: 1.0.0
+      dotnet: 1.0.1
     # Disabled temporarily due to Travis OSX issues
     # - os: osx # OSX 10.11
     #   osx_image: xcode7.3
-    #   dotnet: 1.0.0-preview2-003121
-    #   CLI_VERSION: 1.0.0
+    #   dotnet: 1.0.1
 
 script:
   - ./build.sh

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,7 @@ install:
   - ps: mkdir -Force ".\build\" | Out-Null
   - ps: Invoke-WebRequest "https://raw.githubusercontent.com/dotnet/cli/rel/1.0.0/scripts/obtain/dotnet-install.ps1" -OutFile ".\build\installcli.ps1"
   - ps: $env:DOTNET_INSTALL_DIR = "$pwd\.dotnetcli"
-  - ps: '& .\build\installcli.ps1 -InstallDir "$env:DOTNET_INSTALL_DIR" -NoPath -Version 1.0.0'
+  - ps: '& .\build\installcli.ps1 -InstallDir "$env:DOTNET_INSTALL_DIR" -NoPath -Version 1.0.1'
   - ps: $env:Path = "$env:DOTNET_INSTALL_DIR;$env:Path"
 test: off
 build_script:

--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 export DOTNET_INSTALL_DIR="$PWD/.dotnetcli"
-DotnetCliVersion=${CLI_VERSION:="1.0.0"}
+DotnetCliVersion=${CLI_VERSION:="1.0.1"}
 install_script_url=https://raw.githubusercontent.com/dotnet/cli/rel/1.0.0/scripts/obtain/dotnet-install.sh
 curl -sSL $install_script_url | bash /dev/stdin --version "$DotnetCliVersion" --install-dir "$DOTNET_INSTALL_DIR"
 export PATH="$DOTNET_INSTALL_DIR:$PATH"

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "projects": [ "src", "test" ],
   "sdk": {
-    "version": "1.0.0"
+    "version": "1.0.1"
   }
 }


### PR DESCRIPTION
According to this link https://github.com/dotnet/cli/releases/latest, the current version is 1.0.1
![image](https://cloud.githubusercontent.com/assets/570470/23769905/b0a0204e-055c-11e7-94af-f396bd632b33.png)

If I do `File->New->Project(.NET Core: Console App)` then put `dotnet --version` in the pre-build event, I see `1.0.1`

![image](https://cloud.githubusercontent.com/assets/570470/23769993/010d0e70-055d-11e7-8bb7-a42d35426061.png)

