### PR TITLE
VS2017 Appveyor image and 1.0.4 SDK for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ matrix:
     - os: linux # Ubuntu 14.04
       dist: trusty
       sudo: required
-      dotnet: 1.0.1
+      dotnet: 1.0.4
     # Disabled temporarily due to Travis OSX issues
     # - os: osx # OSX 10.11
     #   osx_image: xcode7.3

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,13 +1,7 @@
 version: '{build}'
 skip_tags: true
-image: Visual Studio 2015
+image: Visual Studio 2017
 configuration: Release
-install:
-  - ps: mkdir -Force ".\build\" | Out-Null
-  - ps: Invoke-WebRequest "https://raw.githubusercontent.com/dotnet/cli/rel/1.0.0/scripts/obtain/dotnet-install.ps1" -OutFile ".\build\installcli.ps1"
-  - ps: $env:DOTNET_INSTALL_DIR = "$pwd\.dotnetcli"
-  - ps: '& .\build\installcli.ps1 -InstallDir "$env:DOTNET_INSTALL_DIR" -NoPath -Version 1.0.1'
-  - ps: $env:Path = "$env:DOTNET_INSTALL_DIR;$env:Path"
 test: off
 build_script:
 - ps: ./Build.ps1


### PR DESCRIPTION
* Update version of SDK on Travis to `1.0.4`
* Update AppVeyor image to VS 2017.