### PR TITLE
Meta PR to fix PR Template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,7 +5,7 @@
 
 
 **Please check if the PR fulfills these requirements**
-- [ ] The commit follows our [guidelines](https://github.com/serilog/serilog/CONTRIBUTING.md)
+- [ ] The commit follows our [guidelines](https://github.com/serilog/serilog/blob/dev/CONTRIBUTING.md)
 - [ ] Unit Tests for the changes have been added (for bug fixes / features)
 
 **Other information**:


### PR DESCRIPTION
**What issue does this PR address?**
The link in PULL_REQUEST_TEMPLATE.md pointed to a 404 (https://github.com/serilog/serilog/CONTRIBUTING.md)


**Does this PR introduce a breaking change?**
No

**Please check if the PR fulfills these requirements**
- [x] The commit follows our [guidelines](https://github.com/serilog/serilog/CONTRIBUTING.md)
- *N/A* Unit Tests for the changes have been added (for bug fixes / features)

**Other information**:
