### PR TITLE
Add support for abstract class parameters in settings

### DIFF
--- a/src/Serilog/Settings/KeyValuePairs/SettingValueConversions.cs
+++ b/src/Serilog/Settings/KeyValuePairs/SettingValueConversions.cs
@@ -51,7 +51,7 @@ namespace Serilog.Settings.KeyValuePairs
             if (convertor != null)
                 return convertor(value);
 
-            if (toTypeInfo.IsInterface && !string.IsNullOrWhiteSpace(value))
+            if ((toTypeInfo.IsInterface || toTypeInfo.IsAbstract) && !string.IsNullOrWhiteSpace(value))
             {
                 var type = Type.GetType(value.Trim(), throwOnError: false);
                 if (type != null)

--- a/test/Serilog.Tests/Settings/SettingValueConversionsTests.cs
+++ b/test/Serilog.Tests/Settings/SettingValueConversionsTests.cs
@@ -3,6 +3,7 @@ using Serilog.Events;
 using Serilog.Formatting;
 using Serilog.Formatting.Json;
 using Serilog.Settings.KeyValuePairs;
+using Serilog.Tests.Support;
 using Xunit;
 
 namespace Serilog.Tests.Settings
@@ -49,6 +50,21 @@ namespace Serilog.Tests.Settings
         {
             var result = SettingValueConversions.ConvertToType("Serilog.Formatting.Json.JsonFormatter", typeof(ITextFormatter));
             Assert.IsType<JsonFormatter>(result);
+        }
+
+        [Fact]
+        public void StringValuesConvertToDefaultInstancesIfTargetIsAbstractClass()
+        {
+            var result = SettingValueConversions.ConvertToType("Serilog.Tests.Support.DummyConcreteClassWithDefaultConstructor, Serilog.Tests", typeof(DummyAbstractClass));
+            Assert.IsType<DummyConcreteClassWithDefaultConstructor>(result);
+        }
+
+        [Fact]
+        public void StringValuesThrowsWhenMissingDefaultConstructorIfTargetIsAbstractClass()
+        {
+            var value = "Serilog.Tests.Support.DummyConcreteClassWithoutDefaultConstructor, Serilog.Tests";
+            Assert.Throws<InvalidOperationException>(() =>
+                SettingValueConversions.ConvertToType(value, typeof(DummyAbstractClass)));
         }
 
         [Theory]

--- a/test/Serilog.Tests/Support/ClassHierarchy.cs
+++ b/test/Serilog.Tests/Support/ClassHierarchy.cs
@@ -1,0 +1,23 @@
+﻿namespace Serilog.Tests.Support
+{
+
+    public abstract class DummyAbstractClass
+    {
+    }
+
+    public class DummyConcreteClassWithDefaultConstructor
+    {
+        // ReSharper disable once UnusedParameter.Local
+        public DummyConcreteClassWithDefaultConstructor(string param = "")
+        {
+        }
+    }
+
+    public class DummyConcreteClassWithoutDefaultConstructor
+    {
+        // ReSharper disable once UnusedParameter.Local
+        public DummyConcreteClassWithoutDefaultConstructor(string param)
+        {
+        }
+    }
+}


### PR DESCRIPTION
When a parameter is an abstract class, now accept the type name of a concrete subclass that has a default constructor ( the same way interfaces are supported)

**What issue does this PR address?**
Resolves #1056 
This is the equivalent of serilog/serilog-settings-configuration#74

**Does this PR introduce a breaking change?**
Nope

**Please check if the PR fulfills these requirements**
- [x] The commit follows our [guidelines](https://github.com/serilog/serilog/blob/dev/CONTRIBUTING.md)
- [x] Unit Tests for the changes have been added (for bug fixes / features)

**Other information**:
