### PR TITLE
Improvements to {Properties} handling in output templates

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -1,1 +1,0 @@
-@powershell .\Build.ps1 %*

--- a/global.json
+++ b/global.json
@@ -1,6 +1,5 @@
 {
-  "projects": [ "src", "test" ],
   "sdk": {
-    "version": "1.0.1"
+    "version": "2.1.4"
   }
 }

--- a/src/Serilog/Formatting/Display/MessageTemplateTextFormatter.cs
+++ b/src/Serilog/Formatting/Display/MessageTemplateTextFormatter.cs
@@ -97,7 +97,7 @@ namespace Serilog.Formatting.Display
                     }
                     else if (pt.PropertyName == OutputProperties.PropertiesPropertyName)
                     {
-                        PropertiesOutputFormat.Render(logEvent.MessageTemplate, logEvent.Properties, _outputTemplate, writer, _formatProvider);
+                        PropertiesOutputFormat.Render(logEvent.MessageTemplate, logEvent.Properties, _outputTemplate, writer, pt.Format, _formatProvider);
                     }
                     else
                     {

--- a/src/Serilog/Formatting/Display/Obsolete/LogEventPropertiesValue.cs
+++ b/src/Serilog/Formatting/Display/Obsolete/LogEventPropertiesValue.cs
@@ -35,7 +35,7 @@ namespace Serilog.Formatting.Display.Obsolete
 
         public override void Render(TextWriter output, string format = null, IFormatProvider formatProvider = null)
         {
-            PropertiesOutputFormat.Render(_template, _properties, _outputTemplate, output, formatProvider);
+            PropertiesOutputFormat.Render(_template, _properties, _outputTemplate, output, format, formatProvider);
         }
     }
 }

--- a/src/Serilog/Formatting/Display/PropertiesOutputFormat.cs
+++ b/src/Serilog/Formatting/Display/PropertiesOutputFormat.cs
@@ -37,7 +37,7 @@ namespace Serilog.Formatting.Display
                 return;
             }
 
-            output.Write('{');
+            output.Write("{ ");
 
             var delim = "";
             foreach (var kvp in properties)
@@ -55,10 +55,7 @@ namespace Serilog.Formatting.Display
                 kvp.Value.Render(output, null, formatProvider);
             }
 
-            if (delim == "")        // No elements
-                output.Write("  "); // Matches default `StructureValue` formatting
-
-            output.Write('}');
+            output.Write(" }");
         }
 
         static bool TemplateContainsPropertyName(MessageTemplate template, string propertyName)

--- a/src/Serilog/Formatting/Display/PropertiesOutputFormat.cs
+++ b/src/Serilog/Formatting/Display/PropertiesOutputFormat.cs
@@ -29,18 +29,12 @@ namespace Serilog.Formatting.Display
         {
             if (format?.Contains("j") == true)
             {
-                for (var i = 0; i < format.Length; ++i)
-                {
-                    if (format[i] == 'j')
-                    {
-                        var sv = new StructureValue(properties
-                            .Where(kvp => !(TemplateContainsPropertyName(template, kvp.Key) ||
-                                            TemplateContainsPropertyName(outputTemplate, kvp.Key)))
-                            .Select(kvp => new LogEventProperty(kvp.Key, kvp.Value)));
-                        JsonValueFormatter.Format(sv, output);
-                        return;
-                    }
-                }
+                var sv = new StructureValue(properties
+                    .Where(kvp => !(TemplateContainsPropertyName(template, kvp.Key) ||
+                                    TemplateContainsPropertyName(outputTemplate, kvp.Key)))
+                    .Select(kvp => new LogEventProperty(kvp.Key, kvp.Value)));
+                JsonValueFormatter.Format(sv, output);
+                return;
             }
 
             output.Write('{');
@@ -80,12 +74,15 @@ namespace Serilog.Formatting.Display
                 return false;
             }
 
-            for (var i = 0; i < template.NamedProperties.Length; i++)
+            if (template.NamedProperties != null)
             {
-                var namedProperty = template.NamedProperties[i];
-                if (namedProperty.PropertyName == propertyName)
+                for (var i = 0; i < template.NamedProperties.Length; i++)
                 {
-                    return true;
+                    var namedProperty = template.NamedProperties[i];
+                    if (namedProperty.PropertyName == propertyName)
+                    {
+                        return true;
+                    }
                 }
             }
 

