### PR TITLE
Hardening of KeyValuePairSettings

### DIFF
--- a/src/Serilog/Settings/KeyValuePairs/KeyValuePairSettings.cs
+++ b/src/Serilog/Settings/KeyValuePairs/KeyValuePairSettings.cs
@@ -164,6 +164,7 @@ namespace Serilog.Settings.KeyValuePairs
         internal static IReadOnlyDictionary<string, string> ExtractDirectives(IEnumerable<KeyValuePair<string, string>> keyValuePairs)
         {
             var directives = keyValuePairs
+                .Where(kvp => kvp.Key != null)
                 .Where(kvp => _supportedDirectives.Any(kvp.Key.StartsWith))
                 .ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
 

--- a/src/Serilog/Settings/KeyValuePairs/KeyValuePairSettings.cs
+++ b/src/Serilog/Settings/KeyValuePairs/KeyValuePairSettings.cs
@@ -83,11 +83,8 @@ namespace Serilog.Settings.KeyValuePairs
         public void Configure(LoggerConfiguration loggerConfiguration)
         {
             if (loggerConfiguration == null) throw new ArgumentNullException(nameof(loggerConfiguration));
-
-            var settings = _settings.ToDictionary(s => s.Key, s => s.Value);
-            var directives = settings.Keys
-                .Where(k => _supportedDirectives.Any(k.StartsWith))
-                .ToDictionary(k => k, k => settings[k]);
+            
+            var directives = ExtractDirectives(_settings);
 
             var declaredLevelSwitches = ParseNamedLevelSwitchDeclarationDirectives(directives);
 
@@ -162,6 +159,16 @@ namespace Serilog.Settings.KeyValuePairs
                     ApplyDirectives(calls, methods, CallableDirectiveReceivers[receiverGroup.Key](loggerConfiguration), declaredLevelSwitches);
                 }
             }
+        }
+
+        internal static Dictionary<string, string> ExtractDirectives(IEnumerable<KeyValuePair<string, string>> keyValuePairs)
+        {
+            var settings = keyValuePairs.ToDictionary(s => s.Key, s => s.Value);
+            var directives = settings.Keys
+                .Where(k => _supportedDirectives.Any(k.StartsWith))
+                .ToDictionary(k => k, k => settings[k]);
+
+            return directives;
         }
 
         internal static bool IsValidSwitchName(string input)

--- a/src/Serilog/Settings/KeyValuePairs/KeyValuePairSettings.cs
+++ b/src/Serilog/Settings/KeyValuePairs/KeyValuePairSettings.cs
@@ -161,13 +161,13 @@ namespace Serilog.Settings.KeyValuePairs
             }
         }
 
-        internal static Dictionary<string, string> ExtractDirectives(IEnumerable<KeyValuePair<string, string>> keyValuePairs)
+        internal static IReadOnlyDictionary<string, string> ExtractDirectives(IEnumerable<KeyValuePair<string, string>> keyValuePairs)
         {
             var directives = keyValuePairs
                 .Where(kvp => _supportedDirectives.Any(kvp.Key.StartsWith))
                 .ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
 
-            return directives;
+            return new ReadOnlyDictionary<string, string>(directives);
         }
 
         internal static bool IsValidSwitchName(string input)
@@ -175,7 +175,7 @@ namespace Serilog.Settings.KeyValuePairs
             return Regex.IsMatch(input, LevelSwitchNameRegex);
         }
 
-        static IReadOnlyDictionary<string, LoggingLevelSwitch> ParseNamedLevelSwitchDeclarationDirectives(Dictionary<string, string> directives)
+        static IReadOnlyDictionary<string, LoggingLevelSwitch> ParseNamedLevelSwitchDeclarationDirectives(IReadOnlyDictionary<string, string> directives)
         {
             var matchLevelSwitchDeclarations = new Regex(LevelSwitchDeclarationDirectiveRegex);
 
@@ -261,7 +261,7 @@ namespace Serilog.Settings.KeyValuePairs
                 .FirstOrDefault();
         }
 
