### PR TITLE
ValueTuple to sequence value conversion

### DIFF
--- a/src/Serilog/Parameters/PropertyValueConverter.cs
+++ b/src/Serilog/Parameters/PropertyValueConverter.cs
@@ -233,10 +233,20 @@ namespace Serilog.Parameters
             }
 
             var definition = valueType.GetGenericTypeDefinition();
+
+            // Ignore the 8+ value case for now.
+#if VALUETUPLE
             if (definition == typeof(ValueTuple<>) || definition == typeof(ValueTuple<,>) ||
                 definition == typeof(ValueTuple<,,>) || definition == typeof(ValueTuple<,,,>) ||
                 definition == typeof(ValueTuple<,,,,>) || definition == typeof(ValueTuple<,,,,,>) ||
-                definition == typeof(ValueTuple<,,,,,,>)) // Ignore the 8+ value case for now.
+                definition == typeof(ValueTuple<,,,,,,>))
+#else
+            var defn = definition.FullName;
+            if (defn == "System.ValueTuple`1" || defn == "System.ValueTuple`2" ||
+                defn == "System.ValueTuple`3" || defn == "System.ValueTuple`4" ||
+                defn == "System.ValueTuple`5" || defn == "System.ValueTuple`6" ||
+                defn == "System.ValueTuple`7")
+#endif
             {
                 var elements = new List<LogEventPropertyValue>();
                 foreach (var field in valueType.GetTypeInfo().DeclaredFields)

--- a/src/Serilog/Parameters/PropertyValueConverter.cs
+++ b/src/Serilog/Parameters/PropertyValueConverter.cs
@@ -202,21 +202,22 @@ namespace Serilog.Parameters
                     var keyProperty = typeInfo.GetDeclaredProperty("Key");
                     var valueProperty = typeInfo.GetDeclaredProperty("Value");
 
-                    {
-                        result = new DictionaryValue(enumerable.Cast<object>().Take(_maximumCollectionCount)
-                            .Select(kvp => new KeyValuePair<ScalarValue, LogEventPropertyValue>(
-                                (ScalarValue) limiter.CreatePropertyValue(keyProperty.GetValue(kvp), destructuring),
-                                limiter.CreatePropertyValue(valueProperty.GetValue(kvp), destructuring)))
-                            .Where(kvp => kvp.Key.Value != null));
-                        return true;
-                    }
-                }
-
-                {
-                    result = new SequenceValue(
-                        enumerable.Cast<object>().Take(_maximumCollectionCount).Select(o => limiter.CreatePropertyValue(o, destructuring)));
+                    result = new DictionaryValue(enumerable
+                        .Cast<object>()
+                        .Take(_maximumCollectionCount)
+                        .Select(kvp => new KeyValuePair<ScalarValue, LogEventPropertyValue>(
+                            (ScalarValue) limiter.CreatePropertyValue(keyProperty.GetValue(kvp), destructuring),
+                            limiter.CreatePropertyValue(valueProperty.GetValue(kvp), destructuring)))
+                        .Where(kvp => kvp.Key.Value != null));
                     return true;
                 }
+
+                result = new SequenceValue(enumerable
+                    .Cast<object>()
+                    .Take(_maximumCollectionCount)
+                    .Select(o => limiter.CreatePropertyValue(o, destructuring)));
+
+                return true;
             }
 
             result = null;
@@ -248,10 +249,8 @@ namespace Serilog.Parameters
                     }
                 }
 
-                {
-                    result = new SequenceValue(elements);
-                    return true;
-                }
+                result = new SequenceValue(elements);
+                return true;
             }
 
             result = null;

--- a/src/Serilog/Serilog.csproj
+++ b/src/Serilog/Serilog.csproj
@@ -23,44 +23,40 @@
   <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
