### PR TITLE
Fixes #1105 - adds static Log.None property with appropriate tests.  …

### DIFF
--- a/src/Serilog/Log.cs
+++ b/src/Serilog/Log.cs
@@ -40,7 +40,15 @@ namespace Serilog
     /// </remarks>
     public static class Log
     {
-        static ILogger _logger = new SilentLogger();
+        /// <summary>
+        /// Initialise a SilentLogger to be the constant value of _noneLogger
+        /// </summary>
+        static readonly ILogger _noneLogger = new SilentLogger();
+
+        /// <summary>
+        /// Use the constant _noneLogger as the initial value
+        /// </summary>
+        static ILogger _logger = _noneLogger;
 
         /// <summary>
         /// The globally-shared logger.
@@ -61,7 +69,7 @@ namespace Serilog
         /// </summary>
         public static void CloseAndFlush()
         {
-            ILogger logger = Interlocked.Exchange(ref _logger, new SilentLogger());
+            ILogger logger = Interlocked.Exchange(ref _logger, _noneLogger);
 
             (logger as IDisposable)?.Dispose();
         }
@@ -1200,6 +1208,17 @@ namespace Serilog
         public static bool BindProperty(string propertyName, object value, bool destructureObjects, out LogEventProperty property)
         {
             return Logger.BindProperty(propertyName, value, destructureObjects, out property);
+        }
+
+        /// <summary>
+        /// An <see cref="ILogger"/> instance that silently ignores all log messages
+        /// </summary>
+        public static ILogger None
+        {
+            get
+            {
+                return _noneLogger;
+            }
         }
     }
 }

--- a/test/Serilog.Tests/LogTests.cs
+++ b/test/Serilog.Tests/LogTests.cs
@@ -14,6 +14,20 @@ namespace Serilog.Tests
             // the collection.
             Assert.IsType<SilentLogger>(Log.Logger);
         }
+        
+        [Fact]
+        public void NonePropertyIsNotAffectedByLoggerInitialization()
+        {
+            Log.Logger = new DisposableLogger();
+            Assert.IsType<SilentLogger>(Log.None);
+            Log.CloseAndFlush();
+        }
+
+        [Fact]
+        public void TheNonePropertyIsSilent()
+        {
+            Assert.IsType<SilentLogger>(Log.None);
+        }
 
         [Fact]
         public void DisposesTheLogger()
@@ -31,5 +45,15 @@ namespace Serilog.Tests
             Log.CloseAndFlush();
             Assert.IsType<SilentLogger>(Log.Logger);
         }
+
+        [Fact]
+        public void NonePropertyIsNotAffectedByReset()
+        {
+            Log.Logger = new DisposableLogger();
+            Log.CloseAndFlush();
+            Assert.IsType<SilentLogger>(Log.None);
+            Log.None.Information("Should not throw");
+        }
+
     }
 }


### PR DESCRIPTION
**What issue does this PR address?**
Adds a static `Log.None` property as per the discussion in #1105 

**Does this PR introduce a breaking change?**
No

**Please check if the PR fulfills these requirements**
- [X] The commit follows our [guidelines](https://github.com/serilog/serilog/blob/dev/CONTRIBUTING.md)
- [X] Unit Tests for the changes have been added (for bug fixes / features)

**Other information**:
Basic change to stash a `SilentLogger` instance in a private static variable on the `Log` class. That instance is used as the initial value of the `Logger` property.  The same instance is then exposed via the `None` property. `CloseAndFlush()` was modified to reset back to this instance rather than creating yet another `SilentLogger` instance.

Comments were updated where appropriate and code style was preserved.

I've added tests to ensure that the `None` property is initialised properly.  I've also ensured via a test that initialisation of the `Logger` property doesn't affect the `None` property. 
Finally I've ensured that `CloseAndFlush` doesn't corrupt the logger stored and accessible via the `None` property by checking that it remains a `SilentLogger` instance and that we can invoke it without raising an exception.

I think there are lines of words here than lines of code changed in the PR.  All tests (on my machine) seem to pass in the various framework versions.

Thanks 💯 