### PR TITLE
Allow combination of settings from multiple sources

### DIFF
--- a/src/Serilog/Core/SettingsSourceBuilderExtensions.cs
+++ b/src/Serilog/Core/SettingsSourceBuilderExtensions.cs
@@ -1,0 +1,86 @@
+﻿// Copyright 2013-2017 Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using Serilog.Settings;
+
+// in this namespace so they appear when using LoggerConfiguration extension methods
+namespace Serilog
+{
+    /// <summary>
+    /// Extensions to allow combining settings from a sequence of key-value settings.
+    /// </summary>
+    public static class SettingsSourceBuilderExtensions
+    {
+        /// <summary>
+        /// Adds a series of key-value settings to the combined configuration
+        /// </summary>
+        /// <param name="self">the builder</param>
+        /// <param name="keyValuePairs">the key-value pairs to add</param>
+        /// <returns>the builder object to allow chaining</returns>
+        public static ISettingsSourceBuilder AddKeyValuePairs(this ISettingsSourceBuilder self,
+            IEnumerable<KeyValuePair<string, string>> keyValuePairs)
+        {
+            if (self == null) throw new ArgumentNullException(nameof(self));
+            var source = new ConstantSettingsSource(keyValuePairs);
+            return self.AddSource(source);
+        }
+
+        /// <summary>
+        /// Adds a single key-value setting to the combined configuration
+        /// </summary>
+        /// <param name="self">the builder</param>
+        /// <param name="kvp">a key-value setting</param>
+        /// <returns>the builder object to allow chaining</returns>
+        public static ISettingsSourceBuilder AddKeyValuePair(this ISettingsSourceBuilder self,
+            KeyValuePair<string, string> kvp)
+        {
+            if (self == null) throw new ArgumentNullException(nameof(self));
+            var source = new ConstantSettingsSource(new[] { kvp });
+            return self.AddSource(source);
+        }
+
+        /// <summary>
+        /// Adds a single key-value setting to the combined configuration
+        /// </summary>
+        /// <param name="self">the builder</param>
+        /// <param name="key">the key of the setting</param>
+        /// <param name="value">the value of the setting</param>
+        /// <returns>the builder object to allow chaining</returns>
+        public static ISettingsSourceBuilder AddKeyValuePair(this ISettingsSourceBuilder self,
+            string key, string value)
+        {
+            if (self == null) throw new ArgumentNullException(nameof(self));
+            if (key == null) throw new ArgumentNullException(nameof(key));
+            var source = new ConstantSettingsSource(new[] { new KeyValuePair<string, string>(key, value) });
+            return self.AddSource(source);
+        }
+
+        /// <summary>
+        /// Adds a source of settings defined as a function to be called later on
+        /// </summary>
+        /// <param name="self">the builder</param>
+        /// <param name="keyValuePairSource">a function that can provided key-value pairs</param>
+        /// <returns>the builder object to allow chaining</returns>
+        public static ISettingsSourceBuilder AddFunc(this ISettingsSourceBuilder self,
+            Func<IEnumerable<KeyValuePair<string, string>>> keyValuePairSource)
+        {
+            if (self == null) throw new ArgumentNullException(nameof(self));
+            if (keyValuePairSource == null) throw new ArgumentNullException(nameof(keyValuePairSource));
+            var source = new DelegatingSettingsSource(keyValuePairSource);
+            return self.AddSource(source);
+        }
+    }
+}

--- a/src/Serilog/Settings/CombinedSettingsSource.cs
+++ b/src/Serilog/Settings/CombinedSettingsSource.cs
@@ -1,0 +1,52 @@
+﻿// Copyright 2013-2017 Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Serilog.Settings
+{
+    class CombinedSettingsSource : ISettingsSource, ISettingsSourceBuilder
+    {
+        List<ISettingsSource> SettingsSources { get; } = new List<ISettingsSource>();
+
+        internal CombinedSettingsSource()
+        {
+        }
+
+        internal CombinedSettingsSource(IEnumerable<ISettingsSource> sources)
+        {
+            SettingsSources.AddRange(sources);
+        }
+
+        public ISettingsSourceBuilder AddSource(ISettingsSource settingSource)
+        {
+            if (settingSource == null) throw new ArgumentNullException(nameof(settingSource));
+            SettingsSources.Add(settingSource);
+            return this;
+        }
+
+        IEnumerable<KeyValuePair<string, string>> ISettingsSource.GetKeyValuePairs()
+        {
+            var result = new Dictionary<string, string>();
+            foreach (var kvp in SettingsSources.SelectMany(x => x.GetKeyValuePairs()))
+            {
+                result[kvp.Key] = kvp.Value;
+            }
+            return result;
+
+        }
+    }
+}