--- a/src/Serilog/Formatting/Display/PropertiesOutputFormat.cs
+++ b/src/Serilog/Formatting/Display/PropertiesOutputFormat.cs
@@ -15,14 +15,31 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using Serilog.Events;
+using Serilog.Formatting.Json;
 
 namespace Serilog.Formatting.Display
 {
     static class PropertiesOutputFormat
     {
-        public static void Render(MessageTemplate template, IReadOnlyDictionary<string, LogEventPropertyValue> properties, MessageTemplate outputTemplate, TextWriter output, IFormatProvider formatProvider = null)
+        static readonly JsonValueFormatter JsonValueFormatter = new JsonValueFormatter("$type");
+
+        public static void Render(MessageTemplate template, IReadOnlyDictionary<string, LogEventPropertyValue> properties, MessageTemplate outputTemplate, TextWriter output, string format, IFormatProvider formatProvider = null)
         {
+            if (format?.Contains("j") == true)
+            {
+                for (var i = 0; i < format.Length; ++i)
+                {
+                    if (format[i] == 'j')
+                    {
+                        var sv = new StructureValue(properties.Select(kvp => new LogEventProperty(kvp.Key, kvp.Value)));
+                        JsonValueFormatter.Format(sv, output);
+                        return;
+                    }
+                }
+            }
+
             output.Write('{');
 
             var delim = "";

--- a/src/Serilog/Formatting/Display/PropertiesOutputFormat.cs
+++ b/src/Serilog/Formatting/Display/PropertiesOutputFormat.cs
@@ -55,6 +55,9 @@ namespace Serilog.Formatting.Display
                 kvp.Value.Render(output, null, formatProvider);
             }
 
+            if (delim == "")        // No elements
+                output.Write("  "); // Matches default `StructureValue` formatting
+
             output.Write('}');
         }
 

--- a/src/Serilog/Rendering/MessageTemplateRenderer.cs
+++ b/src/Serilog/Rendering/MessageTemplateRenderer.cs
@@ -24,7 +24,7 @@ namespace Serilog.Rendering
 {
     static class MessageTemplateRenderer
     {
-        static JsonValueFormatter JsonValueFormatter = new JsonValueFormatter("$type");
+        static readonly JsonValueFormatter JsonValueFormatter = new JsonValueFormatter("$type");
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void Render(MessageTemplate messageTemplate, IReadOnlyDictionary<string, LogEventPropertyValue> properties, TextWriter output, string format = null, IFormatProvider formatProvider = null)

--- a/src/Serilog/Serilog.csproj
+++ b/src/Serilog/Serilog.csproj
@@ -16,61 +16,38 @@
     <PackageProjectUrl>http://serilog.net</PackageProjectUrl>
     <PackageLicenseUrl>http://www.apache.org/licenses/LICENSE-2.0</PackageLicenseUrl>
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
-    <!-- Don't reference the full NETStandard.Library -->
-    <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
     <TreatSpecificWarningsAsErrors />
   </PropertyGroup>
-  
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.0' ">
-    <PackageReference Include="Microsoft.CSharp" Version="4.0.1" />
-    <PackageReference Include="System.Collections" Version="4.0.11" />
-    <PackageReference Include="System.Dynamic.Runtime" Version="4.0.11" />
-    <PackageReference Include="System.Globalization" Version="4.0.11" />
-    <PackageReference Include="System.Linq" Version="4.1.0" />
-    <PackageReference Include="System.Reflection" Version="4.1.0" />
-    <PackageReference Include="System.Reflection.Extensions" Version="4.0.1" />
-    <PackageReference Include="System.Runtime" Version="4.1.0" />
-    <PackageReference Include="System.Runtime.Extensions" Version="4.1.0" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="4.1.0" />
-    <PackageReference Include="System.Threading" Version="4.0.11" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
-    <PackageReference Include="System.Collections.NonGeneric" Version="4.0.1" />
-    <PackageReference Include="Microsoft.CSharp" Version="4.0.1" />
-    <PackageReference Include="System.Collections" Version="4.0.11" />
-    <PackageReference Include="System.Dynamic.Runtime" Version="4.0.11" />
-    <PackageReference Include="System.Globalization" Version="4.0.11" />
-    <PackageReference Include="System.Linq" Version="4.1.0" />
-    <PackageReference Include="System.Reflection" Version="4.1.0" />
-    <PackageReference Include="System.Reflection.Extensions" Version="4.0.1" />
-    <PackageReference Include="System.Runtime" Version="4.1.0" />
-    <PackageReference Include="System.Runtime.Extensions" Version="4.1.0" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="4.1.0" />
-    <PackageReference Include="System.Threading" Version="4.0.11" />
-  </ItemGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net45' ">
+    <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
     <DefineConstants>$(DefineConstants);REMOTING;HASHTABLE</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net46' ">
+    <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
     <DefineConstants>$(DefineConstants);ASYNCLOCAL;HASHTABLE</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
     <DefineConstants>$(DefineConstants);ASYNCLOCAL;HASHTABLE</DefineConstants>
   </PropertyGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="Microsoft.CSharp" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="Microsoft.CSharp" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
+    <PackageReference Include="System.Collections.NonGeneric" Version="4.3.0" />
+  </ItemGroup>
 
 </Project>

--- a/test/Serilog.PerformanceTests/Serilog.PerformanceTests.csproj
+++ b/test/Serilog.PerformanceTests/Serilog.PerformanceTests.csproj
@@ -16,13 +16,9 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
-    <PackageReference Include="xunit" Version="2.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="BenchmarkDotNet" Version="0.10.6" />
-  </ItemGroup>
-  
-  <ItemGroup>
-    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/test/Serilog.Tests/Capturing/PropertyValueConverterTests.cs
+++ b/test/Serilog.Tests/Capturing/PropertyValueConverterTests.cs
@@ -200,13 +200,13 @@ namespace Serilog.Tests.Capturing
             var bytes = Enumerable.Range(0, 1025).Select(b => (byte)b).ToArray();
             var pv = _converter.CreatePropertyValue(bytes);
             var lv = (string)pv.LiteralValue();
-            Assert.True(lv.EndsWith("(1025 bytes)"));
+            Assert.EndsWith("(1025 bytes)", lv);
         }
 
         public class Thrower
         {
-            public string Throws { get { throw new NotSupportedException(); } }
-            public string Doesnt { get { return "Hello"; } }
+            public string Throws => throw new NotSupportedException();
+            public string Doesnt => "Hello";
         }
 
         [Fact]
@@ -310,7 +310,7 @@ namespace Serilog.Tests.Capturing
             var result = _converter.CreatePropertyValue(o, true);
             Assert.Equal(typeof(StructureValue), result.GetType());
             var structuredValue = (StructureValue)result;
-            Assert.Equal(null, structuredValue.TypeTag);
+            Assert.Null(structuredValue.TypeTag);
         }
 
         [Fact]

--- a/test/Serilog.Tests/Context/LogContextTests.cs
+++ b/test/Serilog.Tests/Context/LogContextTests.cs
@@ -287,7 +287,6 @@ namespace Serilog.Tests.Context
         [Fact]
         public void DoesNotThrowOnCrossDomainCallsWhenLeaseExpired()
         {
-            // Arrange
             RemotingException remotingException = null;
 
             AppDomain.CurrentDomain.FirstChanceException +=
@@ -296,7 +295,6 @@ namespace Serilog.Tests.Context
             var logger = new LoggerConfiguration().Enrich.FromLogContext().CreateLogger();
             var remote = AppDomain.CreateDomain("Remote", null, AppDomain.CurrentDomain.SetupInformation);
 
-            // Act
             try
             {
                 using (LogContext.PushProperty("Prop", 42))
@@ -312,7 +310,6 @@ namespace Serilog.Tests.Context
                 AppDomain.Unload(remote);
             }
 
-            // Assert
             Assert.Null(remotingException);
 
             void CallFromRemote() => Thread.Sleep(200);
@@ -321,13 +318,11 @@ namespace Serilog.Tests.Context
         [Fact]
         public async Task DisconnectRemoteObjectsAfterCrossDomainCallsOnDispose()
         {
-            // Arrange
             var tracker = new InMemoryRemoteObjectTracker();
             TrackingServices.RegisterTrackingHandler(tracker);
 
             var remote = AppDomain.CreateDomain("Remote", null, AppDomain.CurrentDomain.SetupInformation);
 
-            // Act
             try
             {
                 using (LogContext.PushProperty("Prop1", 42))
@@ -347,8 +342,9 @@ namespace Serilog.Tests.Context
 
             await Task.Delay(200);
 
-            // Assert
-            Assert.Equal(2, tracker.DisconnectCount);
+            // This is intermittently 2 or 3, depending on the moods of the test runner;
+            // I think "at least two" is what we're concerned about, here.
+            Assert.InRange(tracker.DisconnectCount, 2, 3);
 
             void CallFromRemote() { }
         }

--- a/test/Serilog.Tests/Context/LogContextTests.cs
+++ b/test/Serilog.Tests/Context/LogContextTests.cs
@@ -197,7 +197,7 @@ namespace Serilog.Tests.Context
 
                 // No problem if this happens occasionally; was Assert.Inconclusive().
                 // The test was marshalled back to the same thread after awaiting.
-                Assert.NotSame(pre, post);
+                Assert.NotEqual(pre, post);
             }
         }
 
@@ -302,7 +302,9 @@ namespace Serilog.Tests.Context
                 using (LogContext.PushProperty("Prop", 42))
                 {
                     remote.DoCallBack(CallFromRemote);
+#pragma warning disable Serilog003
                     logger.Information("Prop = {Prop}");
+#pragma warning restore Serilog003
                 }
             }
             finally

--- a/test/Serilog.Tests/Core/MessageTemplateTests.cs
+++ b/test/Serilog.Tests/Core/MessageTemplateTests.cs
@@ -15,8 +15,8 @@ namespace Serilog.Tests.Core
         class Chair
         {
             // ReSharper disable UnusedMember.Local
-            public string Back { get { return "straight"; } }
-            public int[] Legs { get { return new[] { 1, 2, 3, 4 }; } }
+            public string Back => "straight";
+            public int[] Legs => new[] { 1, 2, 3, 4 };
             // ReSharper restore UnusedMember.Local
             public override string ToString()
             {
@@ -27,8 +27,8 @@ namespace Serilog.Tests.Core
         class Receipt
         {
             // ReSharper disable UnusedMember.Local
-            public decimal Sum { get { return 12.345m; } }
-            public DateTime When { get { return new DateTime(2013, 5, 20, 16, 39, 0); } }
+            public decimal Sum => 12.345m;
+            public DateTime When => new DateTime(2013, 5, 20, 16, 39, 0);
             // ReSharper restore UnusedMember.Local
             public override string ToString()
             {

--- a/test/Serilog.Tests/Core/SecondaryLoggerSinkTests.cs
+++ b/test/Serilog.Tests/Core/SecondaryLoggerSinkTests.cs
@@ -70,7 +70,7 @@ namespace Serilog.Tests.Core
 
             logger.Write(Some.DebugEvent());
 
-            Assert.Equal(1, sink.Events.Count);
+            Assert.Single(sink.Events);
         }
 
         [Fact]
@@ -87,7 +87,7 @@ namespace Serilog.Tests.Core
 
             logger.Write(Some.DebugEvent());
 
-            Assert.Equal(0, sink.Events.Count);
+            Assert.Empty(sink.Events);
         }
     }
 }

--- a/test/Serilog.Tests/Debugging/SelfLogTests.cs
+++ b/test/Serilog.Tests/Debugging/SelfLogTests.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using Serilog.Debugging;
 using Xunit;
 
@@ -22,7 +21,7 @@ namespace Serilog.Tests.Debugging
             });
 
             SelfLog.WriteLine("Hello {0} {1} {2}", 0, 1, 2);
-            Assert.True(Messages.Any(m => m.EndsWith("Hello 0 1 2")));
+            Assert.Contains(Messages, m => m.EndsWith("Hello 0 1 2"));
 
             // Better to do this here than in another test, since at this point
             // we've confirmed there's actually something to disable.

--- a/test/Serilog.Tests/Formatting/Display/MessageTemplateTextFormatterTests.cs
+++ b/test/Serilog.Tests/Formatting/Display/MessageTemplateTextFormatterTests.cs
@@ -1,9 +1,8 @@
 ﻿using System;
 using System.Globalization;
 using System.IO;
-
+using System.Linq;
 using Serilog.Events;
-
 using Xunit;
 using Serilog.Tests.Support;
 using Serilog.Formatting.Display;
@@ -263,6 +262,18 @@ namespace Serilog.Tests.Formatting.Display
             var evt = DelegatingSink.GetLogEvent(l => l.ForContext("Name", "World").Information("Hello"));
             var sw = new StringWriter();
             formatter.Format(evt, sw);
+            Assert.Equal(expected, sw.ToString());
+        }
+
+        [Fact]
+        public void AnEmptyPropertiesTokenIsAnEmptyStructureValueWithDefaultFormatting()
+        {
+            var formatter = new MessageTemplateTextFormatter("{Properties}", null);
+            var evt = DelegatingSink.GetLogEvent(l => l.Information("Hello"));
+            var sw = new StringWriter();
+            formatter.Format(evt, sw);
+
+            var expected = new StructureValue(Enumerable.Empty<LogEventProperty>()).ToString();
             Assert.Equal(expected, sw.ToString());
         }
     }

--- a/test/Serilog.Tests/Formatting/Display/MessageTemplateTextFormatterTests.cs
+++ b/test/Serilog.Tests/Formatting/Display/MessageTemplateTextFormatterTests.cs
@@ -159,7 +159,7 @@ namespace Serilog.Tests.Formatting.Display
 
         class SizeFormatter : IFormatProvider, ICustomFormatter
         {
-            private readonly IFormatProvider _innerFormatProvider;
+            readonly IFormatProvider _innerFormatProvider;
 
             public SizeFormatter(IFormatProvider innerFormatProvider)
             {
@@ -173,17 +173,11 @@ namespace Serilog.Tests.Formatting.Display
 
             public string Format(string format, object arg, IFormatProvider formatProvider)
             {
-                if (arg is Size)
-                {
-                    var size = (Size)arg;
+                if (arg is Size size)
                     return size == Size.Large ? "Huge" : size.ToString();
-                }
 
-                var formattable = arg as IFormattable;
-                if (formattable != null)
-                {
+                if (arg is IFormattable formattable)
                     return formattable.ToString(format, _innerFormatProvider);
-                }
 
                 return arg.ToString();
             }
@@ -204,6 +198,16 @@ namespace Serilog.Tests.Formatting.Display
         {
             var formatter = new MessageTemplateTextFormatter("{Properties}", CultureInfo.InvariantCulture);
             var evt = DelegatingSink.GetLogEvent(l => l.ForContext("Foo", 42).Information("Hello from {Bar}!", "bar"));
+            var sw = new StringWriter();
+            formatter.Format(evt, sw);
+            Assert.Equal("{Foo: 42}", sw.ToString());
+        }
+
+        [Fact]
+        public void NonMessagePositionalPropertiesAreRendered()
+        {
+            var formatter = new MessageTemplateTextFormatter("{Properties}", CultureInfo.InvariantCulture);
+            var evt = DelegatingSink.GetLogEvent(l => l.ForContext("Foo", 42).Information("Hello from {0}!", "bar"));
             var sw = new StringWriter();
             formatter.Format(evt, sw);
             Assert.Equal("{Foo: 42}", sw.ToString());

--- a/test/Serilog.Tests/Formatting/Display/MessageTemplateTextFormatterTests.cs
+++ b/test/Serilog.Tests/Formatting/Display/MessageTemplateTextFormatterTests.cs
@@ -247,5 +247,19 @@ namespace Serilog.Tests.Formatting.Display
             formatter.Format(evt, sw);
             Assert.Equal(expected, sw.ToString());
         }
+
+        [Theory]
+        [InlineData("", "{ Name: \"World\" }")]
+        [InlineData(":j", "{\"Name\":\"World\"}")]
+        [InlineData(":lj", "{\"Name\":\"World\"}")]
+        [InlineData(":jl", "{\"Name\":\"World\"}")]
+        public void AppliesJsonFormattingToTopLevelStructuresWhenSpecified(string format, string expected)
+        {
+            var formatter = new MessageTemplateTextFormatter("{Properties" + format + "}", null);
+            var evt = DelegatingSink.GetLogEvent(l => l.Information("{Name}", "World"));
+            var sw = new StringWriter();
+            formatter.Format(evt, sw);
+            Assert.Equal(expected, sw.ToString());
+        }
     }
 }

--- a/test/Serilog.Tests/Formatting/Display/MessageTemplateTextFormatterTests.cs
+++ b/test/Serilog.Tests/Formatting/Display/MessageTemplateTextFormatterTests.cs
@@ -199,7 +199,7 @@ namespace Serilog.Tests.Formatting.Display
             var evt = DelegatingSink.GetLogEvent(l => l.ForContext("Foo", 42).Information("Hello from {Bar}!", "bar"));
             var sw = new StringWriter();
             formatter.Format(evt, sw);
-            Assert.Equal("{Foo: 42}", sw.ToString());
+            Assert.Equal("{ Foo: 42 }", sw.ToString());
         }
 
         [Fact]
@@ -209,7 +209,7 @@ namespace Serilog.Tests.Formatting.Display
             var evt = DelegatingSink.GetLogEvent(l => l.ForContext("Foo", 42).Information("Hello from {0}!", "bar"));
             var sw = new StringWriter();
             formatter.Format(evt, sw);
-            Assert.Equal("{Foo: 42}", sw.ToString());
+            Assert.Equal("{ Foo: 42 }", sw.ToString());
         }
 
         [Fact]
@@ -219,7 +219,7 @@ namespace Serilog.Tests.Formatting.Display
             var evt = DelegatingSink.GetLogEvent(l => l.ForContext("Foo", 42).ForContext("Bar", 42).Information("Hello from bar!"));
             var sw = new StringWriter();
             formatter.Format(evt, sw);
-            Assert.Equal("42 {Bar: 42}", sw.ToString());
+            Assert.Equal("42 { Bar: 42 }", sw.ToString());
         }
 
         [Theory]

--- a/test/Serilog.Tests/Formatting/Display/MessageTemplateTextFormatterTests.cs
+++ b/test/Serilog.Tests/Formatting/Display/MessageTemplateTextFormatterTests.cs
@@ -257,10 +257,10 @@ namespace Serilog.Tests.Formatting.Display
         [InlineData(":j", "{\"Name\":\"World\"}")]
         [InlineData(":lj", "{\"Name\":\"World\"}")]
         [InlineData(":jl", "{\"Name\":\"World\"}")]
-        public void AppliesJsonFormattingToTopLevelStructuresWhenSpecified(string format, string expected)
+        public void AppliesJsonFormattingToPropertiesTokenWhenSpecified(string format, string expected)
         {
             var formatter = new MessageTemplateTextFormatter("{Properties" + format + "}", null);
-            var evt = DelegatingSink.GetLogEvent(l => l.Information("{Name}", "World"));
+            var evt = DelegatingSink.GetLogEvent(l => l.ForContext("Name", "World").Information("Hello"));
             var sw = new StringWriter();
             formatter.Format(evt, sw);
             Assert.Equal(expected, sw.ToString());

--- a/test/Serilog.Tests/Formatting/Json/JsonFormatterTests.cs
+++ b/test/Serilog.Tests/Formatting/Json/JsonFormatterTests.cs
@@ -182,10 +182,10 @@ namespace Serilog.Tests.Formatting.Json
             var d = FormatEvent(e);
 
             var rs = ((IEnumerable)d.Renderings).Cast<dynamic>().ToArray();
-            Assert.Equal(1, rs.Count());
+            Assert.Single(rs);
             var ap = d.Renderings.AProperty;
             var fs = ((IEnumerable)ap).Cast<dynamic>().ToArray();
-            Assert.Equal(1, fs.Count());
+            Assert.Single(fs);
             Assert.Equal("000", (string)fs.Single().Format);
             Assert.Equal("012", (string)fs.Single().Rendering);
         }

--- a/test/Serilog.Tests/Formatting/Json/JsonFormatterTests.cs
+++ b/test/Serilog.Tests/Formatting/Json/JsonFormatterTests.cs
@@ -144,7 +144,7 @@ namespace Serilog.Tests.Formatting.Json
 
             var formatted = FormatToJson(@event);
             var expected = $"{{\"{dictKey}\":{dictValue}}}";
-            Assert.True(formatted.Contains(expected));
+            Assert.Contains(expected, formatted);
         }
 
         [Fact]

--- a/test/Serilog.Tests/LoggerConfigurationTests.cs
+++ b/test/Serilog.Tests/LoggerConfigurationTests.cs
@@ -76,8 +76,8 @@ namespace Serilog.Tests
                 .CreateLogger();
             logger.Write(included);
             logger.Write(excluded);
-            Assert.Equal(1, events.Count);
-            Assert.True(events.Contains(included));
+            Assert.Single(events);
+            Assert.Contains(included, events);
         }
 
         // ReSharper disable UnusedMember.Local, UnusedAutoPropertyAccessor.Local
@@ -461,7 +461,7 @@ namespace Serilog.Tests
 
             logger.Write(Some.InformationEvent());
 
-            Assert.Equal(1, sink.Events.Count);
+            Assert.Single(sink.Events);
         }
 
         [Fact]
@@ -477,7 +477,7 @@ namespace Serilog.Tests
 
             logger.Write(Some.InformationEvent());
 
-            Assert.Equal(1, sink.Events.Count);
+            Assert.Single(sink.Events);
         }
 
         [Fact]
@@ -513,7 +513,7 @@ namespace Serilog.Tests
             logger.ForContext(Constants.SourceContextPropertyName, "Microsoft.AspNet.Something").Write(Some.InformationEvent());
             logger.ForContext<LoggerConfigurationTests>().Write(Some.InformationEvent());
 
-            Assert.Equal(1, sink.Events.Count);
+            Assert.Single(sink.Events);
         }
 
         [Fact]

--- a/test/Serilog.Tests/MethodOverloadConventionTests.cs
+++ b/test/Serilog.Tests/MethodOverloadConventionTests.cs
@@ -99,7 +99,7 @@ namespace Serilog.Tests
             var writeMethod = methods.Single();
 
             Assert.True(writeMethod.IsPublic);
-            Assert.Equal(writeMethod.ReturnType, typeof(void));
+            Assert.Equal(typeof(void), writeMethod.ReturnType);
 
             var level = LogEventLevel.Information;
 
@@ -131,7 +131,7 @@ namespace Serilog.Tests
 
             foreach (var method in methodSet)
             {
-                Assert.Equal(method.ReturnType, typeof(ILogger));
+                Assert.Equal(typeof(ILogger), method.ReturnType);
                 Assert.True(method.IsPublic);
 
                 var signatureMatchAndInvokeSuccess = false;
@@ -178,7 +178,7 @@ namespace Serilog.Tests
             var method = loggerType.GetMethod("BindMessageTemplate");
 
             Assert.NotNull(method);
-            Assert.Equal(method.ReturnType, typeof(bool));
+            Assert.Equal(typeof(bool), method.ReturnType);
             Assert.True(method.IsPublic);
 
             var messageTemplateAttr = method.GetCustomAttribute<MessageTemplateFormatMethodAttribute>();
@@ -189,20 +189,20 @@ namespace Serilog.Tests
             var parameters = method.GetParameters();
             var index = 0;
 
-            Assert.Equal(parameters[index].Name, "messageTemplate");
-            Assert.Equal(parameters[index].ParameterType, typeof(string));
+            Assert.Equal("messageTemplate", parameters[index].Name);
+            Assert.Equal(typeof(string), parameters[index].ParameterType);
             index++;
 
-            Assert.Equal(parameters[index].Name, "propertyValues");
-            Assert.Equal(parameters[index].ParameterType, typeof(object[]));
+            Assert.Equal("propertyValues", parameters[index].Name);
+            Assert.Equal(typeof(object[]), parameters[index].ParameterType);
             index++;
 
-            Assert.Equal(parameters[index].Name, "parsedTemplate");
+            Assert.Equal("parsedTemplate", parameters[index].Name);
             Assert.Equal(parameters[index].ParameterType, typeof(MessageTemplate).MakeByRefType());
             Assert.True(parameters[index].IsOut);
             index++;
 
-            Assert.Equal(parameters[index].Name, "boundProperties");
+            Assert.Equal("boundProperties", parameters[index].Name);
             Assert.Equal(parameters[index].ParameterType, typeof(IEnumerable<LogEventProperty>).MakeByRefType());
             Assert.True(parameters[index].IsOut);
 
@@ -215,7 +215,7 @@ namespace Serilog.Tests
 
             var result = InvokeMethod(method, logger, args);
 
-            Assert.IsType(typeof(bool), result);
+            Assert.IsType<bool>(result);
 
             //silentlogger is always false
             if (loggerType == typeof(SilentLogger))
@@ -226,7 +226,7 @@ namespace Serilog.Tests
             //test null arg path
             var falseResult = InvokeMethod(method, logger, new object[] { null, null, null, null });
 
-            Assert.IsType(typeof(bool), falseResult);
+            Assert.IsType<bool>(falseResult);
             Assert.False(falseResult as bool?);
         }
 
@@ -240,25 +240,25 @@ namespace Serilog.Tests
             var method = loggerType.GetMethod("BindProperty");
 
             Assert.NotNull(method);
-            Assert.Equal(method.ReturnType, typeof(bool));
+            Assert.Equal(typeof(bool), method.ReturnType);
             Assert.True(method.IsPublic);
 
             var parameters = method.GetParameters();
             var index = 0;
 
-            Assert.Equal(parameters[index].Name, "propertyName");
-            Assert.Equal(parameters[index].ParameterType, typeof(string));
+            Assert.Equal("propertyName", parameters[index].Name);
+            Assert.Equal(typeof(string), parameters[index].ParameterType);
             index++;
 
-            Assert.Equal(parameters[index].Name, "value");
-            Assert.Equal(parameters[index].ParameterType, typeof(object));
+            Assert.Equal("value", parameters[index].Name);
+            Assert.Equal(typeof(object), parameters[index].ParameterType);
             index++;
 
-            Assert.Equal(parameters[index].Name, "destructureObjects");
-            Assert.Equal(parameters[index].ParameterType, typeof(bool));
+            Assert.Equal("destructureObjects", parameters[index].Name);
+            Assert.Equal(typeof(bool), parameters[index].ParameterType);
             index++;
 
-            Assert.Equal(parameters[index].Name, "property");
+            Assert.Equal("property", parameters[index].Name);
             Assert.Equal(parameters[index].ParameterType, typeof(LogEventProperty).MakeByRefType());
             Assert.True(parameters[index].IsOut);
 
@@ -271,7 +271,7 @@ namespace Serilog.Tests
 
             var result = InvokeMethod(method, logger, args);
 
-            Assert.IsType(typeof(bool), result);
+            Assert.IsType<bool>(result);
 
             //silentlogger will always be false
             if (loggerType == typeof(SilentLogger))
@@ -282,7 +282,7 @@ namespace Serilog.Tests
             //test null arg path/ invalid property name
             var falseResult = InvokeMethod(method, logger, new object[] { " ", null, false, null });
 
-            Assert.IsType(typeof(bool), falseResult);
+            Assert.IsType<bool>(falseResult);
             Assert.False(falseResult as bool?);
         }
 
@@ -297,7 +297,7 @@ namespace Serilog.Tests
 
             Assert.NotNull(method);
             Assert.True(method.IsPublic);
-            Assert.Equal(method.ReturnType, typeof(bool));
+            Assert.Equal(typeof(bool), method.ReturnType);
 
             var parameters = method.GetParameters();
 
@@ -305,19 +305,19 @@ namespace Serilog.Tests
 
             var parameter = parameters.Single();
 
-            Assert.Equal(parameter.Name, "level");
-            Assert.Equal(parameter.ParameterType, typeof(LogEventLevel));
+            Assert.Equal("level", parameter.Name);
+            Assert.Equal(typeof(LogEventLevel), parameter.ParameterType);
 
             var logger = GetLogger(loggerType, out _, LogEventLevel.Information);
 
             var falseResult = InvokeMethod(method, logger, new object[] { LogEventLevel.Verbose });
 
-            Assert.IsType(typeof(bool), falseResult);
+            Assert.IsType<bool>(falseResult);
             Assert.False(falseResult as bool?);
 
             var trueResult = InvokeMethod(method, logger, new object[] { LogEventLevel.Warning });
 
-            Assert.IsType(typeof(bool), trueResult);
+            Assert.IsType<bool>(trueResult);
 
             //return as silentlogger will always be false
             if (loggerType == typeof(SilentLogger))
@@ -337,8 +337,8 @@ namespace Serilog.Tests
 
                 var parameter = parameters.Single();
 
-                Assert.Equal(parameter.Name, "enricher");
-                Assert.Equal(parameter.ParameterType, typeof(ILogEventEnricher));
+                Assert.Equal("enricher", parameter.Name);
+                Assert.Equal(typeof(ILogEventEnricher), parameter.ParameterType);
             }
             catch (XunitException e)
             {
@@ -367,7 +367,7 @@ namespace Serilog.Tests
 
                 var parameter = parameters.Single();
 
-                Assert.Equal(parameter.Name, "enrichers");
+                Assert.Equal("enrichers", parameter.Name);
 
                 Assert.True(parameter.ParameterType == typeof(IEnumerable<ILogEventEnricher>)
                     || parameter.ParameterType == typeof(ILogEventEnricher[]));
@@ -395,20 +395,20 @@ namespace Serilog.Tests
             try
             {
                 var parameters = method.GetParameters();
-                Assert.Equal(parameters.Length, 3);
+                Assert.Equal(3, parameters.Length);
 
                 var index = 0;
 
-                Assert.Equal(parameters[index].Name, "propertyName");
-                Assert.Equal(parameters[index].ParameterType, typeof(string));
+                Assert.Equal("propertyName", parameters[index].Name);
+                Assert.Equal(typeof(string), parameters[index].ParameterType);
                 index++;
 
-                Assert.Equal(parameters[index].Name, "value");
-                Assert.Equal(parameters[index].ParameterType, typeof(object));
+                Assert.Equal("value", parameters[index].Name);
+                Assert.Equal(typeof(object), parameters[index].ParameterType);
                 index++;
 
-                Assert.Equal(parameters[index].Name, "destructureObjects");
-                Assert.Equal(parameters[index].ParameterType, typeof(bool));
+                Assert.Equal("destructureObjects", parameters[index].Name);
+                Assert.Equal(typeof(bool), parameters[index].ParameterType);
                 Assert.True(parameters[index].IsOptional);
             }
             catch (XunitException e)
@@ -459,7 +459,7 @@ namespace Serilog.Tests
 
                 var genericArg = genericArgs.Single();
 
-                Assert.Equal(genericArg.Name, "TSource");
+                Assert.Equal("TSource", genericArg.Name);
             }
             catch (XunitException e)
             {
@@ -487,8 +487,8 @@ namespace Serilog.Tests
 
                 var arg = args.Single();
 
-                Assert.Equal(arg.Name, "source");
-                Assert.Equal(arg.ParameterType, typeof(Type));
+                Assert.Equal("source", arg.Name);
+                Assert.Equal(typeof(Type), arg.ParameterType);
             }
             catch (XunitException e)
             {
@@ -549,7 +549,7 @@ namespace Serilog.Tests
 
             foreach (var method in methodSet)
             {
-                Assert.Equal(method.ReturnType, typeof(void));
+                Assert.Equal(typeof(void), method.ReturnType);
                 Assert.True(method.IsPublic);
 
                 if (checkMesgTempAttr)
@@ -790,8 +790,8 @@ namespace Serilog.Tests
                     //write convention methods always have one more parameter, LogEventLevel Arg
                     expectedArgCount++;
 
-                    Assert.Equal(parameters[index].ParameterType, typeof(LogEventLevel));
-                    Assert.Equal(parameters[index].Name, "level");
+                    Assert.Equal(typeof(LogEventLevel), parameters[index].ParameterType);
+                    Assert.Equal("level", parameters[index].Name);
                     index++;
                 }
 
@@ -800,13 +800,13 @@ namespace Serilog.Tests
                 // exceptions always come before messageTemplate string
                 if (hasExceptionArg) //verify exception argument type and name
                 {
-                    Assert.Equal(parameters[index].ParameterType, typeof(Exception));
-                    Assert.Equal(parameters[index].Name, "exception");
+                    Assert.Equal(typeof(Exception), parameters[index].ParameterType);
+                    Assert.Equal("exception", parameters[index].Name);
                     index++;
                 }
 
                 //check for message template string argument
-                Assert.Equal(parameters[index].ParameterType, typeof(string));
+                Assert.Equal(typeof(string), parameters[index].ParameterType);
                 Assert.Equal(parameters[index].Name, MessageTemplate);
                 index++;
 
@@ -834,12 +834,12 @@ namespace Serilog.Tests
                     {
                         var genericTypeArg = genericTypeArgs[0];
 
-                        Assert.Equal(genericTypeArg.Name, "T");
+                        Assert.Equal("T", genericTypeArg.Name);
 
                         var genericConstraints = genericTypeArg.GetTypeInfo().GetGenericParameterConstraints();
 
                         Assert.Empty(genericConstraints);
-                        Assert.Equal(parameters[index].Name, "propertyValue");
+                        Assert.Equal("propertyValue", parameters[index].Name);
                         Assert.Equal(genericTypeArg, parameters[index].ParameterType);
                         index++;
                     }
@@ -855,8 +855,8 @@ namespace Serilog.Tests
                     var paramsAttr = parameters[index].GetCustomAttribute(typeof(ParamArrayAttribute), inherit: false);
 
                     Assert.NotNull(paramsAttr);
-                    Assert.Equal(paramsArrayArg.ParameterType, typeof(object[]));
-                    Assert.Equal(paramsArrayArg.Name, "propertyValues");
+                    Assert.Equal(typeof(object[]), paramsArrayArg.ParameterType);
+                    Assert.Equal("propertyValues", paramsArrayArg.Name);
                 }
             }
             catch (XunitException e)
