### PR TITLE
#1073 Overload Wrap() to accept LogEventLevel and LoggingLevelSwitch.

### DIFF
--- a/src/Serilog/Configuration/LoggerSinkConfiguration.cs
+++ b/src/Serilog/Configuration/LoggerSinkConfiguration.cs
@@ -173,10 +173,33 @@ namespace Serilog.Configuration
         /// added in <paramref name="configureWrappedSink"/>.</param>
         /// <param name="configureWrappedSink">An action that configures sinks to be wrapped in <paramref name="wrapSink"/>.</param>
         /// <returns>Configuration object allowing method chaining.</returns>
+        [Obsolete("Please use `LoggerConfiguration.Wrap(loggerSinkConfiguration, wrapSink, configureWrappedSink, restrictedToMinimumLevel, levelSwitch)` instead.")]
         public static LoggerConfiguration Wrap(
             LoggerSinkConfiguration loggerSinkConfiguration,
             Func<ILogEventSink, ILogEventSink> wrapSink,
             Action<LoggerSinkConfiguration> configureWrappedSink)
+        {
+            return LoggerSinkConfiguration.Wrap(loggerSinkConfiguration, wrapSink, configureWrappedSink, LogEventLevel.Verbose, null);
+        }
+
+        /// <summary>
+        /// Helper method for wrapping sinks.
+        /// </summary>
+        /// <param name="loggerSinkConfiguration">The parent sink configuration.</param>
+        /// <param name="wrapSink">A function that allows for wrapping <see cref="ILogEventSink"/>s
+        /// added in <paramref name="configureWrappedSink"/>.</param>
+        /// <param name="configureWrappedSink">An action that configures sinks to be wrapped in <paramref name="wrapSink"/>.</param>
+        /// <param name="restrictedToMinimumLevel">The minimum level for
+        /// events passed through the sink. Ignored when <paramref name="levelSwitch"/> is specified.</param>
+        /// <param name="levelSwitch">A switch allowing the pass-through minimum level
+        /// to be changed at runtime.</param>
+        /// <returns>Configuration object allowing method chaining.</returns>
+        public static LoggerConfiguration Wrap(
+            LoggerSinkConfiguration loggerSinkConfiguration,
+            Func<ILogEventSink, ILogEventSink> wrapSink,
+            Action<LoggerSinkConfiguration> configureWrappedSink,
+            LogEventLevel restrictedToMinimumLevel,
+            LoggingLevelSwitch levelSwitch)
         {
             if (loggerSinkConfiguration == null) throw new ArgumentNullException(nameof(loggerSinkConfiguration));
             if (wrapSink == null) throw new ArgumentNullException(nameof(wrapSink));
@@ -192,8 +215,7 @@ namespace Serilog.Configuration
                 {
                     SelfLog.WriteLine("Wrapping sink {0} does not implement IDisposable, but wrapped sink {1} does.", wrappedSink, sink);
                 }
-
-                loggerSinkConfiguration.Sink(wrappedSink);
+                loggerSinkConfiguration.Sink(wrappedSink, restrictedToMinimumLevel, levelSwitch);
             }
 
             var capturingLoggerSinkConfiguration = new LoggerSinkConfiguration(

--- a/test/Serilog.Tests/LoggerConfigurationTests.cs
+++ b/test/Serilog.Tests/LoggerConfigurationTests.cs
@@ -580,6 +580,7 @@ namespace Serilog.Tests
         [Fact]
         public void WrappingDecoratesTheConfiguredSink()
         {
+            DummyWrappingSink.Emitted.Clear();
             var sink = new CollectingSink();
             var logger = new LoggerConfiguration()
                 .WriteTo.Dummy(w => w.Sink(sink))
@@ -603,6 +604,55 @@ namespace Serilog.Tests
 
             SelfLog.Disable();
             Assert.NotEmpty(messages);
+        }
+
+        [Fact]
+        public void WrappingSinkRespectsLogEventLevelSetting()
+        {
+            DummyWrappingSink.Emitted.Clear();
+            var sink = new CollectingSink();
+            var logger = new LoggerConfiguration()
+                .WriteTo.DummyWrap(w => w.Sink(sink), LogEventLevel.Error, null)
+                .CreateLogger();
+
+            logger.Write(Some.InformationEvent());
+
+            Assert.Empty(DummyWrappingSink.Emitted);
+            Assert.Empty(sink.Events);
+        }
+
+        [Fact]
+        public void WrappingSinkRespectsLevelSwitchSetting()
+        {
+            DummyWrappingSink.Emitted.Clear();
+            var sink = new CollectingSink();
+            var logger = new LoggerConfiguration()
+                .WriteTo.DummyWrap(
+                    w => w.Sink(sink), LogEventLevel.Verbose,
+                    new LoggingLevelSwitch(LogEventLevel.Error))
+                .CreateLogger();
+
+            logger.Write(Some.InformationEvent());
+
+            Assert.Empty(DummyWrappingSink.Emitted);
+            Assert.Empty(sink.Events);
+        }
+
+        [Fact]
+        public void WrappingSinkRespectsSetting()
+        {
+            DummyWrappingSink.Emitted.Clear();
+            var sink = new CollectingSink();
+            var logger = new LoggerConfiguration()
+                .WriteTo.DummyWrap(
+                    w => w.Sink(sink), LogEventLevel.Error,
+                    new LoggingLevelSwitch(LogEventLevel.Verbose))
+                .CreateLogger();
+
+            logger.Write(Some.InformationEvent());
+
+            Assert.NotEmpty(DummyWrappingSink.Emitted);
+            Assert.NotEmpty(sink.Events);
         }
     }
 }

--- a/test/TestDummies/DummyLoggerConfigurationExtensions.cs
+++ b/test/TestDummies/DummyLoggerConfigurationExtensions.cs
@@ -70,5 +70,19 @@ namespace TestDummies
                 s => new DummyWrappingSink(s),
                 wrappedSinkAction);
         }
+
+        public static LoggerConfiguration DummyWrap(
+            this LoggerSinkConfiguration loggerSinkConfiguration,
+            Action<LoggerSinkConfiguration> wrappedSinkAction,
+            LogEventLevel logEventLevel,
+            LoggingLevelSwitch levelSwitch)
+        {
+            return LoggerSinkConfiguration.Wrap(
+                loggerSinkConfiguration,
+                s => new DummyWrappingSink(s),
+                wrappedSinkAction,
+                logEventLevel,
+                levelSwitch);
+        }
     }
 }


### PR DESCRIPTION
**What issue does this PR address?**
#1073.

**Does this PR introduce a breaking change?**
No

**Please check if the PR fulfills these requirements**
- [x] The commit follows our [guidelines](https://github.com/serilog/serilog/blob/dev/CONTRIBUTING.md)
- [x] Unit Tests for the changes have been added (for bug fixes / features)

**Other information**: