### PR TITLE
Add test to prove proper support for TimeSpan in AppSettings

### DIFF
--- a/test/Serilog.Tests/Settings/SettingValueConversionsTests.cs
+++ b/test/Serilog.Tests/Settings/SettingValueConversionsTests.cs
@@ -1,4 +1,5 @@
-﻿using Serilog.Events;
+﻿using System;
+using Serilog.Events;
 using Serilog.Formatting;
 using Serilog.Formatting.Json;
 using Serilog.Settings.KeyValuePairs;
@@ -48,6 +49,22 @@ namespace Serilog.Tests.Settings
         {
             var result = SettingValueConversions.ConvertToType("Serilog.Formatting.Json.JsonFormatter", typeof(ITextFormatter));
             Assert.IsType<JsonFormatter>(result);
+        }
+
+        [Theory]
+        [InlineData("3.14:21:18.986", 3 /*days*/, 14 /*hours*/, 21 /*min*/, 18 /*sec*/, 986 /*ms*/)]
+        [InlineData("4", 4, 0, 0, 0, 0)] // minimal : days
+        [InlineData("2:0", 0, 2, 0, 0, 0)] // minimal hours
+        [InlineData("0:5", 0, 0, 5, 0, 0)] // minimal minutes
+        [InlineData("0:0:7", 0, 0, 0, 7, 0)] // minimal seconds
+        [InlineData("0:0:0.2", 0, 0, 0, 0, 200)] // minimal milliseconds
+        public void TimeSpanValuesCanBeParsed(string input, int expDays, int expHours, int expMin, int expSec, int expMs)
+        {
+            var expectedTimeSpan = new TimeSpan(expDays, expHours, expMin, expSec, expMs);
+            var actual = SettingValueConversions.ConvertToType(input, typeof(TimeSpan));
+
+            Assert.IsType<TimeSpan>(actual);
+            Assert.Equal(expectedTimeSpan, actual);
         }
     }
 }


### PR DESCRIPTION
**What issue does this PR address?**
The initial goal was to provide support for arguments of type `TimeSpan` in serilog-settings-appsettings (see issue serilog/serilog-settings-appsettings#9) .... But it turns out it is already supported, so I'll just contribute the tests that prove it :)

**Does this PR introduce a breaking change?**
Nope. Only tests !

**Please check if the PR fulfills these requirements**
- [x] The commit follows our [guidelines](https://github.com/serilog/serilog/blob/dev/CONTRIBUTING.md)
- [x] Unit Tests for the changes have been added (for bug fixes / features)

**Other information**:
maybe the treatment for `TimeSpan` should be added to the documentation somewhere