### PR TITLE
KeyValuePairSettings - IReadOnlyDictionary / latest setting win

### DIFF
--- a/src/Serilog/Configuration/LoggerSettingsConfiguration.cs
+++ b/src/Serilog/Configuration/LoggerSettingsConfiguration.cs
@@ -14,7 +14,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using System.Linq;
 using Serilog.Settings.KeyValuePairs;
 

--- a/src/Serilog/Configuration/LoggerSettingsConfiguration.cs
+++ b/src/Serilog/Configuration/LoggerSettingsConfiguration.cs
@@ -50,11 +50,21 @@ namespace Serilog.Configuration
         /// </summary>
         /// <param name="settings">A list of key-value pairs describing logger settings.</param>
         /// <returns>Configuration object allowing method chaining.</returns>
+        /// <remarks>In case of duplicate keys, the last value for the key is kept and the previous ones are ignored.</remarks>
         public LoggerConfiguration KeyValuePairs(IEnumerable<KeyValuePair<string, string>> settings)
         {
             if (settings == null) throw new ArgumentNullException(nameof(settings));
+            var uniqueSettings = new Dictionary<string, string>();
+            foreach (var kvp in settings)
+            {
+                uniqueSettings[kvp.Key] = kvp.Value;
+            }
+            return KeyValuePairs(uniqueSettings);
+        }
 
-            return Settings(new KeyValuePairSettings(settings.ToDictionary(x => x.Key, x => x.Value)));
+        LoggerConfiguration KeyValuePairs(IReadOnlyDictionary<string, string> settings)
+        {
+            return Settings(new KeyValuePairSettings(settings));
         }
     }
 }

--- a/src/Serilog/Configuration/LoggerSettingsConfiguration.cs
+++ b/src/Serilog/Configuration/LoggerSettingsConfiguration.cs
@@ -14,6 +14,8 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
 using Serilog.Settings.KeyValuePairs;
 
 namespace Serilog.Configuration
@@ -52,7 +54,9 @@ namespace Serilog.Configuration
         public LoggerConfiguration KeyValuePairs(IEnumerable<KeyValuePair<string, string>> settings)
         {
             if (settings == null) throw new ArgumentNullException(nameof(settings));
-            return Settings(new KeyValuePairSettings(settings));
+
+            var settingsDictionary = new ReadOnlyDictionary<string, string>(settings.ToDictionary(x => x.Key, x => x.Value));
+            return Settings(new KeyValuePairSettings(settingsDictionary));
         }
     }
 }

--- a/src/Serilog/Configuration/LoggerSettingsConfiguration.cs
+++ b/src/Serilog/Configuration/LoggerSettingsConfiguration.cs
@@ -55,8 +55,7 @@ namespace Serilog.Configuration
         {
             if (settings == null) throw new ArgumentNullException(nameof(settings));
 
-            var settingsDictionary = new ReadOnlyDictionary<string, string>(settings.ToDictionary(x => x.Key, x => x.Value));
-            return Settings(new KeyValuePairSettings(settingsDictionary));
+            return Settings(new KeyValuePairSettings(settings.ToDictionary(x => x.Key, x => x.Value)));
         }
     }
 }

--- a/src/Serilog/Settings/KeyValuePairs/KeyValuePairSettings.cs
+++ b/src/Serilog/Settings/KeyValuePairs/KeyValuePairSettings.cs
@@ -14,7 +14,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using System.Linq;
 using System.Reflection;
 using System.Text.RegularExpressions;
@@ -203,7 +202,7 @@ namespace Serilog.Settings.KeyValuePairs
                 }
                 namedSwitches.Add(switchName, newSwitch);
             }
-            return new ReadOnlyDictionary<string, LoggingLevelSwitch>(namedSwitches);
+            return namedSwitches;
         }
 
         static LoggingLevelSwitch LookUpSwitchByName(string switchName, IReadOnlyDictionary<string, LoggingLevelSwitch> declaredLevelSwitches)

--- a/src/Serilog/Settings/KeyValuePairs/KeyValuePairSettings.cs
+++ b/src/Serilog/Settings/KeyValuePairs/KeyValuePairSettings.cs
@@ -73,21 +73,18 @@ namespace Serilog.Settings.KeyValuePairs
             [typeof(LoggerFilterConfiguration)] = lc => lc.Filter
         };
 
-        readonly Dictionary<string, string> _settings;
+        readonly IReadOnlyDictionary<string, string> _settings;
 
-        public KeyValuePairSettings(IEnumerable<KeyValuePair<string, string>> settings)
+        public KeyValuePairSettings(IReadOnlyDictionary<string, string> settings)
         {
-            if (settings == null) throw new ArgumentNullException(nameof(settings));
-            _settings = settings.ToDictionary(s => s.Key, s => s.Value);
+            _settings = settings ?? throw new ArgumentNullException(nameof(settings));
         }
 
         public void Configure(LoggerConfiguration loggerConfiguration)
         {
             if (loggerConfiguration == null) throw new ArgumentNullException(nameof(loggerConfiguration));
-
-            var directives = _settings.Keys
-                .Where(k => _supportedDirectives.Any(k.StartsWith))
-                .ToDictionary(k => k, k => _settings[k]);
+            
+            var directives = ExtractDirectives(_settings);
 
             var declaredLevelSwitches = ParseNamedLevelSwitchDeclarationDirectives(directives);
 
@@ -164,12 +161,21 @@ namespace Serilog.Settings.KeyValuePairs
             }
         }
 
+        internal static IReadOnlyDictionary<string, string> ExtractDirectives(IReadOnlyDictionary<string, string> settings)
+        {
+            var directives = settings
+                .Where(kvp => _supportedDirectives.Any(kvp.Key.StartsWith))
+                .ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
+
+            return new ReadOnlyDictionary<string, string>(directives);
+        }
+
         internal static bool IsValidSwitchName(string input)
         {
             return Regex.IsMatch(input, LevelSwitchNameRegex);
         }
 
-        static IReadOnlyDictionary<string, LoggingLevelSwitch> ParseNamedLevelSwitchDeclarationDirectives(Dictionary<string, string> directives)
+        static IReadOnlyDictionary<string, LoggingLevelSwitch> ParseNamedLevelSwitchDeclarationDirectives(IReadOnlyDictionary<string, string> directives)
         {
             var matchLevelSwitchDeclarations = new Regex(LevelSwitchDeclarationDirectiveRegex);
 
@@ -255,7 +261,7 @@ namespace Serilog.Settings.KeyValuePairs
                 .FirstOrDefault();
         }
 
-        internal static IEnumerable<Assembly> LoadConfigurationAssemblies(Dictionary<string, string> directives)
+        internal static IEnumerable<Assembly> LoadConfigurationAssemblies(IReadOnlyDictionary<string, string> directives)
         {
             var configurationAssemblies = new List<Assembly> { typeof(ILogger).GetTypeInfo().Assembly };
 

--- a/src/Serilog/Settings/KeyValuePairs/KeyValuePairSettings.cs
+++ b/src/Serilog/Settings/KeyValuePairs/KeyValuePairSettings.cs
@@ -83,8 +83,10 @@ namespace Serilog.Settings.KeyValuePairs
         public void Configure(LoggerConfiguration loggerConfiguration)
         {
             if (loggerConfiguration == null) throw new ArgumentNullException(nameof(loggerConfiguration));
-            
-            var directives = ExtractDirectives(_settings);
+
+            var directives = _settings
+                .Where(kvp => _supportedDirectives.Any(kvp.Key.StartsWith))
+                .ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
 
             var declaredLevelSwitches = ParseNamedLevelSwitchDeclarationDirectives(directives);
 
@@ -159,15 +161,6 @@ namespace Serilog.Settings.KeyValuePairs
                     ApplyDirectives(calls, methods, CallableDirectiveReceivers[receiverGroup.Key](loggerConfiguration), declaredLevelSwitches);
                 }
             }
-        }
-
-        internal static IReadOnlyDictionary<string, string> ExtractDirectives(IReadOnlyDictionary<string, string> settings)
-        {
-            var directives = settings
-                .Where(kvp => _supportedDirectives.Any(kvp.Key.StartsWith))
-                .ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
-
-            return new ReadOnlyDictionary<string, string>(directives);
         }
 
         internal static bool IsValidSwitchName(string input)

--- a/test/Serilog.Tests/Settings/KeyValuePairSettingsTests.cs
+++ b/test/Serilog.Tests/Settings/KeyValuePairSettingsTests.cs
@@ -28,21 +28,7 @@ namespace Serilog.Tests.Settings
             var ex = Assert.ThrowsAny<ArgumentException>(action);
             Assert.NotNull(ex);
             Assert.Contains("An item with the same key has already been added.", ex.Message);
-        }
-
-        [Fact]
-        public void IrrelevantKeysAreIgnored()
-        {
-            var irrelevantSettings = new Dictionary<string, string>()
-            {
-                ["whatever:foo:bar"] = "willBeIgnored",
-                ["irrelevant"] = "willBeIgnored",
-            };
-
-            var directives = KeyValuePairSettings.ExtractDirectives(irrelevantSettings);
-
-            Assert.False(directives.Any());
-        }
+        }        
 
         [Fact]
         public void FindsConfigurationAssemblies()

--- a/test/Serilog.Tests/Settings/KeyValuePairSettingsTests.cs
+++ b/test/Serilog.Tests/Settings/KeyValuePairSettingsTests.cs
@@ -321,14 +321,14 @@ namespace Serilog.Tests.Settings
             Assert.False(evt is null, "Minimul level is Debug. It should log Information messages");
 
             evt = null;
-
+            // ReSharper disable HeuristicUnreachableCode
             systemLogger.Write(Some.InformationEvent());
             Assert.True(evt is null, "LoggingLevelSwitch initial level was Warning for logger System.*. It should not log Information messages for SourceContext System.Bar");
 
             systemLogger.Write(Some.WarningEvent());
             Assert.False(evt is null, "LoggingLevelSwitch initial level was Warning for logger System.*. It should log Warning messages for SourceContext System.Bar");
 
-            // ReSharper disable HeuristicUnreachableCode
+            
             evt = null;
             var controlSwitch = DummyWithLevelSwitchSink.ControlLevelSwitch;
 


### PR DESCRIPTION
new PR based on discussion https://github.com/serilog/serilog/pull/1047#issuecomment-338544876 .

Make `KeyValuePairSettings` accept a `IReadOnlyDictionary<string, string>` instead of a `IEnumerable<KeyValuePair<string, string>>` to make it more obvious that : 
- it is not consuming the key-value pairs lazily
- it expects unique keys
- it will not touch the contents of the provided dictionary

This has no impact on the public API given that class `KeyValuePairSettings` is `internal`.

This PR also adds a few tests around the edge cases