### PR TITLE
Include source in package builds

### DIFF
--- a/Build.ps1
+++ b/Build.ps1
@@ -23,10 +23,12 @@ foreach ($src in ls src/*) {
 
 	echo "build: Packaging project in $src"
 
+    & dotnet build -c Release --version-suffix=$buildSuffix
+
     if($suffix) {
-        & dotnet pack -c Release --include-source -o ..\..\artifacts --version-suffix=$suffix
+        & dotnet pack -c Release --include-source --no-build -o ..\..\artifacts --version-suffix=$suffix
     } else {
-        & dotnet pack -c Release --include-source -o ..\..\artifacts
+        & dotnet pack -c Release --include-source --no-build -o ..\..\artifacts
     }
     if($LASTEXITCODE -ne 0) { exit 1 }    
 

--- a/Build.ps1
+++ b/Build.ps1
@@ -23,8 +23,11 @@ foreach ($src in ls src/*) {
 
 	echo "build: Packaging project in $src"
 
-    & dotnet build -c Release --version-suffix=$buildSuffix
-    & dotnet pack -c Release --include-symbols -o ..\..\artifacts --version-suffix=$suffix --no-build
+    if($suffix) {
+        & dotnet pack -c Release --include-source -o ..\..\artifacts --version-suffix=$suffix
+    } else {
+        & dotnet pack -c Release --include-source -o ..\..\artifacts
+    }
     if($LASTEXITCODE -ne 0) { exit 1 }    
 
     Pop-Location


### PR DESCRIPTION
Can't see any reason not to use the build implicit in `dotnet pack`, please correct me if I'm missing anything.