### PR TITLE
Support for Overrides in Child loggers - issue #967

### DIFF
--- a/src/Serilog/Configuration/LoggerSinkConfiguration.cs
+++ b/src/Serilog/Configuration/LoggerSinkConfiguration.cs
@@ -159,7 +159,17 @@ namespace Serilog.Configuration
             LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum)
         {
             if (logger == null) throw new ArgumentNullException(nameof(logger));
-            return Sink(new SecondaryLoggerSink(logger, attemptDispose: false), restrictedToMinimumLevel);
+            ILogEventSink secondarySink = new SecondaryLoggerSink(logger, attemptDispose: false);
+
+            if (logger is Logger concreteLogger)
+            {
+                // Loggers can have their own overrides
+                if (concreteLogger.HasOverrides)
+                {
+                    secondarySink = new OverrideRestrictingSink(secondarySink, concreteLogger.OverrideMap);
+                }
+            }
+            return Sink(secondarySink, restrictedToMinimumLevel);
         }
 
         /// <summary>

--- a/src/Serilog/Configuration/LoggerSinkConfiguration.cs
+++ b/src/Serilog/Configuration/LoggerSinkConfiguration.cs
@@ -134,7 +134,10 @@ namespace Serilog.Configuration
             configureLogger(lc);
 
             ILogEventSink secondaryLoggerSink = new SecondaryLoggerSink(lc.CreateLogger(), attemptDispose: true);
-            // by now, subLoggerOverrides contain the overrides defined for this sublogger
+
+            // Action<LoggerConfiguration> may have set minimum level overrides.
+            // Normally overrides are checked when calling Log.ForContext(), but this cannot
+            // happen for child loggers. For those, we need to check at *Emit* time.
             if (subLoggerOverrides.Count > 0)
             {
                 secondaryLoggerSink = new OverrideRestrictingSink(secondaryLoggerSink, subLoggerOverrides);
@@ -163,7 +166,9 @@ namespace Serilog.Configuration
 
             if (logger is Logger concreteLogger)
             {
-                // Loggers can have their own overrides
+                // Loggers can have their own overrides.
+                // Normally overrides are checked when calling Log.ForContext(), but this cannot
+                // happen for child loggers. For those, we need to check at *Emit* time
                 if (concreteLogger.HasOverrides)
                 {
                     secondarySink = new OverrideRestrictingSink(secondarySink, concreteLogger.OverrideMap);

--- a/src/Serilog/Configuration/LoggerSinkConfiguration.cs
+++ b/src/Serilog/Configuration/LoggerSinkConfiguration.cs
@@ -169,9 +169,9 @@ namespace Serilog.Configuration
                 // Loggers can have their own overrides.
                 // Normally overrides are checked when calling Log.ForContext(), but this cannot
                 // happen for child loggers. For those, we need to check at *Emit* time
-                if (concreteLogger.HasOverrides)
+                if (concreteLogger.TryGetOverrideMap(out var overrideMap))
                 {
-                    secondarySink = new OverrideRestrictingSink(secondarySink, concreteLogger.OverrideMap);
+                    secondarySink = new OverrideRestrictingSink(secondarySink, overrideMap);
                 }
             }
             return Sink(secondarySink, restrictedToMinimumLevel);

--- a/src/Serilog/Configuration/LoggerSinkConfiguration.cs
+++ b/src/Serilog/Configuration/LoggerSinkConfiguration.cs
@@ -140,6 +140,10 @@ namespace Serilog.Configuration
             // happen for child loggers. For those, we need to check at *Emit* time.
             if (subLoggerOverrides.Count > 0)
             {
+                SelfLog.WriteLine("We have detected that you are using .MinimumLevel.Override() from a sub-logger (.WriteTo.Logger(Action<LoggerConfiguration>)). " +
+                                  "Overrides in a sub-logger cannot decrease the level set by the parent logger. Because of this limitation and possible performance impact, " +
+                                  "we recommend using .Filter instead in your sub-loggers. " +
+                                  "Note that support for sub-loggers' minimum level overrides may be removed in the next major version.");
                 secondaryLoggerSink = new OverrideRestrictingSink(secondaryLoggerSink, subLoggerOverrides);
             }
 
@@ -171,6 +175,10 @@ namespace Serilog.Configuration
                 // happen for child loggers. For those, we need to check at *Emit* time
                 if (concreteLogger.TryGetOverrideMap(out var overrideMap))
                 {
+                    SelfLog.WriteLine("We have detected that you are using .MinimumLevel.Override() from a sub-logger (.WriteTo.Logger(Logger)). " +
+                                      "Overrides in a sub-logger cannot decrease the level set by the parent logger. Because of this limitation and possible performance impact, " +
+                                      "we recommend using .Filter instead in your sub-loggers. " +
+                                      "Note that support for sub-loggers' minimum level overrides may be removed in the next major version.");
                     secondarySink = new OverrideRestrictingSink(secondarySink, overrideMap);
                 }
             }

--- a/src/Serilog/Core/Logger.cs
+++ b/src/Serilog/Core/Logger.cs
@@ -108,7 +108,7 @@ namespace Serilog.Core
                         enricher,
                         null,
                         _levelSwitch,
-                        OverrideMap);
+                        _overrideMap);
         }
 
         /// <summary>
@@ -148,11 +148,11 @@ namespace Serilog.Core
 
             var minimumLevel = _minimumLevel;
             var levelSwitch = _levelSwitch;
-            if (OverrideMap != null && propertyName == Constants.SourceContextPropertyName)
+            if (_overrideMap != null && propertyName == Constants.SourceContextPropertyName)
             {
                 var context = value as string;
                 if (context != null)
-                    OverrideMap.GetEffectiveLevel(context, out minimumLevel, out levelSwitch);
+                    _overrideMap.GetEffectiveLevel(context, out minimumLevel, out levelSwitch);
             }
 
             return new Logger(
@@ -162,7 +162,7 @@ namespace Serilog.Core
                 enricher,
                 null,
                 levelSwitch,
-                OverrideMap);
+                _overrideMap);
         }
 
         /// <summary>

--- a/src/Serilog/Core/Logger.cs
+++ b/src/Serilog/Core/Logger.cs
@@ -88,6 +88,9 @@ namespace Serilog.Core
             _enricher = enricher;
         }
 
+        internal bool HasOverrides => _overrideMap != null;
+        internal LevelOverrideMap OverrideMap => _overrideMap;
+
         /// <summary>
         /// Create a logger that enriches log events via the provided enrichers.
         /// </summary>
@@ -105,7 +108,7 @@ namespace Serilog.Core
                         enricher,
                         null,
                         _levelSwitch,
-                        _overrideMap);
+                        OverrideMap);
         }
 
         /// <summary>
@@ -145,11 +148,11 @@ namespace Serilog.Core
 
             var minimumLevel = _minimumLevel;
             var levelSwitch = _levelSwitch;
-            if (_overrideMap != null && propertyName == Constants.SourceContextPropertyName)
+            if (OverrideMap != null && propertyName == Constants.SourceContextPropertyName)
             {
                 var context = value as string;
                 if (context != null)
-                    _overrideMap.GetEffectiveLevel(context, out minimumLevel, out levelSwitch);
+                    OverrideMap.GetEffectiveLevel(context, out minimumLevel, out levelSwitch);
             }
 
             return new Logger(
@@ -159,7 +162,7 @@ namespace Serilog.Core
                 enricher,
                 null,
                 levelSwitch,
-                _overrideMap);
+                OverrideMap);
         }
 
         /// <summary>
@@ -273,11 +276,11 @@ namespace Serilog.Core
         /// <returns>True if the level is enabled; otherwise, false.</returns>
         public bool IsEnabled(LogEventLevel level)
         {
-            if ((int) level < (int) _minimumLevel)
+            if ((int)level < (int)_minimumLevel)
                 return false;
 
             return _levelSwitch == null ||
-                   (int) level >= (int) _levelSwitch.MinimumLevel;
+                   (int)level >= (int)_levelSwitch.MinimumLevel;
         }
 
         /// <summary>
@@ -1359,7 +1362,7 @@ namespace Serilog.Core
                 return false;
             }
 
-            property =_messageTemplateProcessor.CreateProperty(propertyName, value, destructureObjects);
+            property = _messageTemplateProcessor.CreateProperty(propertyName, value, destructureObjects);
             return true;
         }
 

--- a/src/Serilog/Core/Logger.cs
+++ b/src/Serilog/Core/Logger.cs
@@ -88,8 +88,11 @@ namespace Serilog.Core
             _enricher = enricher;
         }
 
-        internal bool HasOverrides => _overrideMap != null;
-        internal LevelOverrideMap OverrideMap => _overrideMap;
+        internal bool TryGetOverrideMap(out LevelOverrideMap overrideMap)
+        {
+            overrideMap = _overrideMap;
+            return _overrideMap != null;
+        }
 
         /// <summary>
         /// Create a logger that enriches log events via the provided enrichers.

--- a/src/Serilog/Core/Sinks/OverrideRestrictingSink.cs
+++ b/src/Serilog/Core/Sinks/OverrideRestrictingSink.cs
@@ -1,0 +1,66 @@
+﻿// Copyright 2013-2015 Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using Serilog.Events;
+
+namespace Serilog.Core.Sinks
+{
+    class OverrideRestrictingSink : ILogEventSink
+    {
+        readonly ILogEventSink _sink;
+        LevelOverrideMap _overrideMap;
+
+        public OverrideRestrictingSink(ILogEventSink sink, Dictionary<string, LoggingLevelSwitch> overrides)
+        {
+            if (sink == null) throw new ArgumentNullException(nameof(sink));
+            if (overrides == null) throw new ArgumentNullException(nameof(overrides));
+            _sink = sink;
+            _overrideMap = new LevelOverrideMap(overrides, LevelAlias.Minimum, null);
+
+        }
+
+        public void Emit(LogEvent logEvent)
+        {
+            if (logEvent == null) throw new ArgumentNullException(nameof(logEvent));
+
+            // overrides have been specified, and because only the
+            // .ForContext is called on the root logger and not on child loggers
+            // we need to check for possible overrides when emitting ...
+
+            if (logEvent.Properties.TryGetValue(Constants.SourceContextPropertyName, out var sourceContext))
+            {
+                if (sourceContext is ScalarValue scalar)
+                {
+                    // maybe do not emit based on namespace overrides
+                    if (scalar.Value is string context)
+                    {
+                        LogEventLevel minLevel;
+                        LoggingLevelSwitch levelSwitch;
+                        _overrideMap.GetEffectiveLevel(context, out minLevel, out levelSwitch);
+
+                        if (logEvent.Level < minLevel || (levelSwitch != null) && logEvent.Level < levelSwitch.MinimumLevel)
+                        {
+                            // event is not critical enough to carry on ...
+                            return;
+                        }
+                    }
+                }
+            }
+
+            _sink.Emit(logEvent);
+        }
+    }
+}

--- a/src/Serilog/Core/Sinks/OverrideRestrictingSink.cs
+++ b/src/Serilog/Core/Sinks/OverrideRestrictingSink.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2013-2015 Serilog Contributors
+﻿// Copyright 2013-2017 Serilog Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -25,18 +25,15 @@ namespace Serilog.Core.Sinks
 
         public OverrideRestrictingSink(ILogEventSink sink, Dictionary<string, LoggingLevelSwitch> overrides)
         {
-            if (sink == null) throw new ArgumentNullException(nameof(sink));
             if (overrides == null) throw new ArgumentNullException(nameof(overrides));
-            _sink = sink;
+            _sink = sink ?? throw new ArgumentNullException(nameof(sink));
             _overrideMap = new LevelOverrideMap(overrides, LevelAlias.Minimum, null);
         }
 
         public OverrideRestrictingSink(ILogEventSink sink, LevelOverrideMap overrideMap)
         {
-            if (sink == null) throw new ArgumentNullException(nameof(sink));
-            if (overrideMap == null) throw new ArgumentNullException(nameof(overrideMap));
-            _sink = sink;
-            _overrideMap = overrideMap;
+            _sink = sink ?? throw new ArgumentNullException(nameof(sink));
+            _overrideMap = overrideMap ?? throw new ArgumentNullException(nameof(overrideMap));
         }
 
         public void Emit(LogEvent logEvent)

--- a/src/Serilog/Core/Sinks/OverrideRestrictingSink.cs
+++ b/src/Serilog/Core/Sinks/OverrideRestrictingSink.cs
@@ -32,6 +32,14 @@ namespace Serilog.Core.Sinks
 
         }
 
+        public OverrideRestrictingSink(ILogEventSink sink, LevelOverrideMap overrideMap)
+        {
+            if (sink == null) throw new ArgumentNullException(nameof(sink));
+            if (overrideMap == null) throw new ArgumentNullException(nameof(overrideMap));
+            _sink = sink;
+            _overrideMap = overrideMap;
+        }
+
         public void Emit(LogEvent logEvent)
         {
             if (logEvent == null) throw new ArgumentNullException(nameof(logEvent));

--- a/src/Serilog/Core/Sinks/OverrideRestrictingSink.cs
+++ b/src/Serilog/Core/Sinks/OverrideRestrictingSink.cs
@@ -21,7 +21,7 @@ namespace Serilog.Core.Sinks
     class OverrideRestrictingSink : ILogEventSink
     {
         readonly ILogEventSink _sink;
-        LevelOverrideMap _overrideMap;
+        readonly LevelOverrideMap _overrideMap;
 
         public OverrideRestrictingSink(ILogEventSink sink, Dictionary<string, LoggingLevelSwitch> overrides)
         {
@@ -29,7 +29,6 @@ namespace Serilog.Core.Sinks
             if (overrides == null) throw new ArgumentNullException(nameof(overrides));
             _sink = sink;
             _overrideMap = new LevelOverrideMap(overrides, LevelAlias.Minimum, null);
-
         }
 
         public OverrideRestrictingSink(ILogEventSink sink, LevelOverrideMap overrideMap)

--- a/src/Serilog/LoggerConfiguration.cs
+++ b/src/Serilog/LoggerConfiguration.cs
@@ -36,12 +36,33 @@ namespace Serilog
         readonly List<Type> _additionalScalarTypes = new List<Type>();
         readonly List<IDestructuringPolicy> _additionalDestructuringPolicies = new List<IDestructuringPolicy>();
         readonly Dictionary<string, LoggingLevelSwitch> _overrides = new Dictionary<string, LoggingLevelSwitch>();
+        readonly Action<string, LoggingLevelSwitch> _addOverrideCallback;
         LogEventLevel _minimumLevel = LogEventLevel.Information;
         LoggingLevelSwitch _levelSwitch;
         int _maximumDestructuringDepth = 10;
         int _maximumStringLength = int.MaxValue;
         int _maximumCollectionCount = int.MaxValue;
         bool _loggerCreated;
+
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+        public LoggerConfiguration()
+#pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
+            : this(null)
+        {
+            
+        }
+
+        internal LoggerConfiguration(Action<string, LoggingLevelSwitch> addOverrideCallback)
+        {
+            if (addOverrideCallback == null)
+            {
+                _addOverrideCallback = (s, lls) => { };
+            }
+            else
+            {
+                _addOverrideCallback = addOverrideCallback;
+            }
+        }
 
         void ApplyInheritedConfiguration(LoggerConfiguration child)
         {
@@ -69,6 +90,12 @@ namespace Serilog
         /// </remarks>
         public LoggerAuditSinkConfiguration AuditTo => new LoggerAuditSinkConfiguration(this, s => _auditSinks.Add(s), ApplyInheritedConfiguration);
 
+        void AddOverride(string source, LoggingLevelSwitch levelSwitch)
+        {
+            _overrides[source] = levelSwitch;
+            _addOverrideCallback(source, levelSwitch);
+        }
+
         /// <summary>
         /// Configures the minimum level at which events will be passed to sinks. If
         /// not specified, only events at the <see cref="LogEventLevel.Information"/>
@@ -85,7 +112,7 @@ namespace Serilog
                         _levelSwitch = null;
                     },
                     sw => _levelSwitch = sw,
-                    (s, lls) => _overrides[s] = lls);
+                    AddOverride);
             }
         }
 

--- a/src/Serilog/LoggerConfiguration.cs
+++ b/src/Serilog/LoggerConfiguration.cs
@@ -44,12 +44,12 @@ namespace Serilog
         int _maximumCollectionCount = int.MaxValue;
         bool _loggerCreated;
 
-#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+        /// <summary>
+        /// Configuration object for creating <see cref="ILogger"/> instances.
+        /// </summary>
         public LoggerConfiguration()
-#pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
             : this(null)
         {
-            
         }
 
         internal LoggerConfiguration(Action<string, LoggingLevelSwitch> addOverrideCallback)

--- a/test/Serilog.Tests/Core/ChildLoggerKnownLimitationsTests.cs
+++ b/test/Serilog.Tests/Core/ChildLoggerKnownLimitationsTests.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Serilog.Core;
+using Serilog.Tests.Support;
+using Xunit;
+using static Serilog.Events.LogEventLevel;
+
+namespace Serilog.Tests.Core
+{
+    public class ChildLoggerKnownLimitationsTests
+    {
+        [Fact]
+        public void ChildLoggerCannotDecreaseRootLoggerOverrideLevel()
+        {
+            var configCallBackSink = new CollectingSink();
+            var loggerSink = new CollectingSink();
+
+            var subLogger = new LoggerConfiguration()
+                .MinimumLevel.Verbose()
+                .MinimumLevel.Override("Foo.Bar", Debug)
+                .WriteTo.Sink(loggerSink)
+                .CreateLogger();
+
+            var logger = new LoggerConfiguration()
+                .MinimumLevel.Verbose()
+                .MinimumLevel.Override("Foo.Bar", Warning)
+                .WriteTo.Logger(lc => lc
+                    .MinimumLevel.Verbose()
+                    .MinimumLevel.Override("Foo.Bar", Debug)
+                    .WriteTo.Sink(configCallBackSink))
+                .WriteTo.Logger(subLogger)
+                .CreateLogger();
+
+            var contextLogger = logger.ForContext(Constants.SourceContextPropertyName, "Foo.Bar");
+            contextLogger.Write(Some.InformationEvent());
+
+            // subloggers would have happily accepted Information event
+            // but root logger had an override with level Warning
+            Assert.Null(loggerSink.Events.FirstOrDefault());
+            Assert.Null(configCallBackSink.Events.FirstOrDefault());
+        }
+    }
+}

--- a/test/Serilog.Tests/Core/ChildLoggerKnownLimitationsTests.cs
+++ b/test/Serilog.Tests/Core/ChildLoggerKnownLimitationsTests.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using Serilog.Core;
 using Serilog.Tests.Support;
@@ -39,6 +38,66 @@ namespace Serilog.Tests.Core
             // but root logger had an override with level Warning
             Assert.Null(loggerSink.Events.FirstOrDefault());
             Assert.Null(configCallBackSink.Events.FirstOrDefault());
+        }
+
+        [Fact]
+        public void SpecifyingMinimumLevelOverridesInWriteToLoggerWithConfigCallBackWritesWarningToSelfLog()
+        {
+            var outputs = new List<string>();
+            using (TemporarySelfLog.SaveTo(outputs))
+            {
+                var configCallBackSink = new CollectingSink();
+
+                var logger = new LoggerConfiguration()
+                    .MinimumLevel.Verbose()
+                    .MinimumLevel.Override("Foo.Bar", Warning)
+                    .WriteTo.Logger(lc => lc
+                        .MinimumLevel.Verbose()
+                        .MinimumLevel.Override("Foo.Bar", Debug)
+                        .WriteTo.Sink(configCallBackSink))
+                    .CreateLogger();
+
+                var contextLogger = logger.ForContext(Constants.SourceContextPropertyName, "Foo.Bar");
+                contextLogger.Write(Some.InformationEvent());
+            }
+
+            Assert.EndsWith("We have detected that you are using .MinimumLevel.Override() from a sub-logger (.WriteTo.Logger(Action<LoggerConfiguration>)). " +
+                         "Overrides in a sub-logger cannot decrease the level set by the parent logger. Because of this limitation and possible performance impact, " +
+                         "we recommend using .Filter instead in your sub-loggers. " +
+                         "Note that support for sub-loggers' minimum level overrides may be removed in the next major version.",
+                         outputs.FirstOrDefault() ?? "");
+        }
+
+
+        [Fact]
+        public void SpecifyingMinimumLevelOverridesInWriteToLoggerWritesWarningToSelfLog()
+        {
+            var outputs = new List<string>();
+            using (TemporarySelfLog.SaveTo(outputs))
+            {
+                var subSink = new CollectingSink();
+
+                var subLogger = new LoggerConfiguration()
+                    .MinimumLevel.Verbose()
+                    .MinimumLevel.Override("Foo.Bar", Debug)
+                    .WriteTo.Sink(subSink)
+                    .CreateLogger();
+
+                var logger = new LoggerConfiguration()
+                    .MinimumLevel.Verbose()
+                    .MinimumLevel.Override("Foo.Bar", Warning)
+                    .WriteTo.Logger(subLogger)
+                    .CreateLogger();
+
+                var contextLogger = logger.ForContext(Constants.SourceContextPropertyName, "Foo.Bar");
+                contextLogger.Write(Some.InformationEvent());
+            }
+
+            Assert.EndsWith("We have detected that you are using .MinimumLevel.Override() from a sub-logger (.WriteTo.Logger(Logger)). " +
+                            "Overrides in a sub-logger cannot decrease the level set by the parent logger. Because of this limitation and possible performance impact, " +
+                            "we recommend using .Filter instead in your sub-loggers. " +
+                            "Note that support for sub-loggers' minimum level overrides may be removed in the next major version.",
+                outputs.FirstOrDefault() ?? "");
         }
     }
 }

--- a/test/Serilog.Tests/Core/ChildLoggerTests.cs
+++ b/test/Serilog.Tests/Core/ChildLoggerTests.cs
@@ -85,7 +85,14 @@ namespace Serilog.Tests.Core
 
             logger.Write(Some.LogEvent(level: eventLevel));
 
-            Assert.Equal(eventShouldGetToChild, evt!=null);
+            if (eventShouldGetToChild)
+            {
+                Assert.NotNull(evt);
+            }
+            else
+            {
+                Assert.Null(evt);
+            }
         }
 
         [Theory]
@@ -166,7 +173,14 @@ namespace Serilog.Tests.Core
 
             logger.Write(Some.LogEvent(level: eventLevel));
 
-            Assert.Equal(eventShouldGetToChild, evt != null);
+            if (eventShouldGetToChild)
+            {
+                Assert.NotNull(evt);
+            }
+            else
+            {
+                Assert.Null(evt);
+            }
         }
 
 
@@ -262,7 +276,14 @@ namespace Serilog.Tests.Core
                 .ForContext(Constants.SourceContextPropertyName, "Root.N1.N2")
                 .Write(Some.LogEvent(level: incomingEventLevel));
 
-            Assert.Equal(eventShouldGetToChild, evt != null);
+            if (eventShouldGetToChild)
+            {
+                Assert.NotNull(evt);
+            }
+            else
+            {
+                Assert.Null(evt);
+            }
         }
     }
 }

--- a/test/Serilog.Tests/Core/ChildLoggerTests.cs
+++ b/test/Serilog.Tests/Core/ChildLoggerTests.cs
@@ -1,4 +1,5 @@
-﻿using Serilog.Core;
+﻿using System.Collections.Generic;
+using Serilog.Core;
 using Serilog.Events;
 using Serilog.Tests.Support;
 using Xunit;
