### PR TITLE
Make Resharper green again

### DIFF
--- a/Serilog.sln.DotSettings
+++ b/Serilog.sln.DotSettings
@@ -50,6 +50,7 @@
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=PossibleNullReferenceException/@EntryIndexedValue">WARNING</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=PossibleUnintendedReferenceComparison/@EntryIndexedValue">HINT</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=PrivateFieldCanBeConvertedToLocalVariable/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RedundantArgumentDefaultValue/@EntryIndexedValue">SUGGESTION</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RedundantAssignment/@EntryIndexedValue">ERROR</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RedundantBaseConstructorCall/@EntryIndexedValue">ERROR</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RedundantBoolCompare/@EntryIndexedValue">ERROR</s:String>

--- a/src/Serilog/Capturing/PropertyValueConverter.cs
+++ b/src/Serilog/Capturing/PropertyValueConverter.cs
@@ -247,6 +247,7 @@ namespace Serilog.Capturing
                 definition == typeof(ValueTuple<,,,,>) || definition == typeof(ValueTuple<,,,,,>) ||
                 definition == typeof(ValueTuple<,,,,,,>))
 #else
+            // ReSharper disable once PossibleNullReferenceException
             var defn = definition.FullName;
             if (defn == "System.ValueTuple`1" || defn == "System.ValueTuple`2" ||
                 defn == "System.ValueTuple`3" || defn == "System.ValueTuple`4" ||

--- a/src/Serilog/Context/LogContext.cs
+++ b/src/Serilog/Context/LogContext.cs
@@ -254,6 +254,8 @@ namespace Serilog.Context
             public override object InitializeLifetimeService()
             {
                 var lease = (ILease)base.InitializeLifetimeService();
+                // ReSharper disable once PossibleNullReferenceException
+                // not 100% sure this will never occur ...
                 lease.Register(LifeTimeSponsor);
                 return lease;
             }

--- a/src/Serilog/Core/Pipeline/MessageTemplateCache.cs
+++ b/src/Serilog/Core/Pipeline/MessageTemplateCache.cs
@@ -51,6 +51,8 @@ namespace Serilog.Core.Pipeline
                 return _innerParser.Parse(messageTemplate);
 
 #if HASHTABLE
+            // ReSharper disable once InconsistentlySynchronizedField
+            // ignored warning because this is by design
             var result = (MessageTemplate)_templates[messageTemplate];
             if (result != null)
                 return result;

--- a/src/Serilog/Settings/KeyValuePairs/KeyValuePairSettings.cs
+++ b/src/Serilog/Settings/KeyValuePairs/KeyValuePairSettings.cs
@@ -148,7 +148,7 @@ namespace Serilog.Settings.KeyValuePairs
 
             if (callableDirectives.Any())
             {
-                var configurationAssemblies = LoadConfigurationAssemblies(directives);
+                var configurationAssemblies = LoadConfigurationAssemblies(directives).ToList();
 
                 foreach (var receiverGroup in callableDirectives.GroupBy(d => d.ReceiverType))
                 {

--- a/test/Serilog.Tests/Capturing/PropertyValueConverterTests.cs
+++ b/test/Serilog.Tests/Capturing/PropertyValueConverterTests.cs
@@ -24,7 +24,7 @@ namespace Serilog.Tests.Capturing
         [Fact]
         public async Task MaximumDepthIsEffectiveAndThreadSafe()
         {
-            var _converter = new PropertyValueConverter(3, 1000, 1000, Enumerable.Empty<Type>(), Enumerable.Empty<IDestructuringPolicy>(), false);
+            var converter = new PropertyValueConverter(3, 1000, 1000, Enumerable.Empty<Type>(), Enumerable.Empty<IDestructuringPolicy>(), false);
 
             var barrier = new Barrier(participantCount: 3);
 
@@ -63,7 +63,7 @@ namespace Serilog.Tests.Capturing
                 {
                     barrier.SignalAndWait();
 
-                    var propValue = _converter.CreatePropertyValue(logObject, true);
+                    var propValue = converter.CreatePropertyValue(logObject, true);
 
                     Assert.IsType<StructureValue>(propValue);
 

--- a/test/Serilog.Tests/Context/LogContextTests.cs
+++ b/test/Serilog.Tests/Context/LogContextTests.cs
@@ -31,7 +31,9 @@ namespace Serilog.Tests.Context
         public LogContextTests()
         {
 #if REMOTING
+            // ReSharper disable AssignNullToNotNullAttribute
             CallContext.LogicalSetData(typeof(LogContext).FullName, null);
+            // ReSharper restore AssignNullToNotNullAttribute
 #endif
         }
 
@@ -266,7 +268,9 @@ namespace Serilog.Tests.Context
             {
                 domain = AppDomain.CreateDomain("LogContextTests", null, AppDomain.CurrentDomain.SetupInformation);
 
+                // ReSharper disable AssignNullToNotNullAttribute
                 var callable = (RemotelyCallable)domain.CreateInstanceAndUnwrap(typeof(RemotelyCallable).Assembly.FullName, typeof(RemotelyCallable).FullName);
+                // ReSharper restore AssignNullToNotNullAttribute
 
                 using (LogContext.PushProperty("Anything", 1001))
                     Assert.True(callable.IsCallable());

--- a/test/Serilog.Tests/MethodOverloadConventionTests.cs
+++ b/test/Serilog.Tests/MethodOverloadConventionTests.cs
@@ -305,9 +305,7 @@ namespace Serilog.Tests
             Assert.Equal(parameter.Name, "level");
             Assert.Equal(parameter.ParameterType, typeof(LogEventLevel));
 
-            CollectingSink sink;
-
-            var logger = GetLogger(loggerType, out sink, LogEventLevel.Information);
+            var logger = GetLogger(loggerType, out _, LogEventLevel.Information);
 
             var falseResult = InvokeMethod(method, logger, new object[] { LogEventLevel.Verbose });
 
@@ -761,10 +759,7 @@ namespace Serilog.Tests
 
         static void InvokeConventionMethod(MethodInfo method, Type[] typeArgs, object[] parameters)
         {
-            CollectingSink sink;
-            LogEventLevel level;
-
-            InvokeConventionMethod(method, typeArgs, parameters, out level, out sink);
+            InvokeConventionMethod(method, typeArgs, parameters, out _, out _);
         }
 
         static void InvokeConventionMethodAndTest(MethodInfo method, Type[] typeArgs, object[] parameters)
@@ -901,9 +896,7 @@ namespace Serilog.Tests
 
         static ILogger GetLogger(Type loggerType)
         {
-            CollectingSink sink;
-
-            return GetLogger(loggerType, out sink);
+            return GetLogger(loggerType, out _);
         }
 
         static ILogger GetLogger(Type loggerType, out CollectingSink sink, LogEventLevel level = LogEventLevel.Verbose)

--- a/test/Serilog.Tests/MethodOverloadConventionTests.cs
+++ b/test/Serilog.Tests/MethodOverloadConventionTests.cs
@@ -501,6 +501,7 @@ namespace Serilog.Tests
             TestForContextResult(method, logger, normalResult: enrichedLogger);
         }
 
+        // ReSharper disable once ParameterOnlyUsedForPreconditionCheck.Local
         void TestForContextResult(MethodInfo method, ILogger logger, object normalResult)
         {
             Assert.NotNull(normalResult);
@@ -884,6 +885,7 @@ namespace Serilog.Tests
             return method.Invoke(instance, parameters);
         }
 
+        // ReSharper disable once ParameterOnlyUsedForPreconditionCheck.Local
         static void EvaluateSingleResult(LogEventLevel level, CollectingSink results)
         {
             //evaluate single log event

--- a/test/Serilog.Tests/Parsing/MessageTemplateParserTests.cs
+++ b/test/Serilog.Tests/Parsing/MessageTemplateParserTests.cs
@@ -11,6 +11,7 @@ namespace Serilog.Tests.Parsing
             return new MessageTemplateParser().Parse(messsageTemplate).Tokens.ToArray();
         }
 
+        // ReSharper disable once ParameterOnlyUsedForPreconditionCheck.Local
         static void AssertParsedAs(string message, params MessageTemplateToken[] messageTemplateTokens)
         {
             var parsed = Parse(message);

--- a/test/Serilog.Tests/Settings/KeyValuePairSettingsTests.cs
+++ b/test/Serilog.Tests/Settings/KeyValuePairSettingsTests.cs
@@ -313,12 +313,14 @@ namespace Serilog.Tests.Settings
             systemLogger.Write(Some.WarningEvent());
             Assert.False(evt is null, "LoggingLevelSwitch initial level was Warning for logger System.*. It should log Warning messages for SourceContext System.Bar");
 
+            // ReSharper disable HeuristicUnreachableCode
             evt = null;
             var controlSwitch = DummyWithLevelSwitchSink.ControlLevelSwitch;
 
             controlSwitch.MinimumLevel = LogEventLevel.Information;
             systemLogger.Write(Some.InformationEvent());
             Assert.False(evt is null, "LoggingLevelSwitch level was changed to Information for logger System.*. It should now log Information events for SourceContext System.Bar.");
+            // ReSharper restore HeuristicUnreachableCode
         }
 
     }

--- a/test/Serilog.Tests/Settings/SettingValueConversionsTests.cs
+++ b/test/Serilog.Tests/Settings/SettingValueConversionsTests.cs
@@ -33,8 +33,8 @@ namespace Serilog.Tests.Settings
         [Fact]
         public void ValuesConvertToNullableTimeSpan()
         {
-            var result = (System.TimeSpan?)SettingValueConversions.ConvertToType("00:01:00", typeof(System.TimeSpan?));
-            Assert.Equal(System.TimeSpan.FromMinutes(1), result);
+            var result = (TimeSpan?)SettingValueConversions.ConvertToType("00:01:00", typeof(TimeSpan?));
+            Assert.Equal(TimeSpan.FromMinutes(1), result);
         }
 
         [Fact]

--- a/test/TestDummies/DummyRollingFileAuditSink.cs
+++ b/test/TestDummies/DummyRollingFileAuditSink.cs
@@ -8,7 +8,9 @@ namespace TestDummies
     public class DummyRollingFileAuditSink : ILogEventSink
     {
         [ThreadStatic]
+        // ReSharper disable ThreadStaticFieldHasInitializer
         public static List<LogEvent> Emitted = new List<LogEvent>();
+        // ReSharper restore ThreadStaticFieldHasInitializer
 
         public void Emit(LogEvent logEvent)
         {

--- a/test/TestDummies/DummyRollingFileSink.cs
+++ b/test/TestDummies/DummyRollingFileSink.cs
@@ -8,7 +8,9 @@ namespace TestDummies
     public class DummyRollingFileSink : ILogEventSink
     {
         [ThreadStatic]
+        // ReSharper disable ThreadStaticFieldHasInitializer
         public static List<LogEvent> Emitted = new List<LogEvent>();
+        // ReSharper restore ThreadStaticFieldHasInitializer
 
         public void Emit(LogEvent logEvent)
         {

--- a/test/TestDummies/DummyWithLevelSwitchSink.cs
+++ b/test/TestDummies/DummyWithLevelSwitchSink.cs
@@ -16,7 +16,9 @@ namespace TestDummies
         public static LoggingLevelSwitch ControlLevelSwitch;
 
         [ThreadStatic]
+        // ReSharper disable ThreadStaticFieldHasInitializer
         public static List<LogEvent> Emitted = new List<LogEvent>();
+        // ReSharper restore ThreadStaticFieldHasInitializer
 
         public void Emit(LogEvent logEvent)
         {

--- a/test/TestDummies/DummyWrappingSink.cs
+++ b/test/TestDummies/DummyWrappingSink.cs
@@ -8,7 +8,9 @@ namespace TestDummies
     public class DummyWrappingSink : ILogEventSink
     {
         [ThreadStatic]
+        // ReSharper disable ThreadStaticFieldHasInitializer
         public static List<LogEvent> Emitted = new List<LogEvent>();
+        // ReSharper restore ThreadStaticFieldHasInitializer
 
         private readonly ILogEventSink _sink;
 


### PR DESCRIPTION
**What issue does this PR address?**
Get rid of errors and warnings reported by ReSharper Solution-wide analysis

**Does this PR introduce a breaking change?**
Nope

**Please check if the PR fulfills these requirements**
- [x] The commit follows our [guidelines](https://github.com/serilog/serilog/blob/dev/CONTRIBUTING.md)
- *N/A* Unit Tests for the changes have been added (for bug fixes / features)

**Other information**:
Before : 
![before-resharper-cleanup](https://user-images.githubusercontent.com/160544/31598054-dfb23678-b24b-11e7-8b06-92666493f295.PNG)

After : 
![after-resharper-cleanup](https://user-images.githubusercontent.com/160544/31598064-e5ebaf88-b24b-11e7-9017-0d9bb632b442.PNG)


There are still some warnings; but I was not sure how to fix them : 
```
Solution Serilog.sln
    Project Serilog
      src\Serilog\Capturing\PropertyValueConverter.cs:250 Possible 'System.NullReferenceException'
      src\Serilog\Capturing\PropertyValueConverter.cs:250 Possible 'System.NullReferenceException'
      src\Serilog\Context\LogContext.cs:257 Possible 'System.NullReferenceException'
      src\Serilog\Core\Pipeline\MessageTemplateCache.cs:54 The field is sometimes used inside synchronized block and sometimes used without synchronization
      src\Serilog\Core\Pipeline\MessageTemplateCache.cs:54 The field is sometimes used inside synchronized block and sometimes used without synchronization
      src\Serilog\Core\Pipeline\MessageTemplateCache.cs:54 The field is sometimes used inside synchronized block and sometimes used without synchronization
```