@@ -892,7 +892,7 @@ namespace Serilog.Tests
         static void EvaluateSingleResult(LogEventLevel level, CollectingSink results)
         {
             //evaluate single log event
-            Assert.Equal(1, results.Events.Count);
+            Assert.Single(results.Events);
 
             var evt = results.Events.Single();
 

--- a/test/Serilog.Tests/Parsing/MessageTemplateParserTests.cs
+++ b/test/Serilog.Tests/Parsing/MessageTemplateParserTests.cs
@@ -24,7 +24,7 @@ namespace Serilog.Tests.Parsing
         public void AnEmptyMessageIsASingleTextToken()
         {
             var t = Parse("");
-            Assert.Equal(1, t.Length);
+            Assert.Single(t);
             Assert.IsType<TextToken>(t.Single());
         }
 

--- a/test/Serilog.Tests/Serilog.Tests.csproj
+++ b/test/Serilog.Tests/Serilog.Tests.csproj
@@ -1,26 +1,23 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp1.0;net452;net46</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.0;net452;net46</TargetFrameworks>
     <AssemblyName>Serilog.Tests</AssemblyName>
     <AssemblyOriginatorKeyFile>../../assets/Serilog.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
     <PackageId>Serilog.Tests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
-    <PackageTargetFallback Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">$(PackageTargetFallback);dnxcore50;portable-net45+win8</PackageTargetFallback>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Serilog\Serilog.csproj" />
     <ProjectReference Include="..\TestDummies\TestDummies.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
-    <PackageReference Include="xunit" Version="2.2.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="System.ValueTuple" Version="4.3.1" />
-  </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
     <Reference Include="System" />
@@ -32,11 +29,11 @@
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net46' ">
     <DefineConstants>$(DefineConstants);APPDOMAIN;ASYNCLOCAL;GETCURRENTMETHOD</DefineConstants>
   </PropertyGroup>
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">
+    <DefineConstants>$(DefineConstants);ASYNCLOCAL</DefineConstants>
+  </PropertyGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
-  </ItemGroup>
-  <ItemGroup>
-    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/test/Serilog.Tests/Settings/CallableConfigurationMethodFinderTests.cs
+++ b/test/Serilog.Tests/Settings/CallableConfigurationMethodFinderTests.cs
@@ -23,8 +23,8 @@ namespace Serilog.Tests.Settings
                 .ToList();
 
 
-            Assert.True(eventEnrichers.Contains("FromLogContext"));
-            Assert.True(eventEnrichers.Contains("WithDummyThreadId"));
+            Assert.Contains("FromLogContext", eventEnrichers);
+            Assert.Contains("WithDummyThreadId", eventEnrichers);
         }
     }
 }

--- a/test/Serilog.Tests/Settings/KeyValuePairSettingsTests.cs
+++ b/test/Serilog.Tests/Settings/KeyValuePairSettingsTests.cs
@@ -43,7 +43,7 @@ namespace Serilog.Tests.Settings
             var configurationAssemblies = KeyValuePairSettings.LoadConfigurationAssemblies(new Dictionary<string, string>()).ToList();
 
             // The core Serilog assembly is always considered
-            Assert.Equal(1, configurationAssemblies.Count);
+            Assert.Single(configurationAssemblies);
         }
 
         [Fact]
@@ -120,8 +120,8 @@ namespace Serilog.Tests.Settings
 
             log.Write(Some.InformationEvent());
 
-            Assert.Equal(1, DummyRollingFileSink.Emitted.Count);
-            Assert.Equal(0, DummyRollingFileAuditSink.Emitted.Count);
+            Assert.Single(DummyRollingFileSink.Emitted);
+            Assert.Empty(DummyRollingFileAuditSink.Emitted);
         }
 
         [Fact]
@@ -142,8 +142,8 @@ namespace Serilog.Tests.Settings
 
             log.Write(Some.InformationEvent());
 
-            Assert.Equal(0, DummyRollingFileSink.Emitted.Count);
-            Assert.Equal(1, DummyRollingFileAuditSink.Emitted.Count);
+            Assert.Empty(DummyRollingFileSink.Emitted);
+            Assert.Single(DummyRollingFileAuditSink.Emitted);
         }
 
         [Fact]

--- a/test/TestDummies/DummyLoggerConfigurationExtensions.cs
+++ b/test/TestDummies/DummyLoggerConfigurationExtensions.cs
@@ -68,7 +68,9 @@ namespace TestDummies
             return LoggerSinkConfiguration.Wrap(
                 loggerSinkConfiguration,
                 s => new DummyWrappingSink(s),
-                wrappedSinkAction);
+                wrappedSinkAction,
+                LevelAlias.Minimum,
+                null);
         }
 
         public static LoggerConfiguration DummyWrap(

--- a/test/TestDummies/TestDummies.csproj
+++ b/test/TestDummies/TestDummies.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net452;netstandard1.3</TargetFrameworks>
+    <TargetFrameworks>net452;netstandard2.0</TargetFrameworks>
     <AssemblyName>TestDummies</AssemblyName>
     <AssemblyOriginatorKeyFile>../../assets/Serilog.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>


### PR DESCRIPTION
Fixes serilog/serilog-sinks-file#45 - support {Properties:j} in output templates; fixes #1088 - handle positional properties when computing {Properties}.

Brings the built-in message template formatting in line with _Serilog.Sinks.Console_.

Originally, `:j` wasn't supported on `{Properties}` because the formatting APIs here required some additional allocations in order to implement it, but in retrospect, better to be consistent.