-        internal static IEnumerable<Assembly> LoadConfigurationAssemblies(Dictionary<string, string> directives)
+        internal static IEnumerable<Assembly> LoadConfigurationAssemblies(IReadOnlyDictionary<string, string> directives)
         {
             var configurationAssemblies = new List<Assembly> { typeof(ILogger).GetTypeInfo().Assembly };
 

--- a/src/Serilog/Settings/KeyValuePairs/KeyValuePairSettings.cs
+++ b/src/Serilog/Settings/KeyValuePairs/KeyValuePairSettings.cs
@@ -73,21 +73,21 @@ namespace Serilog.Settings.KeyValuePairs
             [typeof(LoggerFilterConfiguration)] = lc => lc.Filter
         };
 
-        readonly Dictionary<string, string> _settings;
+        readonly IEnumerable<KeyValuePair<string, string>> _settings;
 
         public KeyValuePairSettings(IEnumerable<KeyValuePair<string, string>> settings)
         {
-            if (settings == null) throw new ArgumentNullException(nameof(settings));
-            _settings = settings.ToDictionary(s => s.Key, s => s.Value);
+            _settings = settings ?? throw new ArgumentNullException(nameof(settings));
         }
 
         public void Configure(LoggerConfiguration loggerConfiguration)
         {
             if (loggerConfiguration == null) throw new ArgumentNullException(nameof(loggerConfiguration));
 
-            var directives = _settings.Keys
+            var settings = _settings.ToDictionary(s => s.Key, s => s.Value);
+            var directives = settings.Keys
                 .Where(k => _supportedDirectives.Any(k.StartsWith))
-                .ToDictionary(k => k, k => _settings[k]);
+                .ToDictionary(k => k, k => settings[k]);
 
             var declaredLevelSwitches = ParseNamedLevelSwitchDeclarationDirectives(directives);
 

--- a/src/Serilog/Settings/KeyValuePairs/KeyValuePairSettings.cs
+++ b/src/Serilog/Settings/KeyValuePairs/KeyValuePairSettings.cs
@@ -163,10 +163,9 @@ namespace Serilog.Settings.KeyValuePairs
 
         internal static Dictionary<string, string> ExtractDirectives(IEnumerable<KeyValuePair<string, string>> keyValuePairs)
         {
-            var settings = keyValuePairs.ToDictionary(s => s.Key, s => s.Value);
-            var directives = settings.Keys
-                .Where(k => _supportedDirectives.Any(k.StartsWith))
-                .ToDictionary(k => k, k => settings[k]);
+            var directives = keyValuePairs
+                .Where(kvp => _supportedDirectives.Any(kvp.Key.StartsWith))
+                .ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
 
             return directives;
         }

--- a/test/Serilog.Tests/Settings/KeyValuePairSettingsTests.cs
+++ b/test/Serilog.Tests/Settings/KeyValuePairSettingsTests.cs
@@ -16,6 +16,41 @@ namespace Serilog.Tests.Settings
     public class KeyValuePairSettingsTests
     {
         [Fact]
+        public void KeyValuePairsEnumerableAreNotConsumedUntilConfigureIsCalled()
+        {
+            int enumerableConsumeCount = 0;
+            IEnumerable<KeyValuePair<string, string>> GetKeyValuePairs()
+            {
+                enumerableConsumeCount++;
+                yield return new KeyValuePair<string, string>("foo", "bar");
+            }
+
+            var settings = new KeyValuePairSettings(GetKeyValuePairs());
+            Assert.Equal(0, enumerableConsumeCount);
+
+            settings.Configure(new LoggerConfiguration());
+            Assert.Equal(1, enumerableConsumeCount);
+        }
+
+        [Fact]
+        public void DuplicateKeysCauseException()
+        {
+            IEnumerable<KeyValuePair<string, string>> GetKeyValuePairs()
+            {
+                yield return new KeyValuePair<string, string>("prop1", "initialValue");
+                yield return new KeyValuePair<string, string>("prop2", "initialValue");
+                yield return new KeyValuePair<string, string>("prop1", "overridenValue");
+            }
+
+            var settings = new KeyValuePairSettings(GetKeyValuePairs());
+
+            Action action = () => settings.Configure(new LoggerConfiguration());
+            var ex = Assert.ThrowsAny<Exception>(action);
+            Assert.NotNull(ex);
+            Assert.Contains("An item with the same key has already been added.", ex.Message);
+        }
+
+        [Fact]
         public void FindsConfigurationAssemblies()
         {
             var configurationAssemblies = KeyValuePairSettings.LoadConfigurationAssemblies(new Dictionary<string, string>()).ToList();
@@ -181,7 +216,7 @@ namespace Serilog.Tests.Settings
                 ["level-switch:switchNameNotStartingWithDollar"] = "Warning",
             };
 
-            var ex = Assert.Throws<FormatException>(() =>  new LoggerConfiguration()
+            var ex = Assert.Throws<FormatException>(() => new LoggerConfiguration()
                 .ReadFrom.KeyValuePairs(settings));
 
             Assert.Contains("\"switchNameNotStartingWithDollar\"", ex.Message);
@@ -301,7 +336,7 @@ namespace Serilog.Tests.Settings
                 .CreateLogger();
 
             var systemLogger = log.ForContext(Constants.SourceContextPropertyName, "System.Bar");
-            
+
             log.Write(Some.InformationEvent());
             Assert.False(evt is null, "Minimul level is Debug. It should log Information messages");
 

--- a/test/Serilog.Tests/Settings/KeyValuePairSettingsTests.cs
+++ b/test/Serilog.Tests/Settings/KeyValuePairSettingsTests.cs
@@ -37,17 +37,29 @@ namespace Serilog.Tests.Settings
         {
             IEnumerable<KeyValuePair<string, string>> GetKeyValuePairs()
             {
-                yield return new KeyValuePair<string, string>("prop1", "initialValue");
-                yield return new KeyValuePair<string, string>("prop2", "initialValue");
-                yield return new KeyValuePair<string, string>("prop1", "overridenValue");
+                yield return new KeyValuePair<string, string>("minimum-level", "Debug");
+                yield return new KeyValuePair<string, string>("minimum-level:override:System", "Warning");
+                yield return new KeyValuePair<string, string>("minimum-level", "Information");
             }
 
-            var settings = new KeyValuePairSettings(GetKeyValuePairs());
-
-            Action action = () => settings.Configure(new LoggerConfiguration());
+            Action action = () => KeyValuePairSettings.ExtractDirectives(GetKeyValuePairs());
             var ex = Assert.ThrowsAny<Exception>(action);
             Assert.NotNull(ex);
             Assert.Contains("An item with the same key has already been added.", ex.Message);
+        }
+
+        [Fact]
+        public void IrrelevantKeysAreIgnored()
+        {
+            IEnumerable<KeyValuePair<string, string>> GetKeyValuePairs()
+            {
+                yield return new KeyValuePair<string, string>("whatever:foo:bar", "willBeIgnored");
+                yield return new KeyValuePair<string, string>("irrelevant", "willBeIgnored");
+            }
+
+            var directives = KeyValuePairSettings.ExtractDirectives(GetKeyValuePairs());
+
+            Assert.False(directives.Any());
         }
 
         [Fact]

--- a/test/Serilog.Tests/Settings/KeyValuePairSettingsTests.cs
+++ b/test/Serilog.Tests/Settings/KeyValuePairSettingsTests.cs
@@ -63,6 +63,19 @@ namespace Serilog.Tests.Settings
         }
 
         [Fact]
+        public void NullKeysAreIgnored()
+        {
+            IEnumerable<KeyValuePair<string, string>> GetKeyValuePairs()
+            {
+                yield return new KeyValuePair<string, string>(null, "willBeIgnored");
+            }
+
+            var directives = KeyValuePairSettings.ExtractDirectives(GetKeyValuePairs());
+
+            Assert.False(directives.Any());
+        }
+
+        [Fact]
         public void FindsConfigurationAssemblies()
         {
             var configurationAssemblies = KeyValuePairSettings.LoadConfigurationAssemblies(new Dictionary<string, string>()).ToList();


### PR DESCRIPTION
**What issue does this PR address?**
Harden / Refactor `KeyValuePairSettings` as a preparation for adding extensions on top of it

- Made KeyValuePairSettings consume the `IEnumerable<KeyValuePair<string,string>>` only when `Configure` is called
- Ignored KeyValuePairs with a `null` key
- Added tests about exception that can be thrown

**Does this PR introduce a breaking change?**
No

**Please check if the PR fulfills these requirements**
- [x] The commit follows our [guidelines](https://github.com/serilog/serilog/blob/dev/CONTRIBUTING.md)
- [x] Unit Tests for the changes have been added (for bug fixes / features)

**Other information**:
