### PR TITLE
Add support for reference to public static properties in settings

### DIFF
--- a/src/Serilog/Configuration/LoggerSettingsConfiguration.cs
+++ b/src/Serilog/Configuration/LoggerSettingsConfiguration.cs
@@ -14,7 +14,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using Serilog.Settings.KeyValuePairs;
 
 namespace Serilog.Configuration

--- a/test/Serilog.Tests/Settings/KeyValuePairSettingsTests.cs
+++ b/test/Serilog.Tests/Settings/KeyValuePairSettingsTests.cs
@@ -325,7 +325,7 @@ namespace Serilog.Tests.Settings
             var systemLogger = log.ForContext(Constants.SourceContextPropertyName, "System.Bar");
 
             log.Write(Some.InformationEvent());
-            Assert.False(evt is null, "Minimul level is Debug. It should log Information messages");
+            Assert.False(evt is null, "Minimum level is Debug. It should log Information messages");
 
             evt = null;
             // ReSharper disable HeuristicUnreachableCode

--- a/test/Serilog.Tests/Settings/KeyValuePairSettingsTests.cs
+++ b/test/Serilog.Tests/Settings/KeyValuePairSettingsTests.cs
@@ -10,6 +10,8 @@ using TestDummies;
 using Serilog.Configuration;
 using Serilog.Core;
 using Serilog.Formatting;
+using TestDummies.Console;
+using TestDummies.Console.Themes;
 
 namespace Serilog.Tests.Settings
 {
@@ -343,5 +345,41 @@ namespace Serilog.Tests.Settings
             // ReSharper restore HeuristicUnreachableCode
         }
 
+        [Fact]
+        public void SinksWithAbstractParamsAreConfiguredWithTypeName()
+        {
+            var settings = new Dictionary<string, string>
+            {
+                ["using:TestDummies"] = typeof(DummyLoggerConfigurationExtensions).GetTypeInfo().Assembly.FullName,
+                ["write-to:DummyConsole.theme"] = "Serilog.Tests.Support.CustomConsoleTheme, Serilog.Tests"
+            };
+
+            DummyConsoleSink.Theme = null;
+
+            new LoggerConfiguration()
+                .ReadFrom.KeyValuePairs(settings)
+                .CreateLogger();
+
+            Assert.NotNull(DummyConsoleSink.Theme);
+            Assert.IsType<CustomConsoleTheme>(DummyConsoleSink.Theme);
+        }
+
+        [Fact]
+        public void SinksAreConfiguredWithStaticMember()
+        {
+            var settings = new Dictionary<string, string>
+            {
+                ["using:TestDummies"] = typeof(DummyLoggerConfigurationExtensions).GetTypeInfo().Assembly.FullName,
+                ["write-to:DummyConsole.theme"] = "TestDummies.Console.Themes.ConsoleThemes::Theme1, TestDummies"
+            };
+
+            DummyConsoleSink.Theme = null;
+
+            new LoggerConfiguration()
+                .ReadFrom.KeyValuePairs(settings)
+                .CreateLogger();
+
+            Assert.Equal(ConsoleThemes.Theme1, DummyConsoleSink.Theme);
+        }
     }
 }

--- a/test/Serilog.Tests/Settings/SettingValueConversionsTests.cs
+++ b/test/Serilog.Tests/Settings/SettingValueConversionsTests.cs
@@ -82,5 +82,100 @@ namespace Serilog.Tests.Settings
             Assert.IsType<TimeSpan>(actual);
             Assert.Equal(expectedTimeSpan, actual);
         }
+
+        [Theory]
+        [InlineData("My.NameSpace.Class+InnerClass::Member",
+                    "My.NameSpace.Class+InnerClass", "Member")]
+        [InlineData("  TrimMe.NameSpace.Class::NeedsTrimming  ",
+                    "TrimMe.NameSpace.Class", "NeedsTrimming")]
+        [InlineData("My.NameSpace.Class::Member",
+                    "My.NameSpace.Class", "Member")]
+        [InlineData("My.NameSpace.Class::Member, MyAssembly",
+                    "My.NameSpace.Class, MyAssembly", "Member")]
+        [InlineData("My.NameSpace.Class::Member, MyAssembly, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
+                    "My.NameSpace.Class, MyAssembly, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089", "Member")]
+        [InlineData("Just a random string with :: in it",
+                    null, null)]
+        [InlineData("Its::a::trapWithColonsAppearingTwice",
+                    null, null)]
+        [InlineData("ThereIsNoMemberHere::",
+            null, null)]
+        [InlineData(null,
+            null, null)]
+        [InlineData(" " ,
+            null, null)]
+        public void TryParseStaticMemberAccessorReturnsExpectedResults(string input, string expectedAccessorType, string expectedPropertyName)
+        {
+            var actual = SettingValueConversions.TryParseStaticMemberAccessor(input,
+                out var actualAccessorType,
+                out var actualMemberName);
+
+            if (expectedAccessorType == null)
+            {
+                Assert.False(actual, $"Should not parse {input}");
+            }
+            else
+            {
+                Assert.True(actual, $"should successfully parse {input}");
+                Assert.Equal(expectedAccessorType, actualAccessorType);
+                Assert.Equal(expectedPropertyName, actualMemberName);
+            }
+        }
+
+        [Theory]
+        [InlineData("Serilog.Tests.Support.ClassWithStaticAccessors::StringProperty, Serilog.Tests", typeof(string), "StringProperty")]
+        [InlineData("Serilog.Tests.Support.ClassWithStaticAccessors::IntProperty, Serilog.Tests", typeof(int), 42)]
+        public void StaticMembersAccessorsCanBeUsedForSImpleTypes(string input, Type targetType, object expectedValue)
+        {
+            var actual = SettingValueConversions.ConvertToType(input, targetType);
+
+            Assert.IsAssignableFrom(targetType, actual);
+            Assert.Equal(expectedValue, actual);
+        }
+
+        [Theory]
+        [InlineData("Serilog.Tests.Support.ClassWithStaticAccessors::InterfaceProperty, Serilog.Tests", typeof(IAmAnInterface))]
+        [InlineData("Serilog.Tests.Support.ClassWithStaticAccessors::AbstractProperty, Serilog.Tests", typeof(AnAbstractClass))]
+        public void StaticMembersAccessorsCanBeUsedForReferenceTypes(string input, Type targetType)
+        {
+            var actual = SettingValueConversions.ConvertToType(input, targetType);
+
+            Assert.IsAssignableFrom(targetType, actual);
+            Assert.Equal(ConcreteImpl.Instance, actual);
+        }
+
+        [Theory]
+        // unknown type
+        [InlineData("Namespace.ThisIsNotAKnownType::StringProperty, Serilog.Tests", typeof(string))]
+        // good type name, but wrong namespace
+        [InlineData("Random.Namespace.ClassWithStaticAccessors::StringProperty, Serilog.Tests", typeof(string))]
+        // good full type name, but missing or wrong assembly
+        [InlineData("Serilog.Tests.Support.ClassWithStaticAccessors::StringProperty", typeof(string))]
+        [InlineData("Serilog.Tests.Support.ClassWithStaticAccessors::StringProperty, TestDummies", typeof(string))]
+        public void StaticAccessorOnUnknownTypeThrowsTypeLoadException(string input, Type targetType)
+        {
+            Assert.Throws<TypeLoadException>(() =>
+                SettingValueConversions.ConvertToType(input, targetType)
+            );
+        }
+
+        [Theory]
+        // unknown member
+        [InlineData("Serilog.Tests.Support.ClassWithStaticAccessors::UnknownMember, Serilog.Tests", typeof(string))]
+        // static property exists but it's private
+        [InlineData("Serilog.Tests.Support.ClassWithStaticAccessors::PrivateStringProperty, Serilog.Tests", typeof(string))]
+        // public member exists but it's a field
+        [InlineData("Serilog.Tests.Support.ClassWithStaticAccessors::StringField, Serilog.Tests", typeof(string))]
+        // public property exists but it's not static
+        [InlineData("Serilog.Tests.Support.ClassWithStaticAccessors::InstanceStringProperty, Serilog.Tests", typeof(string))]
+        public void StaticAccessorWithInvalidMemberThrowsInvalidOperationException(string input, Type targetType)
+        {
+            var exception = Assert.Throws<InvalidOperationException>(() =>
+                SettingValueConversions.ConvertToType(input, targetType)
+            );
+
+            Assert.Contains("Could not find public static property ", exception.Message);
+            Assert.Contains("on type `Serilog.Tests.Support.ClassWithStaticAccessors, Serilog.Tests`", exception.Message);
+        }
     }
 }

--- a/test/Serilog.Tests/Settings/SettingValueConversionsTests.cs
+++ b/test/Serilog.Tests/Settings/SettingValueConversionsTests.cs
@@ -125,6 +125,8 @@ namespace Serilog.Tests.Settings
         [Theory]
         [InlineData("Serilog.Tests.Support.ClassWithStaticAccessors::StringProperty, Serilog.Tests", typeof(string), "StringProperty")]
         [InlineData("Serilog.Tests.Support.ClassWithStaticAccessors::IntProperty, Serilog.Tests", typeof(int), 42)]
+        [InlineData("Serilog.Tests.Support.ClassWithStaticAccessors::StringField, Serilog.Tests", typeof(string), "StringField")]
+        [InlineData("Serilog.Tests.Support.ClassWithStaticAccessors::IntField, Serilog.Tests", typeof(int), 666)]
         public void StaticMembersAccessorsCanBeUsedForSImpleTypes(string input, Type targetType, object expectedValue)
         {
             var actual = SettingValueConversions.ConvertToType(input, targetType);
@@ -136,6 +138,8 @@ namespace Serilog.Tests.Settings
         [Theory]
         [InlineData("Serilog.Tests.Support.ClassWithStaticAccessors::InterfaceProperty, Serilog.Tests", typeof(IAmAnInterface))]
         [InlineData("Serilog.Tests.Support.ClassWithStaticAccessors::AbstractProperty, Serilog.Tests", typeof(AnAbstractClass))]
+        [InlineData("Serilog.Tests.Support.ClassWithStaticAccessors::InterfaceField, Serilog.Tests", typeof(IAmAnInterface))]
+        [InlineData("Serilog.Tests.Support.ClassWithStaticAccessors::AbstractField, Serilog.Tests", typeof(AnAbstractClass))]
         public void StaticMembersAccessorsCanBeUsedForReferenceTypes(string input, Type targetType)
         {
             var actual = SettingValueConversions.ConvertToType(input, targetType);
@@ -164,17 +168,19 @@ namespace Serilog.Tests.Settings
         [InlineData("Serilog.Tests.Support.ClassWithStaticAccessors::UnknownMember, Serilog.Tests", typeof(string))]
         // static property exists but it's private
         [InlineData("Serilog.Tests.Support.ClassWithStaticAccessors::PrivateStringProperty, Serilog.Tests", typeof(string))]
-        // public member exists but it's a field
-        [InlineData("Serilog.Tests.Support.ClassWithStaticAccessors::StringField, Serilog.Tests", typeof(string))]
+        // static field exists but it's private
+        [InlineData("Serilog.Tests.Support.ClassWithStaticAccessors::PrivateStringField, Serilog.Tests", typeof(string))]
         // public property exists but it's not static
         [InlineData("Serilog.Tests.Support.ClassWithStaticAccessors::InstanceStringProperty, Serilog.Tests", typeof(string))]
+        // public field exists but it's not static
+        [InlineData("Serilog.Tests.Support.ClassWithStaticAccessors::InstanceStringField, Serilog.Tests", typeof(string))]
         public void StaticAccessorWithInvalidMemberThrowsInvalidOperationException(string input, Type targetType)
         {
             var exception = Assert.Throws<InvalidOperationException>(() =>
                 SettingValueConversions.ConvertToType(input, targetType)
             );
 
-            Assert.Contains("Could not find public static property ", exception.Message);
+            Assert.Contains("Could not find a public static property or field ", exception.Message);
             Assert.Contains("on type `Serilog.Tests.Support.ClassWithStaticAccessors, Serilog.Tests`", exception.Message);
         }
     }

--- a/test/Serilog.Tests/Settings/SettingValueConversionsTests.cs
+++ b/test/Serilog.Tests/Settings/SettingValueConversionsTests.cs
@@ -99,10 +99,13 @@ namespace Serilog.Tests.Settings
         [InlineData("Its::a::trapWithColonsAppearingTwice",
                     null, null)]
         [InlineData("ThereIsNoMemberHere::",
-            null, null)]
+                    null, null)]
         [InlineData(null,
-            null, null)]
+                    null, null)]
         [InlineData(" " ,
+                    null, null)]
+        // a full-qualified type name should not be considered a static member accessor
+        [InlineData("My.NameSpace.Class, MyAssembly, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
             null, null)]
         public void TryParseStaticMemberAccessorReturnsExpectedResults(string input, string expectedAccessorType, string expectedPropertyName)
         {
@@ -123,19 +126,6 @@ namespace Serilog.Tests.Settings
         }
 
         [Theory]
-        [InlineData("Serilog.Tests.Support.ClassWithStaticAccessors::StringProperty, Serilog.Tests", typeof(string), "StringProperty")]
-        [InlineData("Serilog.Tests.Support.ClassWithStaticAccessors::IntProperty, Serilog.Tests", typeof(int), 42)]
-        [InlineData("Serilog.Tests.Support.ClassWithStaticAccessors::StringField, Serilog.Tests", typeof(string), "StringField")]
-        [InlineData("Serilog.Tests.Support.ClassWithStaticAccessors::IntField, Serilog.Tests", typeof(int), 666)]
-        public void StaticMembersAccessorsCanBeUsedForSImpleTypes(string input, Type targetType, object expectedValue)
-        {
-            var actual = SettingValueConversions.ConvertToType(input, targetType);
-
-            Assert.IsAssignableFrom(targetType, actual);
-            Assert.Equal(expectedValue, actual);
-        }
-
-        [Theory]
         [InlineData("Serilog.Tests.Support.ClassWithStaticAccessors::InterfaceProperty, Serilog.Tests", typeof(IAmAnInterface))]
         [InlineData("Serilog.Tests.Support.ClassWithStaticAccessors::AbstractProperty, Serilog.Tests", typeof(AnAbstractClass))]
         [InlineData("Serilog.Tests.Support.ClassWithStaticAccessors::InterfaceField, Serilog.Tests", typeof(IAmAnInterface))]
@@ -150,12 +140,12 @@ namespace Serilog.Tests.Settings
 
         [Theory]
         // unknown type
-        [InlineData("Namespace.ThisIsNotAKnownType::StringProperty, Serilog.Tests", typeof(string))]
+        [InlineData("Namespace.ThisIsNotAKnownType::InterfaceProperty, Serilog.Tests", typeof(IAmAnInterface))]
         // good type name, but wrong namespace
-        [InlineData("Random.Namespace.ClassWithStaticAccessors::StringProperty, Serilog.Tests", typeof(string))]
+        [InlineData("Random.Namespace.ClassWithStaticAccessors::InterfaceProperty, Serilog.Tests", typeof(IAmAnInterface))]
         // good full type name, but missing or wrong assembly