@@ -9,58 +10,67 @@ namespace Serilog.Tests.Core
     public class ChildLoggerTests
     {
 
+        public static IEnumerable<object[]> GetMinimumLevelInheritanceTestCases()
+        {
+            // Visualizing the pipeline from left to right ....
+            //
+            //   Event  --> Root Logger --> restrictedTo --> Child Logger -> YES or
+            //    lvl        min lvl           param            min lvl       NO ?
+            //
+            object[] T(LogEventLevel el, int? rl, int? rt, int? cl, bool r)
+            {
+                return new object[]{ el, rl, rt, cl, r };
+            }
+            // numbers are relative to incoming event level
+            // Information + 1 = Warning
+            // Information - 1 = Debug
+            // Information + null = default
+            //
+            // - default case - nothing specified
+            // equivalent to "Information+ allowed"
+            yield return T(Verbose,     null, null, null, false);
+            yield return T(Debug,       null, null, null, false);
+            yield return T(Information, null, null, null, true);
+            yield return T(Warning,     null, null, null, true);
+            yield return T(Error,       null, null, null, true);
+            yield return T(Fatal,       null, null, null, true);
+                                    
+            // - cases where event level is high enough all along the pipeline
+            //                  e       -->  --> -->  = OK
+            yield return T(Verbose,     +0, +0, +0, true);
+            yield return T(Debug,       +0, +0, +0, true);
+            yield return T(Information, +0, +0, +0, true);
+            yield return T(Warning,     +0, +0, +0, true);
+            yield return T(Error,       +0, +0, +0, true);
+            yield return T(Fatal,       +0, +0, +0, true);
+
+            // - cases where event is blocked by root minimum level
+            //                 e        -x>  -   -   = NO
+            yield return T(Verbose,     +1, +0, +0, false);
+            yield return T(Debug,       +1, +0, +0, false);
+            yield return T(Information, +1, +0, +0, false);
+            yield return T(Warning,     +1, +0, +0, false);
+            yield return T(Error,       +1, +0, +0, false);
+
+            // - cases where event is blocked by param restrictedToMinimumLevel
+            //                 e        --> -x>  -   = NO
+            yield return T(Verbose,     +0, +1, +0, false);
+            yield return T(Debug,       +0, +1, +0, false);
+            yield return T(Information, +0, +1, +0, false);
+            yield return T(Warning,     +0, +1, +0, false);
+            yield return T(Error,       +0, +1, +0, false);
+
+            // - cases where event is blocked by child minimum level
+            //                 e        --> --> -x>  = NO
+            yield return T(Verbose,     +0, +0, +1, false);
+            yield return T(Debug,       +0, +0, +1, false);
+            yield return T(Information, +0, +0, +1, false);
+            yield return T(Warning,     +0, +0, +1, false);
+            yield return T(Error,       +0, +0, +1, false);
+        }
+
         [Theory]
-        // Visualizing the pipeline from left to right ....
-        //
-        //   Event  --> Root Logger --> restrictedTo --> Child Logger -> YES or
-        //    lvl        min lvl           param            min lvl       NO ?
-        //
-        // numbers are relative to incoming event level
-        // Information + 1 = Warning
-        // Information - 1 = Debug
-        // Information + null = default
-        //
-        // - default case - nothing specified
-        // equivalent to "Information+ allowed"
-        [InlineData(Verbose,     null, null, null, false)]
-        [InlineData(Debug,       null, null, null, false)]
-        [InlineData(Information, null, null, null, true)]
-        [InlineData(Warning,     null, null, null, true)]
-        [InlineData(Error,       null, null, null, true)]
-        [InlineData(Fatal,       null, null, null, true)]
-
-        // - cases where event level is high enough all along the pipeline
-        //              e       -->  --> -->  = OK
-        [InlineData(Verbose,     +0, +0, +0, true)]
-        [InlineData(Debug,       +0, +0, +0, true)]
-        [InlineData(Information, +0, +0, +0, true)]
-        [InlineData(Warning,     +0, +0, +0, true)]
-        [InlineData(Error,       +0, +0, +0, true)]
-        [InlineData(Fatal,       +0, +0, +0, true)]
-
-        // - cases where event is blocked by root minimum level
-        //              e        -x>  -   -   = NO
-        [InlineData(Verbose,     +1, +0, +0, false)]
-        [InlineData(Debug,       +1, +0, +0, false)]
-        [InlineData(Information, +1, +0, +0, false)]
-        [InlineData(Warning,     +1, +0, +0, false)]
-        [InlineData(Error,       +1, +0, +0, false)]
-
-        // - cases where event is blocked by param restrictedToMinimumLevel
-        //              e        --> -x>  -   = NO
-        [InlineData(Verbose,     +0, +1, +0, false)]
-        [InlineData(Debug,       +0, +1, +0, false)]
-        [InlineData(Information, +0, +1, +0, false)]
-        [InlineData(Warning,     +0, +1, +0, false)]
-        [InlineData(Error,       +0, +1, +0, false)]
-
-        // - cases where event is blocked by child minimum level
-        //              e        --> --> -x>  = NO
-        [InlineData(Verbose,     +0, +0, +1, false)]
-        [InlineData(Debug,       +0, +0, +1, false)]
-        [InlineData(Information, +0, +0, +1, false)]
-        [InlineData(Warning,     +0, +0, +1, false)]
-        [InlineData(Error,       +0, +0, +1, false)]
+        [MemberData(nameof(GetMinimumLevelInheritanceTestCases))]
         public void WriteToLoggerWithConfigCallbackMinimumLevelInheritanceScenarios(
             LogEventLevel eventLevel,
             int? rootMinimumLevelIncrement,
@@ -96,57 +106,7 @@ namespace Serilog.Tests.Core
         }
 
         [Theory]
-         // Visualizing the pipeline from left to right ....
-        //
-        //   Event  --> Root Logger --> restrictedTo --> Child Logger -> YES or
-        //    lvl        min lvl           param            min lvl       NO ?
-        //
-        // numbers are relative to incoming event level
-        // Information + 1 = Warning
-        // Information - 1 = Debug
-        // Information + null = default
-        //
-        // - default case - nothing specified
-        // equivalent to "Information+ allowed"
-        [InlineData(Verbose,     null, null, null, false)]
-        [InlineData(Debug,       null, null, null, false)]
-        [InlineData(Information, null, null, null, true)]
-        [InlineData(Warning,     null, null, null, true)]
-        [InlineData(Error,       null, null, null, true)]
-        [InlineData(Fatal,       null, null, null, true)]
-
-        // - cases where event level is high enough all along the pipeline
-        //              e       -->  --> -->  = OK
-        [InlineData(Verbose,     +0, +0, +0, true)]
-        [InlineData(Debug,       +0, +0, +0, true)]
-        [InlineData(Information, +0, +0, +0, true)]
-        [InlineData(Warning,     +0, +0, +0, true)]
-        [InlineData(Error,       +0, +0, +0, true)]
-        [InlineData(Fatal,       +0, +0, +0, true)]
-
-        // - cases where event is blocked by root minimum level
-        //              e        -x>  -   -   = NO
-        [InlineData(Verbose,     +1, +0, +0, false)]
-        [InlineData(Debug,       +1, +0, +0, false)]
-        [InlineData(Information, +1, +0, +0, false)]
-        [InlineData(Warning,     +1, +0, +0, false)]
-        [InlineData(Error,       +1, +0, +0, false)]
-
-        // - cases where event is blocked by param restrictedToMinimumLevel
-        //              e        --> -x>  -   = NO
-        [InlineData(Verbose,     +0, +1, +0, false)]
-        [InlineData(Debug,       +0, +1, +0, false)]
-        [InlineData(Information, +0, +1, +0, false)]
-        [InlineData(Warning,     +0, +1, +0, false)]
-        [InlineData(Error,       +0, +1, +0, false)]
-
-        // - cases where event is blocked by child minimum level
-        //              e        --> --> -x>  = NO
-        [InlineData(Verbose,     +0, +0, +1, false)]
-        [InlineData(Debug,       +0, +0, +1, false)]
-        [InlineData(Information, +0, +0, +1, false)]
-        [InlineData(Warning,     +0, +0, +1, false)]
-        [InlineData(Error,       +0, +0, +1, false)]
+        [MemberData(nameof(GetMinimumLevelInheritanceTestCases))]
         public void WriteToLoggerMinimumLevelInheritanceScenarios(
             LogEventLevel eventLevel,
             int? rootMinimumLevelIncrement,
@@ -183,61 +143,68 @@ namespace Serilog.Tests.Core
             }
         }
 
-
+        public static IEnumerable<object[]> GetMinimumLevelOverrideInheritanceTestCases()
+        {
+            // Visualizing the pipeline from left to right ....
+            //
+            //   Event  --> Root Logger --> Child Logger -> YES or
+            //    lvl       override/lvl    override/levl     NO ?
+            //
+            object[] T(string rs, int? rl, string cs, int? cl, bool r)
+            {
+                return new object[] { rs, rl, cs, cl, r };
+            }
+            // numbers are relative to incoming event level
+            // Information + 1 = Warning
+            // Information - 1 = Debug
+            //
+            // Incoming event is Information
+            // with SourceContext Root.N1.N2
+            //
+            // - default case - no overrides
+            yield return T(null, 0, null, 0, true);
+            // - root overrides with level lower or equal to event
+            // ... and child logger is out of the way
+            yield return T("Root", +0, null, +0, true);
+            yield return T("Root", -1, null, +0, true);
+            yield return T("Root.N1", +0, null, +0, true);
+            yield return T("Root.N1", -1, null, +0, true);
+            yield return T("Root.N1.N2", +0, null, +0, true);
+            yield return T("Root.N1.N2", -1, null, +0, true);
+            // - root overrides on irrelevant namespaces
+            yield return T("xx", +1, null, +0, true);
+            yield return T("Root.xx", +1, null, +0, true);
+            yield return T("Root.N1.xx", +1, null, +0, true);
+            // - child overrides on irrelevant namespaces
+            yield return T(null, +0, "xx", +1, true);
+            yield return T(null, +0, "Root.xx", +1, true);
+            yield return T(null, +1, "Root.N1.xx", +1, true);
+            // - root overrides prevent all processing from children
+            // even though children would happily accept it
+            yield return T("Root", +1, null, +0, false);
+            yield return T("Root", +1, "Root", +0, false);
+            yield return T("Root.N1", +1, null, +0, false);
+            yield return T("Root.N1", +1, "Root.N1", +0, false);
+            yield return T("Root.N1.N2", +1, null, +0, false);
+            yield return T("Root.N1.N2", +1, "Root.N1.N2", +0, false);
+            // - no root overrides but children has its own
+            yield return T(null, +0, "Root", +1, false);
+            yield return T(null, +0, "Root.N1", +1, false);
+            yield return T(null, +0, "Root.N1.N2", +1, false);
+            // - root overrides let it through but child rejects it
+            yield return T("Root", +0, "Root", +1, false);
+            yield return T("Root.N1", +0, "Root", +1, false);
+            yield return T("Root.N1.N2", +0, "Root", +1, false);
+            yield return T("Root", +0, "Root.N1", +1, false);
+            yield return T("Root.N1", +0, "Root.N1", +1, false);
+            yield return T("Root.N1.N2", +0, "Root.N1", +1, false);
+            yield return T("Root", +0, "Root.N1.N2", +1, false);
+            yield return T("Root.N1", +0, "Root.N1.N2", +1, false);
+            yield return T("Root.N1.N2", +0, "Root.N1.N2", +1, false);
+    }
 
         [Theory]
-        // Visualizing the pipeline from left to right ....
-        //
-        //   Event  --> Root Logger --> Child Logger -> YES or
-        //    lvl       override/lvl    override/levl     NO ?
-        //
-        // numbers are relative to incoming event level
-        // Information + 1 = Warning
-        // Information - 1 = Debug
-        //
-        // Incoming event is Information
-        // with SourceContext Root.N1.N2
-        //
-        // - default case - no overrides
-        [InlineData(null, 0, null, 0, true)]
-        // - root overrides with level lower or equal to event
-        // ... and child logger is out of the way
-        [InlineData("Root", +0, null, +0, true)]
-        [InlineData("Root", -1, null, +0, true)]
-        [InlineData("Root.N1", +0, null, +0, true)]
-        [InlineData("Root.N1", -1, null, +0, true)]
-        [InlineData("Root.N1.N2", +0, null, +0, true)]
-        [InlineData("Root.N1.N2", -1, null, +0, true)]
-        // - root overrides on irrelevant namespaces
-        [InlineData("xx", +1, null, +0, true)]
-        [InlineData("Root.xx", +1, null, +0, true)]
-        [InlineData("Root.N1.xx", +1, null, +0, true)]
-        // - child overrides on irrelevant namespaces
-        [InlineData(null, +0, "xx", +1, true)]
-        [InlineData(null, +0, "Root.xx", +1, true)]
-        [InlineData(null, +1, "Root.N1.xx", +1, true)]
-        // - root overrides prevent all processing from children
-        // even though children would happily accept it
-        [InlineData("Root", +1, null, +0, false)]
-        [InlineData("Root", +1, "Root", +0, false)]
-        [InlineData("Root.N1", +1, null, +0, false)]
-        [InlineData("Root.N1", +1, "Root.N1", +0, false)]
-        [InlineData("Root.N1.N2", +1, null, +0, false)]
-        [InlineData("Root.N1.N2", +1, "Root.N1.N2", +0, false)]
-        // - no root overrides but children has its own
-        [InlineData(null, +0, "Root", +1, false)]
-        [InlineData(null, +0, "Root.N1", +1, false)]
-        [InlineData(null, +0, "Root.N1.N2", +1, false)]
-        // - root overrides let it through but child rejects it
-        [InlineData("Root", +0, "Root", +1, false)]
-        [InlineData("Root.N1", +0, "Root", +1, false)]
-        [InlineData("Root.N1.N2", +0, "Root", +1, false)]
-        [InlineData("Root", +0, "Root.N1", +1, false)]
-        [InlineData("Root.N1", +0, "Root.N1", +1, false)]
-        [InlineData("Root.N1.N2", +0, "Root.N1", +1, false)]
-        [InlineData("Root", +0, "Root.N1.N2", +1, false)]
-        [InlineData("Root.N1", +0, "Root.N1.N2", +1, false)]
-        [InlineData("Root.N1.N2", +0, "Root.N1.N2", +1, false)]
+        [MemberData(nameof(GetMinimumLevelOverrideInheritanceTestCases))]
         public void WriteToLoggerWithConfigCallbackMinimumLevelOverrideInheritanceScenarios(
             string rootOverrideSource,
             int rootOverrideLevelIncrement,
@@ -285,61 +252,9 @@ namespace Serilog.Tests.Core
                 Assert.Null(evt);
             }
         }
-
-
+        
         [Theory]
-        // Visualizing the pipeline from left to right ....
-        //
-        //   Event  --> Root Logger --> Child Logger -> YES or
-        //    lvl       override/lvl    override/levl     NO ?
-        //
-        // numbers are relative to incoming event level
-        // Information + 1 = Warning
-        // Information - 1 = Debug
-        //
-        // Incoming event is Information
-        // with SourceContext Root.N1.N2
-        //
-        // - default case - no overrides
-        [InlineData(null, 0, null, 0, true)]
-        // - root overrides with level lower or equal to event
-        // ... and child logger is out of the way
-        [InlineData("Root", +0, null, +0, true)]
-        [InlineData("Root", -1, null, +0, true)]
-        [InlineData("Root.N1", +0, null, +0, true)]
-        [InlineData("Root.N1", -1, null, +0, true)]
-        [InlineData("Root.N1.N2", +0, null, +0, true)]
-        [InlineData("Root.N1.N2", -1, null, +0, true)]
-        // - root overrides on irrelevant namespaces
-        [InlineData("xx", +1, null, +0, true)]
-        [InlineData("Root.xx", +1, null, +0, true)]
-        [InlineData("Root.N1.xx", +1, null, +0, true)]
-        // - child overrides on irrelevant namespaces
-        [InlineData(null, +0, "xx", +1, true)]
-        [InlineData(null, +0, "Root.xx", +1, true)]
-        [InlineData(null, +1, "Root.N1.xx", +1, true)]
-        // - root overrides prevent all processing from children
-        // even though children would happily accept it
-        [InlineData("Root", +1, null, +0, false)]
-        [InlineData("Root", +1, "Root", +0, false)]
-        [InlineData("Root.N1", +1, null, +0, false)]
-        [InlineData("Root.N1", +1, "Root.N1", +0, false)]
-        [InlineData("Root.N1.N2", +1, null, +0, false)]
-        [InlineData("Root.N1.N2", +1, "Root.N1.N2", +0, false)]
-        // - no root overrides but children has its own
-        [InlineData(null, +0, "Root", +1, false)]
-        [InlineData(null, +0, "Root.N1", +1, false)]
-        [InlineData(null, +0, "Root.N1.N2", +1, false)]
-        // - root overrides let it through but child rejects it
-        [InlineData("Root", +0, "Root", +1, false)]
-        [InlineData("Root.N1", +0, "Root", +1, false)]
-        [InlineData("Root.N1.N2", +0, "Root", +1, false)]
-        [InlineData("Root", +0, "Root.N1", +1, false)]
-        [InlineData("Root.N1", +0, "Root.N1", +1, false)]
-        [InlineData("Root.N1.N2", +0, "Root.N1", +1, false)]
-        [InlineData("Root", +0, "Root.N1.N2", +1, false)]
-        [InlineData("Root.N1", +0, "Root.N1.N2", +1, false)]
-        [InlineData("Root.N1.N2", +0, "Root.N1.N2", +1, false)]
+        [MemberData(nameof(GetMinimumLevelOverrideInheritanceTestCases))]
         public void WriteToLoggerMinimumLevelOverrideInheritanceScenarios(
             string rootOverrideSource,
             int rootOverrideLevelIncrement,

--- a/test/Serilog.Tests/Core/ChildLoggerTests.cs
+++ b/test/Serilog.Tests/Core/ChildLoggerTests.cs
@@ -1,5 +1,4 @@
 ﻿using Serilog.Core;
-using Serilog.Core.Sinks;
 using Serilog.Events;
 using Serilog.Tests.Support;
 using Xunit;
@@ -211,6 +210,20 @@ namespace Serilog.Tests.Core
         [InlineData("Root.N1", +1, "Root.N1", +0, false)]
         [InlineData("Root.N1.N2", +1, null, +0, false)]
         [InlineData("Root.N1.N2", +1, "Root.N1.N2", +0, false)]
+        // - no root overrides but children has its own
+        [InlineData(null, +0, "Root", +1, false)]
+        [InlineData(null, +0, "Root.N1", +1, false)]
+        [InlineData(null, +0, "Root.N1.N2", +1, false)]
+        // - root overrides let it through but child rejects it
+        [InlineData("Root", +0, "Root", +1, false)]
+        [InlineData("Root.N1", +0, "Root", +1, false)]
+        [InlineData("Root.N1.N2", +0, "Root", +1, false)]
+        [InlineData("Root", +0, "Root.N1", +1, false)]
+        [InlineData("Root.N1", +0, "Root.N1", +1, false)]
+        [InlineData("Root.N1.N2", +0, "Root.N1", +1, false)]
+        [InlineData("Root", +0, "Root.N1.N2", +1, false)]
+        [InlineData("Root.N1", +0, "Root.N1.N2", +1, false)]
+        [InlineData("Root.N1.N2", +0, "Root.N1.N2", +1, false)]
         public void WriteToLoggerWithConfigCallbackMinimumLevelOverrideInheritanceScenarios(
             string rootOverrideSource,
             int rootOverrideLevelIncrement,

--- a/test/Serilog.Tests/Core/OverrideRestrictingSinkTests.cs
+++ b/test/Serilog.Tests/Core/OverrideRestrictingSinkTests.cs
@@ -1,0 +1,51 @@
+﻿using System.Collections.Generic;
+using Serilog.Core;
+using Serilog.Core.Sinks;
+using Serilog.Events;
+using Serilog.Tests.Support;
+using Xunit;
+using static Serilog.Events.LogEventLevel;
+
+namespace Serilog.Tests.Core
+{
+    public class OverrideRestrictingSinkTests
+    {
+        [Theory]
+        [InlineData("Whatever", Verbose, true)]
+        [InlineData("Whatever.Sub", Verbose, true)]
+        [InlineData("Whatever.Sub.Sub", Verbose, true)]
+        [InlineData("Fatal", Fatal, true)]
+        [InlineData("Fatal", Error, false)]
+        [InlineData("Fatal.Sub", Fatal, true)]
+        [InlineData("Fatal.Sub", Error, false)]
+        [InlineData("Fatal.Error", Error, true)]
+        [InlineData("Fatal.Error", Warning, false)]
+        [InlineData("Fatal.Error.Sub", Error, true)]
+        [InlineData("Fatal.Error.Sub", Warning, false)]
+        public void OverridesAreTakenIntoAccount(string context, LogEventLevel level, bool shouldBeEmitted)
+        {
+            var overides = new Dictionary<string, LoggingLevelSwitch>
+            {
+                ["Fatal"] = new LoggingLevelSwitch(Fatal),
+                ["Fatal.Error"] = new LoggingLevelSwitch(Error),
+            };
+            LogEvent emitted = null;
+            var sut = new OverrideRestrictingSink(
+                new DelegatingSink(e => emitted = e),
+                overrides: overides);
+
+            var evt = Some.LogEvent(context, level: level);
+
+            sut.Emit(evt);
+
+            if (shouldBeEmitted)
+            {
+                Assert.NotNull(emitted);
+            }
+            else
+            {
+                Assert.Null(emitted);
+            }
+        }
+    }
+}

--- a/test/Serilog.Tests/Core/OverrideRestrictingSinkTests.cs
+++ b/test/Serilog.Tests/Core/OverrideRestrictingSinkTests.cs
@@ -24,7 +24,7 @@ namespace Serilog.Tests.Core
         [InlineData("Fatal.Error.Sub", Warning, false)]
         public void OverridesAreTakenIntoAccount(string context, LogEventLevel level, bool shouldBeEmitted)
         {
-            var overides = new Dictionary<string, LoggingLevelSwitch>
+            var overrides = new Dictionary<string, LoggingLevelSwitch>
             {
                 ["Fatal"] = new LoggingLevelSwitch(Fatal),
                 ["Fatal.Error"] = new LoggingLevelSwitch(Error),
@@ -32,7 +32,7 @@ namespace Serilog.Tests.Core
             LogEvent emitted = null;
             var sut = new OverrideRestrictingSink(
                 new DelegatingSink(e => emitted = e),
-                overrides: overides);
+                overrides: overrides);
 
             var evt = Some.LogEvent(context, level: level);
 

--- a/test/Serilog.Tests/Core/SecondaryLoggerSinkTests.cs
+++ b/test/Serilog.Tests/Core/SecondaryLoggerSinkTests.cs
@@ -89,5 +89,46 @@ namespace Serilog.Tests.Core
 
             Assert.Equal(0, sink.Events.Count);
         }
+
+        [Fact]
+        public void Issue967_ChildLoggersCanHaveMinimumLevelOverrides()
+        {
+            var sink = new CollectingSink();
+            var logger = new LoggerConfiguration()
+                .MinimumLevel.Information()
+                .WriteTo.Logger(lc => lc
+                    .MinimumLevel.Information()
+                    .MinimumLevel.Override("Serilog.Tests", LogEventLevel.Error)
+                    .WriteTo.Sink(sink))
+                .CreateLogger();
+
+            logger.Write(Some.InformationEvent());
+            logger.Write(Some.LogEvent(level: LogEventLevel.Error));
+
+            var contextLogger = logger.ForContext<LoggerConfigurationTests>();
+            contextLogger.Write(Some.InformationEvent());
+            contextLogger.Write(Some.LogEvent(level: LogEventLevel.Error));
+
+            Assert.Equal(3, sink.Events.Count);
+        }
+
+        [Fact]
+        public void ChildLoggerCanHaveMinimumLevelOverrides()
+        {
+            var sink = new CollectingSink();
+
+            var logger = new LoggerConfiguration()
+                .MinimumLevel.Debug()
+                .WriteTo.Logger(lc => lc
+                    .MinimumLevel.Override("Microsoft", LogEventLevel.Information)
+                    .WriteTo.Sink(sink))
+                .CreateLogger();
+
+            logger.ForContext(Constants.SourceContextPropertyName, "Microsoft.Foo").Write(Some.DebugEvent());
+            Assert.Equal(0, sink.Events.Count);
+
+            logger.ForContext(Constants.SourceContextPropertyName, "Microsoft.Foo").Write(Some.InformationEvent());
+            Assert.Equal(1, sink.Events.Count);
+        }
     }
 }

--- a/test/Serilog.Tests/Support/Some.cs
+++ b/test/Serilog.Tests/Support/Some.cs
@@ -1,7 +1,9 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading;
+using Serilog.Core;
 using Serilog.Events;
 using Serilog.Parsing;
 
@@ -39,6 +41,13 @@ namespace Serilog.Tests.Support
         public static DateTimeOffset OffsetInstant()
         {
             return new DateTimeOffset(Instant());
+        }
+
+        public static LogEvent LogEvent(string sourceContext, DateTimeOffset? timestamp = null, LogEventLevel level = LogEventLevel.Information)
+        {
+            return new LogEvent(timestamp ?? OffsetInstant(), level,
+                null, MessageTemplate(),
+                new List<LogEventProperty> { new LogEventProperty(Constants.SourceContextPropertyName, new ScalarValue(sourceContext)) });
         }
 
         public static LogEvent LogEvent(DateTimeOffset? timestamp = null, LogEventLevel level = LogEventLevel.Information)

--- a/test/Serilog.Tests/Support/TemporarySelfLog.cs
+++ b/test/Serilog.Tests/Support/TemporarySelfLog.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using Serilog.Debugging;
+
+namespace Serilog.Tests.Support
+{
+    public class TemporarySelfLog : IDisposable
+    {
+        TemporarySelfLog(Action<string> output)
+        {
+            SelfLog.Enable(output);
+        }
+
+        public void Dispose()
+        {
+            SelfLog.Disable();
+        }
+
+        public static IDisposable SaveTo(List<string> target)
+        {
+            if (target == null) throw new ArgumentNullException(nameof(target));
+            return new TemporarySelfLog(target.Add);
+        }
+    }
+}


### PR DESCRIPTION
**What issue does this PR address?**
Issue #967 

**Does this PR introduce a breaking change?**
It shouldn't ! 
It does introduce new types / new constructor overrides, but they are maked as internal.

**Please check if the PR fulfills these requirements**
- [x] The commit follows our [guidelines](https://github.com/serilog/serilog/blob/dev/CONTRIBUTING.md)
- [x] Unit Tests for the changes have been added (for bug fixes / features)

**Other information**:
All the tests pass, but there is definitely room for improvement :)