-    <PackageReference Include="System.ValueTuple" Version="4.3.1" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
-    <PackageReference Include="System.ValueTuple" Version="4.3.1" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.0' ">
-    <PackageReference Include="Microsoft.CSharp" Version="4.3.0" />
-    <PackageReference Include="System.Collections" Version="4.3.0" />
-    <PackageReference Include="System.Dynamic.Runtime" Version="4.3.0" />
-    <PackageReference Include="System.Globalization" Version="4.3.0" />
-    <PackageReference Include="System.Linq" Version="4.3.0" />
-    <PackageReference Include="System.Reflection" Version="4.3.0" />
-    <PackageReference Include="System.Reflection.Extensions" Version="4.3.0" />
-    <PackageReference Include="System.Runtime" Version="4.3.0" />
-    <PackageReference Include="System.Runtime.Extensions" Version="4.3.0" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.0" />
-    <PackageReference Include="System.Threading" Version="4.3.0" />
-    <PackageReference Include="System.ValueTuple" Version="4.3.1" />
+    <PackageReference Include="Microsoft.CSharp" Version="4.0.1" />
+    <PackageReference Include="System.Collections" Version="4.0.11" />
+    <PackageReference Include="System.Dynamic.Runtime" Version="4.0.11" />
+    <PackageReference Include="System.Globalization" Version="4.0.11" />
+    <PackageReference Include="System.Linq" Version="4.1.0" />
+    <PackageReference Include="System.Reflection" Version="4.1.0" />
+    <PackageReference Include="System.Reflection.Extensions" Version="4.0.1" />
+    <PackageReference Include="System.Runtime" Version="4.1.0" />
+    <PackageReference Include="System.Runtime.Extensions" Version="4.1.0" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.1.0" />
+    <PackageReference Include="System.Threading" Version="4.0.11" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
-    <PackageReference Include="System.Collections.NonGeneric" Version="4.3.0" />
-    <PackageReference Include="Microsoft.CSharp" Version="4.3.0" />
-    <PackageReference Include="System.Collections" Version="4.3.0" />
-    <PackageReference Include="System.Dynamic.Runtime" Version="4.3.0" />
-    <PackageReference Include="System.Globalization" Version="4.3.0" />
-    <PackageReference Include="System.Linq" Version="4.3.0" />
-    <PackageReference Include="System.Reflection" Version="4.3.0" />
-    <PackageReference Include="System.Reflection.Extensions" Version="4.3.0" />
-    <PackageReference Include="System.Runtime" Version="4.3.0" />
-    <PackageReference Include="System.Runtime.Extensions" Version="4.3.0" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.0" />
-    <PackageReference Include="System.Threading" Version="4.3.0" />
-    <PackageReference Include="System.ValueTuple" Version="4.3.1" />
+    <PackageReference Include="System.Collections.NonGeneric" Version="4.0.1" />
+    <PackageReference Include="Microsoft.CSharp" Version="4.0.1" />
+    <PackageReference Include="System.Collections" Version="4.0.11" />
+    <PackageReference Include="System.Dynamic.Runtime" Version="4.0.11" />
+    <PackageReference Include="System.Globalization" Version="4.0.11" />
+    <PackageReference Include="System.Linq" Version="4.1.0" />
+    <PackageReference Include="System.Reflection" Version="4.1.0" />
+    <PackageReference Include="System.Reflection.Extensions" Version="4.0.1" />
+    <PackageReference Include="System.Runtime" Version="4.1.0" />
+    <PackageReference Include="System.Runtime.Extensions" Version="4.1.0" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.1.0" />
+    <PackageReference Include="System.Threading" Version="4.0.11" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net45' ">

--- a/src/Serilog/Serilog.csproj
+++ b/src/Serilog/Serilog.csproj
@@ -23,25 +23,44 @@
   <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
+    <PackageReference Include="System.ValueTuple" Version="4.3.1" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
+    <PackageReference Include="System.ValueTuple" Version="4.3.1" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.0' ">
-    <PackageReference Include="Microsoft.CSharp" Version="4.0.1" />
-    <PackageReference Include="System.Collections" Version="4.0.11" />
-    <PackageReference Include="System.Dynamic.Runtime" Version="4.0.11" />
-    <PackageReference Include="System.Globalization" Version="4.0.11" />
-    <PackageReference Include="System.Linq" Version="4.1.0" />
-    <PackageReference Include="System.Reflection" Version="4.1.0" />
-    <PackageReference Include="System.Reflection.Extensions" Version="4.0.1" />
-    <PackageReference Include="System.Runtime" Version="4.1.0" />
-    <PackageReference Include="System.Runtime.Extensions" Version="4.1.0" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="4.1.0" />
-    <PackageReference Include="System.Threading" Version="4.0.11" />
+    <PackageReference Include="Microsoft.CSharp" Version="4.3.0" />
+    <PackageReference Include="System.Collections" Version="4.3.0" />
+    <PackageReference Include="System.Dynamic.Runtime" Version="4.3.0" />
+    <PackageReference Include="System.Globalization" Version="4.3.0" />
+    <PackageReference Include="System.Linq" Version="4.3.0" />
+    <PackageReference Include="System.Reflection" Version="4.3.0" />
+    <PackageReference Include="System.Reflection.Extensions" Version="4.3.0" />
+    <PackageReference Include="System.Runtime" Version="4.3.0" />
+    <PackageReference Include="System.Runtime.Extensions" Version="4.3.0" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.0" />
+    <PackageReference Include="System.Threading" Version="4.3.0" />
+    <PackageReference Include="System.ValueTuple" Version="4.3.1" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
+    <PackageReference Include="System.Collections.NonGeneric" Version="4.3.0" />
+    <PackageReference Include="Microsoft.CSharp" Version="4.3.0" />
+    <PackageReference Include="System.Collections" Version="4.3.0" />
+    <PackageReference Include="System.Dynamic.Runtime" Version="4.3.0" />
+    <PackageReference Include="System.Globalization" Version="4.3.0" />
+    <PackageReference Include="System.Linq" Version="4.3.0" />
+    <PackageReference Include="System.Reflection" Version="4.3.0" />
+    <PackageReference Include="System.Reflection.Extensions" Version="4.3.0" />
+    <PackageReference Include="System.Runtime" Version="4.3.0" />
+    <PackageReference Include="System.Runtime.Extensions" Version="4.3.0" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.0" />
+    <PackageReference Include="System.Threading" Version="4.3.0" />
+    <PackageReference Include="System.ValueTuple" Version="4.3.1" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net45' ">
@@ -55,20 +74,5 @@
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
     <DefineConstants>$(DefineConstants);ASYNCLOCAL;HASHTABLE</DefineConstants>
   </PropertyGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
-    <PackageReference Include="System.Collections.NonGeneric" Version="4.0.1" />
-    <PackageReference Include="Microsoft.CSharp" Version="4.0.1" />
-    <PackageReference Include="System.Collections" Version="4.0.11" />
-    <PackageReference Include="System.Dynamic.Runtime" Version="4.0.11" />
-    <PackageReference Include="System.Globalization" Version="4.0.11" />
-    <PackageReference Include="System.Linq" Version="4.1.0" />
-    <PackageReference Include="System.Reflection" Version="4.1.0" />
-    <PackageReference Include="System.Reflection.Extensions" Version="4.0.1" />
-    <PackageReference Include="System.Runtime" Version="4.1.0" />
-    <PackageReference Include="System.Runtime.Extensions" Version="4.1.0" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="4.1.0" />
-    <PackageReference Include="System.Threading" Version="4.0.11" />
-  </ItemGroup>
 
 </Project>

--- a/test/Serilog.Tests/Parameters/PropertyValueConverterTests.cs
+++ b/test/Serilog.Tests/Parameters/PropertyValueConverterTests.cs
@@ -271,6 +271,39 @@ namespace Serilog.Tests.Parameters
             Assert.Equal(1, nested.Elements.Count);
             Assert.Equal(new ScalarValue("B"), nested.Elements[0]);
         }
+
+        [Fact]
+        public void AllTupleLengthsUpToSevenAreSupported()
+        {
+            var tuples = new object[]
+            {
+                ValueTuple.Create(1),
+                (1, 2),
+                (1, 2, 3),
+                (1, 2, 3, 4),
+                (1, 2, 3, 4, 5),
+                (1, 2, 3, 4, 5, 6),
+                (1, 2, 3, 4, 5, 6, 7)
+            };
+
+            foreach (var t in tuples)
+                Assert.IsType<SequenceValue>(_converter.CreatePropertyValue(t));
+        }
+
+        [Fact]
+        public void EightPlusValueTupleElementsAreIgnored()
+        {
+            var scalar = _converter.CreatePropertyValue((1, 2, 3, 4, 5, 6, 7, 8));
+            Assert.IsType<ScalarValue>(scalar);
+        }
+
+        [Fact]
+        public void DestructuringIsTransitivelyApplied()
+        {
+            var tuple = _converter.CreatePropertyValue(ValueTuple.Create(new {A = 1}), true);
+            var sequence = Assert.IsType<SequenceValue>(tuple);
+            Assert.IsType<StructureValue>(sequence.Elements[0]);
+        }
     }
 }
 

--- a/test/Serilog.Tests/Parameters/PropertyValueConverterTests.cs
+++ b/test/Serilog.Tests/Parameters/PropertyValueConverterTests.cs
@@ -8,6 +8,8 @@ using Serilog.Parameters;
 using Serilog.Parsing;
 using Serilog.Tests.Support;
 
+// ReSharper disable UnusedAutoPropertyAccessor.Global, UnusedParameter.Local
+
 namespace Serilog.Tests.Parameters
 {
     public class PropertyValueConverterTests
@@ -188,7 +190,7 @@ namespace Serilog.Tests.Parameters
 
         public class DerivedWithOverrides : BaseWithProps
         {
-            new public string PropA { get; set; }
+            public new string PropA { get; set; }
             public override string PropB { get; set; }
             public string PropD { get; set; }
         }
@@ -216,7 +218,7 @@ namespace Serilog.Tests.Parameters
 
         class HasIndexer
         {
-            public string this[int index] { get { return "Indexer"; } }
+            public string this[int index] => "Indexer";
         }
 
         [Fact]
@@ -231,7 +233,7 @@ namespace Serilog.Tests.Parameters
         // (reducing garbage).
         class HasItem
         {
-            public string Item { get { return "Item"; } }
+            public string Item => "Item";
         }
 
         [Fact]
@@ -252,6 +254,22 @@ namespace Serilog.Tests.Parameters
             Assert.Equal(typeof(StructureValue), result.GetType());
             var structuredValue = (StructureValue)result;
             Assert.Equal(null, structuredValue.TypeTag);
+        }
+
+        [Fact]
+        public void ValueTuplesAreRecognizedWhenDestructuring()
+        {
+            var o = (1, "A", new[] { "B" });
+            var result = _converter.CreatePropertyValue(o);
+
+            var sequenceValue = Assert.IsType<SequenceValue>(result);
+
+            Assert.Equal(3, sequenceValue.Elements.Count);
+            Assert.Equal(new ScalarValue(1), sequenceValue.Elements[0]);
+            Assert.Equal(new ScalarValue("A"), sequenceValue.Elements[1]);
+            var nested = Assert.IsType<SequenceValue>(sequenceValue.Elements[2]);
+            Assert.Equal(1, nested.Elements.Count);
+            Assert.Equal(new ScalarValue("B"), nested.Elements[0]);
         }
     }
 }

--- a/test/Serilog.Tests/Parameters/PropertyValueConverterTests.cs
+++ b/test/Serilog.Tests/Parameters/PropertyValueConverterTests.cs
@@ -273,7 +273,7 @@ namespace Serilog.Tests.Parameters
         }
 
         [Fact]
-        public void AllTupleLengthsUpToSevenAreSupported()
+        public void AllTupleLengthsUpToSevenAreSupportedForCapturing()
         {
             var tuples = new object[]
             {
@@ -291,14 +291,14 @@ namespace Serilog.Tests.Parameters
         }
 
         [Fact]
-        public void EightPlusValueTupleElementsAreIgnored()
+        public void EightPlusValueTupleElementsAreIgnoredByCapturing()
         {
             var scalar = _converter.CreatePropertyValue((1, 2, 3, 4, 5, 6, 7, 8));
             Assert.IsType<ScalarValue>(scalar);
         }
 
         [Fact]
-        public void DestructuringIsTransitivelyApplied()
+        public void ValueTupleDestructuringIsTransitivelyApplied()
         {
             var tuple = _converter.CreatePropertyValue(ValueTuple.Create(new {A = 1}), true);
             var sequence = Assert.IsType<SequenceValue>(tuple);

--- a/test/Serilog.Tests/Serilog.Tests.csproj
+++ b/test/Serilog.Tests/Serilog.Tests.csproj
@@ -18,6 +18,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
     <PackageReference Include="xunit" Version="2.2.0" />
+    <PackageReference Include="System.ValueTuple" Version="4.3.1" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">
   </ItemGroup>


### PR DESCRIPTION
This PR for #965 converts tuples like `(1, 2, 3)` into arrays like `[1, 2, 3]` for consumption by sinks.

I don't think tuples are important enough, currently, to justify the effort of including another `LogEventPropertyValue` type to represent them. Arrays are a bit easier on the eyes than structures, and we don't lose any information since tuple member names aren't available dynamically.

The `@` operator is not required to capture a tuple. E.g.:

```csharp
Log.Information("{T}", (1, 2));
```

is fine. Specifying `@` will trigger deep serialization in the case of tuple members that are complex types.

The PR is a little ham-fisted (the change doesn't fit in as an `IScalarConversionPolicy`, unfortunately, so special treatment is needed). Only tuples up to length 7 are supported.

Since tuples are here to stay, and supported everywhere Serilog runs, I've introduced the _System.ValueTuple_ dependency for the current targets. A .NET 4.7-specific target would avoid it, as will .NET Core 2.0. We can add this fresh round of targets once core 2.0 ships, I think (4.7 is a pain right now as it requires a targeting pack).