### PR TITLE
Fixes #1105 - add a static None property to the Logger class

### DIFF
--- a/src/Serilog/Core/Logger.cs
+++ b/src/Serilog/Core/Logger.cs
@@ -1373,21 +1373,10 @@ namespace Serilog.Core
         {
             _dispose?.Invoke();
         }
-
+        
         /// <summary>
-        /// Backing property for the exposed None property
+        /// An <see cref="ILogger"/> instance that efficiently ignores all method calls.
         /// </summary>
-        static readonly ILogger _noneLogger = new SilentLogger();
-
-        /// <summary>
-        /// An <see cref="ILogger"/> instance that efficiently ignores all method calls
-        /// </summary>
-        public static ILogger None
-        {
-            get
-            {
-                return _noneLogger;
-            }
-        }
+        public static ILogger None { get; } = new SilentLogger();
     }
 }

--- a/src/Serilog/Core/Logger.cs
+++ b/src/Serilog/Core/Logger.cs
@@ -16,6 +16,7 @@ using System;
 using System.Collections.Generic;
 using Serilog.Capturing;
 using Serilog.Core.Enrichers;
+using Serilog.Core.Pipeline;
 using Serilog.Debugging;
 using Serilog.Events;
 
@@ -1371,6 +1372,22 @@ namespace Serilog.Core
         public void Dispose()
         {
             _dispose?.Invoke();
+        }
+
+        /// <summary>
+        /// Backing property for the exposed None property
+        /// </summary>
+        static readonly ILogger _noneLogger = new SilentLogger();
+
+        /// <summary>
+        /// An <see cref="ILogger"/> instance that efficiently ignores all method calls
+        /// </summary>
+        public static ILogger None
+        {
+            get
+            {
+                return _noneLogger;
+            }
         }
     }
 }

--- a/test/Serilog.Tests/Core/LoggerTests.cs
+++ b/test/Serilog.Tests/Core/LoggerTests.cs
@@ -125,5 +125,13 @@ namespace Serilog.Tests.Core
         {
             Assert.IsType<SilentLogger>(Logger.None);
         }
+
+        [Fact]
+        public void TheNoneLoggerIsAConstant()
+        {
+            var firstCall = Logger.None;
+            var secondCall = Logger.None;
+            Assert.Equal(firstCall, secondCall);
+        }
 	}
 }

--- a/test/Serilog.Tests/Core/LoggerTests.cs
+++ b/test/Serilog.Tests/Core/LoggerTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Xunit;
 using Serilog.Core;
+using Serilog.Core.Pipeline;
 using Serilog.Events;
 using Serilog.Tests.Support;
 
@@ -117,6 +118,12 @@ namespace Serilog.Tests.Core
 
             Assert.Equal("Name", property.Name);
             Assert.Equal("World", property.Value.LiteralValue());
+        }
+
+        [Fact]
+        public void TheNoneLoggerIsSilent()
+        {
+            Assert.IsType<SilentLogger>(Logger.None);
         }
 	}
 }


### PR DESCRIPTION
**What issue does this PR address?**
Addresses issue #1105.  Replaces PR #1108 

**Does this PR introduce a breaking change?**
No

**Please check if the PR fulfills these requirements**
- [X] The commit follows our [guidelines](https://github.com/serilog/serilog/blob/dev/CONTRIBUTING.md)
- [X] Unit Tests for the changes have been added (for bug fixes / features)

**Other information**:
Sorry for the new PR.  Given the changes in the old PR were in the completely wrong file, it seemed easier to just close that PR and open a new one.

Issue #1105 asked for an easy way to get at a constant instance of a `SilentLogger`. The original PR added this on the `Log` class and slightly adjusted that class' internals to make use of this instance.
This new PR instead modifies the `Logger` class to add a static `Logger.None` property that returns the same `SilentLogger`.

One new allocation overall.  I suspect we can live with that (?).  Former PR didn't have that issue.  A lazy init sounds like overkill for this but I'm happy to be told I'm wrong.

Only one new unit test - verifying that the property is a silent logger.  There's not a lot of machinery or moving parts to verify anymore compared with the earlier PR.

Feedback most welcome. Thanks 💯 