-        [InlineData("Serilog.Tests.Support.ClassWithStaticAccessors::StringProperty", typeof(string))]
-        [InlineData("Serilog.Tests.Support.ClassWithStaticAccessors::StringProperty, TestDummies", typeof(string))]
+        [InlineData("Serilog.Tests.Support.ClassWithStaticAccessors::InterfaceProperty", typeof(IAmAnInterface))]
+        [InlineData("Serilog.Tests.Support.ClassWithStaticAccessors::InterfaceProperty, TestDummies", typeof(IAmAnInterface))]
         public void StaticAccessorOnUnknownTypeThrowsTypeLoadException(string input, Type targetType)
         {
             Assert.Throws<TypeLoadException>(() =>
@@ -165,15 +155,15 @@ namespace Serilog.Tests.Settings
 
         [Theory]
         // unknown member
-        [InlineData("Serilog.Tests.Support.ClassWithStaticAccessors::UnknownMember, Serilog.Tests", typeof(string))]
+        [InlineData("Serilog.Tests.Support.ClassWithStaticAccessors::UnknownMember, Serilog.Tests", typeof(IAmAnInterface))]
         // static property exists but it's private
-        [InlineData("Serilog.Tests.Support.ClassWithStaticAccessors::PrivateStringProperty, Serilog.Tests", typeof(string))]
+        [InlineData("Serilog.Tests.Support.ClassWithStaticAccessors::PrivateInterfaceProperty, Serilog.Tests", typeof(IAmAnInterface))]
         // static field exists but it's private
-        [InlineData("Serilog.Tests.Support.ClassWithStaticAccessors::PrivateStringField, Serilog.Tests", typeof(string))]
+        [InlineData("Serilog.Tests.Support.ClassWithStaticAccessors::PrivateInterfaceField, Serilog.Tests", typeof(IAmAnInterface))]
         // public property exists but it's not static
-        [InlineData("Serilog.Tests.Support.ClassWithStaticAccessors::InstanceStringProperty, Serilog.Tests", typeof(string))]
+        [InlineData("Serilog.Tests.Support.ClassWithStaticAccessors::InstanceInterfaceProperty, Serilog.Tests", typeof(IAmAnInterface))]
         // public field exists but it's not static
-        [InlineData("Serilog.Tests.Support.ClassWithStaticAccessors::InstanceStringField, Serilog.Tests", typeof(string))]
+        [InlineData("Serilog.Tests.Support.ClassWithStaticAccessors::InstanceInterfaceField, Serilog.Tests", typeof(IAmAnInterface))]
         public void StaticAccessorWithInvalidMemberThrowsInvalidOperationException(string input, Type targetType)
         {
             var exception = Assert.Throws<InvalidOperationException>(() =>

--- a/test/Serilog.Tests/Support/ClassHierarchy.cs
+++ b/test/Serilog.Tests/Support/ClassHierarchy.cs
@@ -4,7 +4,7 @@
     {
     }
 
-    public class DummyConcreteClassWithDefaultConstructor
+    public class DummyConcreteClassWithDefaultConstructor : DummyAbstractClass
     {
         // ReSharper disable once UnusedParameter.Local
         public DummyConcreteClassWithDefaultConstructor(string param = "")
@@ -12,7 +12,7 @@
         }
     }
 
-    public class DummyConcreteClassWithoutDefaultConstructor
+    public class DummyConcreteClassWithoutDefaultConstructor : DummyAbstractClass
     {
         // ReSharper disable once UnusedParameter.Local
         public DummyConcreteClassWithoutDefaultConstructor(string param)

--- a/test/Serilog.Tests/Support/ClassHierarchy.cs
+++ b/test/Serilog.Tests/Support/ClassHierarchy.cs
@@ -1,6 +1,5 @@
 ﻿namespace Serilog.Tests.Support
 {
-
     public abstract class DummyAbstractClass
     {
     }

--- a/test/Serilog.Tests/Support/CustomConsoleTheme.cs
+++ b/test/Serilog.Tests/Support/CustomConsoleTheme.cs
@@ -1,0 +1,8 @@
+﻿using TestDummies.Console.Themes;
+
+namespace Serilog.Tests.Support
+{
+    class CustomConsoleTheme : ConsoleTheme
+    {
+    }
+}

--- a/test/Serilog.Tests/Support/StaticAccessorClasses.cs
+++ b/test/Serilog.Tests/Support/StaticAccessorClasses.cs
@@ -1,0 +1,35 @@
+﻿
+namespace Serilog.Tests.Support
+{
+    public interface IAmAnInterface
+    {
+
+    }
+
+    public abstract class AnAbstractClass
+    {
+
+    }
+
+    class ConcreteImpl : AnAbstractClass, IAmAnInterface
+    {
+        ConcreteImpl()
+        {
+
+        }
+
+        public static ConcreteImpl Instance { get; } = new ConcreteImpl();
+    }
+
+    public class ClassWithStaticAccessors
+    {
+        public static string StringProperty => nameof(StringProperty);
+        public static int IntProperty => 42;
+        public static IAmAnInterface InterfaceProperty => ConcreteImpl.Instance;
+        public static AnAbstractClass AbstractProperty => ConcreteImpl.Instance;
+        // ReSharper disable once UnusedMember.Local
+        static string PrivateStringProperty => nameof(PrivateStringProperty);
+        public string InstanceStringProperty => nameof(InstanceStringProperty);
+        public static string StringField = nameof(StringField);
+    }
+}

--- a/test/Serilog.Tests/Support/StaticAccessorClasses.cs
+++ b/test/Serilog.Tests/Support/StaticAccessorClasses.cs
@@ -27,9 +27,19 @@ namespace Serilog.Tests.Support
         public static int IntProperty => 42;
         public static IAmAnInterface InterfaceProperty => ConcreteImpl.Instance;
         public static AnAbstractClass AbstractProperty => ConcreteImpl.Instance;
+
+        public static string StringField = nameof(StringField);
+        public static int IntField = 666;
+        public static IAmAnInterface InterfaceField = ConcreteImpl.Instance;
+        public static AnAbstractClass AbstractField = ConcreteImpl.Instance;
+
         // ReSharper disable once UnusedMember.Local
         static string PrivateStringProperty => nameof(PrivateStringProperty);
+#pragma warning disable 169
+        static string PrivateStringField = nameof(PrivateStringField);
+#pragma warning restore 169
         public string InstanceStringProperty => nameof(InstanceStringProperty);
-        public static string StringField = nameof(StringField);
+        public string InstanceStringField = nameof(InstanceStringField);
+
     }
 }

--- a/test/Serilog.Tests/Support/StaticAccessorClasses.cs
+++ b/test/Serilog.Tests/Support/StaticAccessorClasses.cs
@@ -23,23 +23,19 @@ namespace Serilog.Tests.Support
 
     public class ClassWithStaticAccessors
     {
-        public static string StringProperty => nameof(StringProperty);
-        public static int IntProperty => 42;
         public static IAmAnInterface InterfaceProperty => ConcreteImpl.Instance;
         public static AnAbstractClass AbstractProperty => ConcreteImpl.Instance;
 
-        public static string StringField = nameof(StringField);
-        public static int IntField = 666;
         public static IAmAnInterface InterfaceField = ConcreteImpl.Instance;
         public static AnAbstractClass AbstractField = ConcreteImpl.Instance;
 
         // ReSharper disable once UnusedMember.Local
-        static string PrivateStringProperty => nameof(PrivateStringProperty);
+        static IAmAnInterface PrivateInterfaceProperty => ConcreteImpl.Instance;
 #pragma warning disable 169
-        static string PrivateStringField = nameof(PrivateStringField);
+        static IAmAnInterface PrivateInterfaceField = ConcreteImpl.Instance;
 #pragma warning restore 169
-        public string InstanceStringProperty => nameof(InstanceStringProperty);
-        public string InstanceStringField = nameof(InstanceStringField);
+        public IAmAnInterface InstanceInterfaceProperty => ConcreteImpl.Instance;
+        public IAmAnInterface InstanceInterfaceField = ConcreteImpl.Instance;
 
     }
 }

--- a/test/TestDummies/Console/DummyConsoleSink.cs
+++ b/test/TestDummies/Console/DummyConsoleSink.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using Serilog.Core;
+using Serilog.Events;
+using TestDummies.Console.Themes;
+
+namespace TestDummies.Console
+{
+    public class DummyConsoleSink : ILogEventSink
+    {
+        public DummyConsoleSink(ConsoleTheme theme = null)
+        {
+            Theme = theme ?? ConsoleTheme.None;
+        }
+
+        [ThreadStatic]
+        public static ConsoleTheme Theme;
+
+        public void Emit(LogEvent logEvent)
+        {
+        }
+    }
+
+}
+

--- a/test/TestDummies/Console/Themes/ConcreteConsoleTheme.cs
+++ b/test/TestDummies/Console/Themes/ConcreteConsoleTheme.cs
@@ -1,0 +1,6 @@
+namespace TestDummies.Console.Themes
+{
+    class ConcreteConsoleTheme : ConsoleTheme
+    {
+    }
+}

--- a/test/TestDummies/Console/Themes/ConsoleTheme.cs
+++ b/test/TestDummies/Console/Themes/ConsoleTheme.cs
@@ -1,0 +1,7 @@
+namespace TestDummies.Console.Themes
+{
+    public abstract class ConsoleTheme
+    {
+        public static ConsoleTheme None { get; } = new EmptyConsoleTheme();
+    }
+}

--- a/test/TestDummies/Console/Themes/ConsoleThemes.cs
+++ b/test/TestDummies/Console/Themes/ConsoleThemes.cs
@@ -1,0 +1,7 @@
+namespace TestDummies.Console.Themes
+{
+    public static class ConsoleThemes
+    {
+        public static ConsoleTheme Theme1 { get; } = new ConcreteConsoleTheme();
+    }
+}

--- a/test/TestDummies/Console/Themes/EmptyConsoleTheme.cs
+++ b/test/TestDummies/Console/Themes/EmptyConsoleTheme.cs
@@ -1,0 +1,6 @@
+namespace TestDummies.Console.Themes
+{
+    class EmptyConsoleTheme : ConsoleTheme
+    {
+    }
+}

--- a/test/TestDummies/DummyLoggerConfigurationExtensions.cs
+++ b/test/TestDummies/DummyLoggerConfigurationExtensions.cs
@@ -4,6 +4,8 @@ using Serilog.Events;
 using Serilog.Formatting;
 using Serilog.Configuration;
 using Serilog.Core;
+using TestDummies.Console;
+using TestDummies.Console.Themes;
 
 namespace TestDummies
 {
@@ -49,6 +51,14 @@ namespace TestDummies
             LoggingLevelSwitch controlLevelSwitch = null)
         {
             return loggerSinkConfiguration.Sink(new DummyWithLevelSwitchSink(controlLevelSwitch), restrictedToMinimumLevel);
+        }
+
+        public static LoggerConfiguration DummyConsole(
+            this LoggerSinkConfiguration loggerSinkConfiguration,
+            LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
+            ConsoleTheme theme = null)
+        {
+            return loggerSinkConfiguration.Sink(new DummyConsoleSink(theme), restrictedToMinimumLevel);
         }
 
         public static LoggerConfiguration Dummy(


### PR DESCRIPTION
as a value for parameters, using the syntax `NameSpace.To.ConcreteType::StaticProperty, AssemblyName`

**What issue does this PR address?**
resolves #1057 

**Does this PR introduce a breaking change?**
It shouldn't, although technically, there is a chance that "string" settings whose value looks like `"Namespace.To.TypeName::PropertyName"` may now be interpreted as a reference to a static property, even though I've done my best to avoid ambiguities.  

**Please check if the PR fulfills these requirements**
- [x] The commit follows our [guidelines](https://github.com/serilog/serilog/blob/dev/CONTRIBUTING.md)
- [x] Unit Tests for the changes have been added (for bug fixes / features)

**Other information**:
When / if accepted, similar code should be needed in *Serilog.Settings.Configuration* to handle issue serilog/serilog-settings-configuration#73 .