### PR TITLE
Sink wrapping

### DIFF
--- a/src/Serilog/Configuration/LoggerSinkConfiguration.cs
+++ b/src/Serilog/Configuration/LoggerSinkConfiguration.cs
@@ -150,6 +150,21 @@ namespace Serilog.Configuration
         {
             if (logger == null) throw new ArgumentNullException(nameof(logger));
             return Sink(new SecondaryLoggerSink(logger, attemptDispose: false), restrictedToMinimumLevel);
-        } 
+        }
+
+        public static LoggerConfiguration Wrap(
+            LoggerSinkConfiguration parentSinkConfiguration,
+            Func<ILogEventSink, ILogEventSink> addSink,
+            Action<LoggerSinkConfiguration> sinkConfigAction)
+        {
+            var sinkConfiguration = new LoggerSinkConfiguration(
+                parentSinkConfiguration._loggerConfiguration,
+                s => parentSinkConfiguration.Sink(addSink(s)),
+                parentSinkConfiguration._applyInheritedConfiguration);
+
+            sinkConfigAction(sinkConfiguration);
+
+            return parentSinkConfiguration._loggerConfiguration;
+        }
     }
 }

--- a/src/Serilog/Configuration/LoggerSinkConfiguration.cs
+++ b/src/Serilog/Configuration/LoggerSinkConfiguration.cs
@@ -152,19 +152,27 @@ namespace Serilog.Configuration
             return Sink(new SecondaryLoggerSink(logger, attemptDispose: false), restrictedToMinimumLevel);
         }
 
+        /// <summary>
+        /// Helper method for wrapping sinks.
+        /// </summary>
+        /// <param name="logggerSinkConfiguration">The parent sink configuration.</param>
+        /// <param name="sinkDecorator">A function that allows for wrapping <see cref="ILogEventSink"/>s
+        /// added in <paramref name="sinkConfigurationAction"/></param>
+        /// <param name="sinkConfigurationAction">An action that configures sinks to be wrapped in <paramref name="sinkDecorator"/></param>
+        /// <returns>Configuration object allowing method chaining.</returns>
         public static LoggerConfiguration Wrap(
-            LoggerSinkConfiguration parentSinkConfiguration,
-            Func<ILogEventSink, ILogEventSink> addSink,
-            Action<LoggerSinkConfiguration> sinkConfigAction)
+            LoggerSinkConfiguration logggerSinkConfiguration,
+            Func<ILogEventSink, ILogEventSink> sinkDecorator,
+            Action<LoggerSinkConfiguration> sinkConfigurationAction)
         {
-            var sinkConfiguration = new LoggerSinkConfiguration(
-                parentSinkConfiguration._loggerConfiguration,
-                s => parentSinkConfiguration.Sink(addSink(s)),
-                parentSinkConfiguration._applyInheritedConfiguration);
+            var capturingLoggerSinkConfiguration = new LoggerSinkConfiguration(
+                logggerSinkConfiguration._loggerConfiguration,
+                s => logggerSinkConfiguration.Sink(sinkDecorator(s)),
+                logggerSinkConfiguration._applyInheritedConfiguration);
 
-            sinkConfigAction(sinkConfiguration);
+            sinkConfigurationAction(capturingLoggerSinkConfiguration);
 
-            return parentSinkConfiguration._loggerConfiguration;
+            return logggerSinkConfiguration._loggerConfiguration;
         }
     }
 }

--- a/src/Serilog/Configuration/LoggerSinkConfiguration.cs
+++ b/src/Serilog/Configuration/LoggerSinkConfiguration.cs
@@ -155,24 +155,28 @@ namespace Serilog.Configuration
         /// <summary>
         /// Helper method for wrapping sinks.
         /// </summary>
-        /// <param name="logggerSinkConfiguration">The parent sink configuration.</param>
-        /// <param name="sinkDecorator">A function that allows for wrapping <see cref="ILogEventSink"/>s
-        /// added in <paramref name="sinkConfigurationAction"/></param>
-        /// <param name="sinkConfigurationAction">An action that configures sinks to be wrapped in <paramref name="sinkDecorator"/></param>
+        /// <param name="loggerSinkConfiguration">The parent sink configuration.</param>
+        /// <param name="wrapSink">A function that allows for wrapping <see cref="ILogEventSink"/>s
+        /// added in <paramref name="configureWrappedSink"/>.</param>
+        /// <param name="configureWrappedSink">An action that configures sinks to be wrapped in <paramref name="wrapSink"/>.</param>
         /// <returns>Configuration object allowing method chaining.</returns>
         public static LoggerConfiguration Wrap(
-            LoggerSinkConfiguration logggerSinkConfiguration,
-            Func<ILogEventSink, ILogEventSink> sinkDecorator,
-            Action<LoggerSinkConfiguration> sinkConfigurationAction)
+            LoggerSinkConfiguration loggerSinkConfiguration,
+            Func<ILogEventSink, ILogEventSink> wrapSink,
+            Action<LoggerSinkConfiguration> configureWrappedSink)
         {
+            if (loggerSinkConfiguration == null) throw new ArgumentNullException(nameof(loggerSinkConfiguration));
+            if (wrapSink == null) throw new ArgumentNullException(nameof(wrapSink));
+            if (configureWrappedSink == null) throw new ArgumentNullException(nameof(configureWrappedSink));
+
             var capturingLoggerSinkConfiguration = new LoggerSinkConfiguration(
-                logggerSinkConfiguration._loggerConfiguration,
-                s => logggerSinkConfiguration.Sink(sinkDecorator(s)),
-                logggerSinkConfiguration._applyInheritedConfiguration);
+                loggerSinkConfiguration._loggerConfiguration,
+                s => loggerSinkConfiguration.Sink(wrapSink(s)),
+                loggerSinkConfiguration._applyInheritedConfiguration);
 
-            sinkConfigurationAction(capturingLoggerSinkConfiguration);
+            configureWrappedSink(capturingLoggerSinkConfiguration);
 
-            return logggerSinkConfiguration._loggerConfiguration;
+            return loggerSinkConfiguration._loggerConfiguration;
         }
     }
 }

--- a/test/Serilog.Tests/LoggerConfigurationTests.cs
+++ b/test/Serilog.Tests/LoggerConfigurationTests.cs
@@ -8,6 +8,7 @@ using Xunit;
 using Serilog.Configuration;
 using Serilog.Core;
 using Serilog.Core.Filters;
+using Serilog.Debugging;
 using Serilog.Events;
 using Serilog.Tests.Support;
 using TestDummies;
@@ -591,6 +592,20 @@ namespace Serilog.Tests
 
             Assert.NotEmpty(DummyWrappingSink.Emitted);
             Assert.NotEmpty(sink.Events);
+        }
+
+        [Fact]
+        public void WrappingWarnsAboutNonDisposableWrapper()
+        {
+            var messages = new List<string>();
+            SelfLog.Enable(s => messages.Add(s));
+
+            new LoggerConfiguration()
+                .WriteTo.Dummy(w => w.Sink<DisposeTrackingSink>())
+                .CreateLogger();
+
+            SelfLog.Disable();
+            Assert.NotEmpty(messages);
         }
     }
 }

--- a/test/Serilog.Tests/LoggerConfigurationTests.cs
+++ b/test/Serilog.Tests/LoggerConfigurationTests.cs
@@ -580,11 +580,11 @@ namespace Serilog.Tests
         }
 
         [Fact]
-        public void WrappedSinks()
+        public void WrappingDecoratesTheConfiguredSink()
         {
             var sink = new CollectingSink();
             var logger = new LoggerConfiguration()
-                .WriteTo.DummyWrapping(w => w.Sink(sink))
+                .WriteTo.Dummy(w => w.Sink(sink))
                 .CreateLogger();
 
             logger.Write(Some.InformationEvent());

--- a/test/Serilog.Tests/LoggerConfigurationTests.cs
+++ b/test/Serilog.Tests/LoggerConfigurationTests.cs
@@ -10,6 +10,7 @@ using Serilog.Core;
 using Serilog.Core.Filters;
 using Serilog.Events;
 using Serilog.Tests.Support;
+using TestDummies;
 
 namespace Serilog.Tests
 {
@@ -576,6 +577,20 @@ namespace Serilog.Tests
             {
                 get { throw new Exception("Boom!"); }
             }
+        }
+
+        [Fact]
+        public void WrappedSinks()
+        {
+            var sink = new CollectingSink();
+            var logger = new LoggerConfiguration()
+                .WriteTo.DummyWrapping(w => w.Sink(sink))
+                .CreateLogger();
+
+            logger.Write(Some.InformationEvent());
+
+            Assert.NotEmpty(DummyWrappingSink.Emitted);
+            Assert.NotEmpty(sink.Events);
         }
     }
 }

--- a/test/TestDummies/DummyLoggerConfigurationExtensions.cs
+++ b/test/TestDummies/DummyLoggerConfigurationExtensions.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using Serilog;
 using Serilog.Events;
 using Serilog.Formatting;
@@ -41,6 +40,16 @@ namespace TestDummies
             IFormatProvider formatProvider = null)
         {
             return loggerSinkConfiguration.Sink(new DummyRollingFileAuditSink(), restrictedToMinimumLevel);
+        }
+
+        public static LoggerConfiguration DummyWrapping(
+            this LoggerSinkConfiguration loggerSinkConfiguration,
+            Action<LoggerSinkConfiguration> wrappedSinkAction)
+        {
+            return LoggerSinkConfiguration.Wrap(
+                loggerSinkConfiguration,
+                s => new DummyWrappingSink(s),
+                wrappedSinkAction);
         }
     }
 }

--- a/test/TestDummies/DummyLoggerConfigurationExtensions.cs
+++ b/test/TestDummies/DummyLoggerConfigurationExtensions.cs
@@ -42,7 +42,7 @@ namespace TestDummies
             return loggerSinkConfiguration.Sink(new DummyRollingFileAuditSink(), restrictedToMinimumLevel);
         }
 
-        public static LoggerConfiguration DummyWrapping(
+        public static LoggerConfiguration Dummy(
             this LoggerSinkConfiguration loggerSinkConfiguration,
             Action<LoggerSinkConfiguration> wrappedSinkAction)
         {

--- a/test/TestDummies/DummyWrappingSink.cs
+++ b/test/TestDummies/DummyWrappingSink.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using Serilog.Core;
+using Serilog.Events;
+using System.Collections.Generic;
+
+namespace TestDummies
+{
+    public class DummyWrappingSink : ILogEventSink
+    {
+        [ThreadStatic]
+        public static List<LogEvent> Emitted = new List<LogEvent>();
+
+        private readonly ILogEventSink _sink;
+
+        public DummyWrappingSink(ILogEventSink sink)
+        {
+            _sink = sink;
+        }
+
+        public void Emit(LogEvent logEvent)
+        {
+            Emitted.Add(logEvent);
+            _sink.Emit(logEvent);
+        }
+    }
+}


### PR DESCRIPTION
In our use of Serilog we'd like to be able to easily wrap existing sinks while also maintaining use of built-in extension methods. For example, we can create a decorator sink that adds the ability to disable sink output during runtime, and can be added to any existing sink.

This PR currently is a first pass on the API for this, so we can discuss the best approach for adding this in. The initial approach adds a new method to LoggerSinkConfiguration which accepts a callback to creating the wrapping Sink.