### PR TITLE
LogContext Push() and Clone()

### DIFF
--- a/src/Serilog/Context/LogContext.cs
+++ b/src/Serilog/Context/LogContext.cs
@@ -80,12 +80,12 @@ namespace Serilog.Context
         }
 
         /// <summary>
-        /// Push an enricher onto context, returning an <see cref="IDisposable"/>
+        /// Push an enricher onto the context, returning an <see cref="IDisposable"/>
         /// that must later be used to remove the property, along with any others that
         /// may have been pushed on top of it and not yet popped. The property must
         /// be popped from the same thread/logical call context.
         /// </summary>
-        /// <param name="enricher">Log Properties to push onto the log context</param>
+        /// <param name="enricher">An enricher to push onto the log context</param>
         /// <returns>A token that must be disposed, in order, to pop properties back off the stack.</returns>
         /// <exception cref="ArgumentNullException"></exception>
         public static IDisposable Push(ILogEventEnricher enricher)
@@ -107,7 +107,7 @@ namespace Serilog.Context
         /// be popped from the same thread/logical call context.
         /// </summary>
         /// <seealso cref="PropertyEnricher"/>.
-        /// <param name="enrichers">Log Properties to push onto the log context</param>
+        /// <param name="enrichers">Enrichers to push onto the log context</param>
         /// <returns>A token that must be disposed, in order, to pop properties back off the stack.</returns>
         /// <exception cref="ArgumentNullException"></exception>
         public static IDisposable Push(params ILogEventEnricher[] enrichers)
@@ -129,7 +129,7 @@ namespace Serilog.Context
         /// Push enrichers onto the log context. This method is obsolete, please
         /// use <see cref="Push(Serilog.Core.ILogEventEnricher[])"/> instead.
         /// </summary>
-        /// <param name="properties">Log Properties to push onto the log context</param>
+        /// <param name="properties">Enrichers to push onto the log context</param>
         /// <returns>A token that must be disposed, in order, to pop properties back off the stack.</returns>
         /// <exception cref="ArgumentNullException"></exception>
         [Obsolete("Please use `LogContext.Push(properties)` instead.")]

--- a/src/Serilog/Context/LogContext.cs
+++ b/src/Serilog/Context/LogContext.cs
@@ -139,6 +139,17 @@ namespace Serilog.Context
             return Push(properties);
         }
 
+        /// <summary>
+        /// Obtain an enricher that represents the current contents of the <see cref="LogContext"/>. This
+        /// can be pushed back onto the context in a different location/thread when required.
+        /// </summary>
+        /// <returns>An enricher that represents the current contents of the <see cref="LogContext"/>.</returns>
+        public static ILogEventEnricher Clone()
+        {
+            var stack = GetOrCreateEnricherStack();
+            return new SafeAggregateEnricher(stack);
+        }
+
         static ImmutableStack<ILogEventEnricher> GetOrCreateEnricherStack()
         {
             var enrichers = Enrichers;
@@ -181,14 +192,8 @@ namespace Serilog.Context
 
         static ImmutableStack<ILogEventEnricher> Enrichers
         {
-            get
-            {
-                return Data.Value;
-            }
-            set
-            {
-                Data.Value = value;
-            }
+            get => Data.Value;
+            set => Data.Value = value;
         }
 
 #elif REMOTING
@@ -211,14 +216,8 @@ namespace Serilog.Context
 
         static ImmutableStack<ILogEventEnricher> Enrichers
         {
-            get
-            {
-                return Data;
-            }
-            set
-            {
-                Data = value;
-            }
+            get => Data;
+            set => Data = value;
         }
 #endif
     }

--- a/src/Serilog/Core/Enrichers/FixedPropertyEnricher.cs
+++ b/src/Serilog/Core/Enrichers/FixedPropertyEnricher.cs
@@ -23,8 +23,7 @@ namespace Serilog.Core.Enrichers
 
         public FixedPropertyEnricher(LogEventProperty logEventProperty)
         {
-            if (logEventProperty == null) throw new ArgumentNullException(nameof(logEventProperty));
-            _logEventProperty = logEventProperty;
+            _logEventProperty = logEventProperty ?? throw new ArgumentNullException(nameof(logEventProperty));
         }
 
         public void Enrich(LogEvent logEvent, ILogEventPropertyFactory propertyFactory)

--- a/test/Serilog.Tests/Serilog.Tests.csproj
+++ b/test/Serilog.Tests/Serilog.Tests.csproj
@@ -29,7 +29,7 @@
     <DefineConstants>$(DefineConstants);APPDOMAIN;REMOTING;GETCURRENTMETHOD</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net46' ">
-    <DefineConstants>$(DefineConstants);ASYNCLOCAL</DefineConstants>
+    <DefineConstants>$(DefineConstants);ASYNCLOCAL;GETCURRENTMETHOD</DefineConstants>
   </PropertyGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
     <Reference Include="System" />


### PR DESCRIPTION
This implements the suggestions in #733.

 * `Push()` is just a naming fix - `PushProperties()` actually pushes a collection of enrichers
 * `Clone()` lets worker threads opt-in to inheriting the parent's context stack