--- a/src/Serilog/Settings/ConstantSettingsSource.cs
+++ b/src/Serilog/Settings/ConstantSettingsSource.cs
@@ -1,0 +1,35 @@
+﻿// Copyright 2013-2017 Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+
+namespace Serilog.Settings
+{
+    class ConstantSettingsSource : ISettingsSource
+    {
+        IEnumerable<KeyValuePair<string, string>> _keyValuePairs;
+
+        public ConstantSettingsSource(IEnumerable<KeyValuePair<string, string>> keyValuePairs)
+        {
+            if (keyValuePairs == null) throw new ArgumentNullException(nameof(keyValuePairs));
+            _keyValuePairs = keyValuePairs;
+        }
+
+        public IEnumerable<KeyValuePair<string, string>> GetKeyValuePairs()
+        {
+            return _keyValuePairs;
+        }
+    }
+}

--- a/src/Serilog/Settings/DelegatingSettingsSource.cs
+++ b/src/Serilog/Settings/DelegatingSettingsSource.cs
@@ -1,0 +1,34 @@
+﻿// Copyright 2013-2017 Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+
+namespace Serilog.Settings
+{
+    class DelegatingSettingsSource : ISettingsSource
+    {
+        readonly Func<IEnumerable<KeyValuePair<string, string>>> _source;
+
+        public DelegatingSettingsSource(Func<IEnumerable<KeyValuePair<string, string>>> source)
+        {
+            _source = source ?? throw new ArgumentNullException(nameof(source));
+        }
+
+        public IEnumerable<KeyValuePair<string, string>> GetKeyValuePairs()
+        {
+            return _source();
+        }
+    }
+}

--- a/src/Serilog/Settings/ISettingsSource.cs
+++ b/src/Serilog/Settings/ISettingsSource.cs
@@ -1,0 +1,30 @@
+﻿// Copyright 2013-2017 Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Collections.Generic;
+
+namespace Serilog.Settings
+{
+    /// <summary>
+    /// The core interface for a source of key-value settings to define a <see cref="LoggerConfiguration"/>
+    /// </summary>
+    public interface ISettingsSource
+    {
+        /// <summary>
+        /// Retrieves the key-value settings defined by this source.
+        /// </summary>
+        /// <returns>A sequence of key-value settings</returns>
+        IEnumerable<KeyValuePair<string, string>> GetKeyValuePairs();
+    }
+}

--- a/src/Serilog/Settings/ISettingsSourceBuilder.cs
+++ b/src/Serilog/Settings/ISettingsSourceBuilder.cs
@@ -1,0 +1,29 @@
+﻿// Copyright 2013-2017 Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Serilog.Settings
+{
+    /// <summary>
+    /// A builder that allows to combine sources of key-value settings in a fluent way.
+    /// </summary>
+    public interface ISettingsSourceBuilder
+    {
+        /// <summary>
+        /// Adds a <see cref="ISettingsSource"/> after the already defined sources to the combined source
+        /// </summary>
+        /// <param name="settingSource">a source of key-value settings</param>
+        /// <returns>a <see cref="ISettingsSourceBuilder"/> with the added source to allow chaining</returns>
+        ISettingsSourceBuilder AddSource(ISettingsSource settingSource);
+    }
+}

--- a/src/Serilog/Settings/KeyValuePairs/KeyValuePairSettings.cs
+++ b/src/Serilog/Settings/KeyValuePairs/KeyValuePairSettings.cs
@@ -73,21 +73,22 @@ namespace Serilog.Settings.KeyValuePairs
             [typeof(LoggerFilterConfiguration)] = lc => lc.Filter
         };
 
-        readonly Dictionary<string, string> _settings;
+        readonly ISettingsSource _settingsSource;
 
-        public KeyValuePairSettings(IEnumerable<KeyValuePair<string, string>> settings)
+        public KeyValuePairSettings(ISettingsSource settingsSource)
         {
-            if (settings == null) throw new ArgumentNullException(nameof(settings));
-            _settings = settings.ToDictionary(s => s.Key, s => s.Value);
+            if (settingsSource == null) throw new ArgumentNullException(nameof(settingsSource));
+            _settingsSource = settingsSource;
         }
 
         public void Configure(LoggerConfiguration loggerConfiguration)
         {
             if (loggerConfiguration == null) throw new ArgumentNullException(nameof(loggerConfiguration));
+            var settings = _settingsSource.GetKeyValuePairs().ToDictionary(x => x.Key, x => x.Value);
 
-            var directives = _settings.Keys
+            var directives = settings.Keys
                 .Where(k => _supportedDirectives.Any(k.StartsWith))
-                .ToDictionary(k => k, k => _settings[k]);
+                .ToDictionary(k => k, k => settings[k]);
 
             var declaredLevelSwitches = ParseNamedLevelSwitchDeclarationDirectives(directives);
 

--- a/src/Serilog/Settings/SettingsSource.cs
+++ b/src/Serilog/Settings/SettingsSource.cs
@@ -1,0 +1,56 @@
+﻿using System;
+// Copyright 2013-2017 Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Collections.Generic;
+
+namespace Serilog.Settings
+{
+    /// <summary>
+    /// A basic implementation of ISettingsSource that can be use as a starting point for other implementations.
+    /// </summary>
+    public class SettingsSource : ISettingsSource
+    {
+        List<KeyValuePair<string, string>> _keyValuePairs = new List<KeyValuePair<string, string>>();
+
+        /// <summary>
+        /// Adds a key-value pair to the source
+        /// </summary>
+        /// <param name="key">the key</param>
+        /// <param name="value">the value</param>
+        public void AddKeyValuePair(string key, string value)
+        {
+            this.AddKeyValuePair(new KeyValuePair<string, string>(key, value));
+        }
+
+        /// <summary>
+        /// Adds a key-value pair to the source
+        /// </summary>
+        /// <param name="keyValuePair">a key-value pair</param>
+        public void AddKeyValuePair(KeyValuePair<string, string> keyValuePair)
+        {
+            if (keyValuePair.Key == null) throw new ArgumentNullException($"{nameof(keyValuePair)}.{nameof(keyValuePair.Key)}");
+            _keyValuePairs.Add(keyValuePair);
+        }
+
+        /// <summary>
+        /// Retrives the key value pairs
+        /// </summary>
+        /// <returns></returns>
+        public IEnumerable<KeyValuePair<string, string>> GetKeyValuePairs()
+        {
+            return _keyValuePairs;
+        }
+    }
+}

--- a/test/Serilog.Tests/Settings/CombinedSettingsSourceTests.cs
+++ b/test/Serilog.Tests/Settings/CombinedSettingsSourceTests.cs
@@ -1,0 +1,44 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Serilog.Settings;
+using Serilog.Tests.Support;
+using Xunit;
+
+namespace Serilog.Tests.Settings
+{
+    public class CombinedSettingsSourceTests
+    {
+        [Fact]
+        public void BuilderCombinesDifferentSources()
+        {
+            var source1 = new ConstantSettingsSource(new Dictionary<string, string>
+                {
+                    { "minimum-level", "Error"},
+                    { "enrich:with-property:Enriched1", "Enrichement1"}
+                });
+
+            var source2 = new ConstantSettingsSource(new Dictionary<string, string>
+            {
+                { "minimum-level", "Information"}
+            });
+
+            var source3 = new ConstantSettingsSource(new Dictionary<string, string>
+            {
+                { "enrich:with-property:Enriched2", "Enrichement2"}
+            });
+
+            ISettingsSource combinedSource = new CombinedSettingsSource(new [] {source1, source2, source3});
+            
+            var keyValuePairs = combinedSource.GetKeyValuePairs().ToList();
+
+            var expected = new Dictionary<string, string>()
+            {
+                { "minimum-level", "Information"},
+                { "enrich:with-property:Enriched1", "Enrichement1"},
+                { "enrich:with-property:Enriched2", "Enrichement2"},
+            }.ToList();
+
+            Assert.Equal(expected, keyValuePairs, new KeyValuePairComparer<string, string>());
+        }
+    }
+}

--- a/test/Serilog.Tests/Settings/SettingsSourceBuilderTest.cs
+++ b/test/Serilog.Tests/Settings/SettingsSourceBuilderTest.cs
@@ -1,0 +1,91 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using Serilog.Events;
+using Serilog.Tests.Support;
+using Xunit;
+
+namespace Serilog.Tests.Settings
+{
+    public class SettingsSourceBuilderTest
+    {
+        [Fact]
+        public void CombinedCanMergeMultipleKeyValuePairLists()
+        {
+            LogEvent evt = null;
+            var log = new LoggerConfiguration()
+                .ReadFrom.Combined(builder => builder
+                    .AddKeyValuePairs(new Dictionary<string, string>
+                    {
+                        {"enrich:with-property:UntouchedProp", "initialValue"},
+                        {"enrich:with-property:OverridenProp", "initialValue"},
+                    })
+                    .AddKeyValuePairs(new Dictionary<string, string>
+                    {
+                        {"enrich:with-property:OverridenProp", "overridenValue"},
+                        {"enrich:with-property:NewProp", "value"},
+                    }))
+                .WriteTo.Sink(new DelegatingSink(e => evt = e))
+                .CreateLogger();
+
+            log.Information("a message that should be enriched with properties");
+
+            Assert.NotNull(evt);
+            Assert.Equal("initialValue", evt.Properties["UntouchedProp"].LiteralValue());
+            Assert.Equal("overridenValue", evt.Properties["OverridenProp"].LiteralValue());
+            Assert.Equal("value", evt.Properties["NewProp"].LiteralValue());
+        }
+
+        [Fact]
+        public void CombinedCanMergeMultipleKeyValuePairs()
+        {
+            LogEvent evt = null;
+            var log = new LoggerConfiguration()
+                .ReadFrom.Combined(builder => builder
+                    .AddKeyValuePair("enrich:with-property:UntouchedProp", "initialValue")
+                    .AddKeyValuePair("enrich:with-property:OverridenProp", "initialValue")
+                    .AddKeyValuePair("enrich:with-property:NewProp", "value")
+                    .AddKeyValuePair(new KeyValuePair<string, string>("enrich:with-property:OverridenProp", "overridenValue"))
+                    )
+                .WriteTo.Sink(new DelegatingSink(e => evt = e))
+                .CreateLogger();
+
+            log.Information("a message that should be enriched with properties");
+
+            Assert.NotNull(evt);
+            Assert.Equal("initialValue", evt.Properties["UntouchedProp"].LiteralValue());
+            Assert.Equal("overridenValue", evt.Properties["OverridenProp"].LiteralValue());
+            Assert.Equal("value", evt.Properties["NewProp"].LiteralValue());
+        }
+
+        [Fact]
+        public void CombinedCanMergeKeyValuePairsFromFunctions()
+        {
+            IEnumerable<KeyValuePair<string, string>> Func1()
+            {
+                yield return new KeyValuePair<string, string>("enrich:with-property:UntouchedProp", "initialValue");
+                yield return new KeyValuePair<string, string>("enrich:with-property:OverridenProp", "initialValue");
+            }
+
+            IEnumerable<KeyValuePair<string, string>> Func2()
+            {
+                yield return new KeyValuePair<string, string>("enrich:with-property:OverridenProp", "overridenValue");
+                yield return new KeyValuePair<string, string>("enrich:with-property:NewProp", "value");
+            }
+
+            LogEvent evt = null;
+            var log = new LoggerConfiguration()
+                .ReadFrom.Combined(builder => builder
+                    .AddFunc(Func1)
+                    .AddFunc(Func2))
+                .WriteTo.Sink(new DelegatingSink(e => evt = e))
+                .CreateLogger();
+
+            log.Information("a message that should be enriched with properties");
+
+            Assert.NotNull(evt);
+            Assert.Equal("initialValue", evt.Properties["UntouchedProp"].LiteralValue());
+            Assert.Equal("overridenValue", evt.Properties["OverridenProp"].LiteralValue());
+            Assert.Equal("value", evt.Properties["NewProp"].LiteralValue());
+        }
+    }
+}

--- a/test/Serilog.Tests/Settings/SettingsSourceTests.cs
+++ b/test/Serilog.Tests/Settings/SettingsSourceTests.cs
@@ -1,0 +1,59 @@
+﻿using System.Collections.Generic;
+using Serilog.Events;
+using Serilog.Settings;
+using Serilog.Tests.Support;
+using Xunit;
+
+namespace Serilog.Tests.Settings
+{
+    public class SettingsSourceTests
+    {
+        [Fact]
+        public void SourceCanProcessKeyValuePairsFromSource()
+        {
+            LogEvent evt = null;
+            var log = new LoggerConfiguration()
+                .ReadFrom.Source(new ConstantSettingsSource(
+                    new Dictionary<string, string>
+                    {
+                        {"enrich:with-property:SomeProp", "initialValue"},
+                    }))
+                .WriteTo.Sink(new DelegatingSink(e => evt = e))
+                .CreateLogger();
+
+            log.Information("a message that should be enriched with properties");
+
+            Assert.NotNull(evt);
+            Assert.Equal("initialValue", evt.Properties["SomeProp"].LiteralValue());
+        }
+
+        [Fact]
+        public void SourcesCanCombineKeyValuePairsFromMulltipleSources()
+        {
+            LogEvent evt = null;
+            var source1 = new ConstantSettingsSource(
+                new Dictionary<string, string>
+                {
+                    {"enrich:with-property:UntouchedProp", "initialValue"},
+                    {"enrich:with-property:OverridenProp", "initialValue"},
+                });
+            var source2 = new ConstantSettingsSource(
+                new Dictionary<string, string>
+                {
+                    {"enrich:with-property:OverridenProp", "overridenValue"},
+                    {"enrich:with-property:NewProp", "value"},
+                });
+            var log = new LoggerConfiguration()
+                .ReadFrom.Sources(source1, source2)
+                .WriteTo.Sink(new DelegatingSink(e => evt = e))
+                .CreateLogger();
+
+            log.Information("a message that should be enriched with properties");
+
+            Assert.NotNull(evt);
+            Assert.Equal("initialValue", evt.Properties["UntouchedProp"].LiteralValue());
+            Assert.Equal("overridenValue", evt.Properties["OverridenProp"].LiteralValue());
+            Assert.Equal("value", evt.Properties["NewProp"].LiteralValue());
+        }
+    }
+}

--- a/test/Serilog.Tests/Support/KeyValuePairComparer.cs
+++ b/test/Serilog.Tests/Support/KeyValuePairComparer.cs
@@ -1,0 +1,18 @@
+﻿using System.Collections.Generic;
+
+namespace Serilog.Tests.Support
+{
+    public class KeyValuePairComparer<TK, TValue> : IEqualityComparer<KeyValuePair<TK, TValue>>
+    {
+        public bool Equals(KeyValuePair<TK, TValue> x, KeyValuePair<TK, TValue> y)
+        {
+            return x.Key.Equals(y.Key) && x.Value.Equals(y.Value);
+        }
+
+        public int GetHashCode(KeyValuePair<TK, TValue> obj)
+        {
+            return obj.GetHashCode();
+        }
+    }
+
+}


### PR DESCRIPTION
**What issue does this PR address?**
This is a first step regarding the combination of multiple sources of key-value settings, to allow finer control over those settings

**Does this PR introduce a breaking change?**
No. No existing public signature was changed (only additions)

**Please check if the PR fulfills these requirements**
- [x] The commit follows our [guidelines](https://github.com/serilog/serilog/blob/dev/CONTRIBUTING.md)
- [x] Unit Tests for the changes have been added (for bug fixes / features)

**Other information**:
First part towards #1028
- Introduces ISettingsSource to define a source of key-value settings
- Updates KeyValuePairSettings to rely on ISettingsSource
- Adds ReadFrom.Source / ReadFrom.Sources
- Introduces ISettingsSourceBuilder
- Introduces ReadFrom.Combined(Func<ISettingsSourceBuilder, ISettingsSourceBuilder>) to allow for fluent combination of sources
- Introduces SettingsSourceBuilderExtensions to support AddKeyValuePairs / AddKeyValuePair / AddFunc
