### PR TITLE
Fix #1133

### DIFF
--- a/src/Serilog/Policies/ByteArrayScalarConversionPolicy.cs
+++ b/src/Serilog/Policies/ByteArrayScalarConversionPolicy.cs
@@ -42,7 +42,7 @@ namespace Serilog.Policies
             }
             else
             {
-                result = new ScalarValue(bytes.ToArray());
+                result = new ScalarValue(string.Concat(bytes.Select(b => b.ToString("X2"))));
             }
 
             return true;

--- a/test/Serilog.Tests/Capturing/PropertyValueConverterTests.cs
+++ b/test/Serilog.Tests/Capturing/PropertyValueConverterTests.cs
@@ -79,7 +79,7 @@ namespace Serilog.Tests.Capturing
         {
             var pv = _converter.CreatePropertyValue(new byte[0], Destructuring.Destructure);
             Assert.IsType<ScalarValue>(pv);
-            Assert.IsType<byte[]>(((ScalarValue)pv).Value);
+            Assert.IsType<string>(((ScalarValue)pv).Value);
         }
 
         [Fact]
@@ -185,17 +185,16 @@ namespace Serilog.Tests.Capturing
         }
 
         [Fact]
-        public void WhenByteArraysAreConvertedTheyAreCopiedToArrayScalars()
+        public void ByteArraysAreConvertedToStrings()
         {
             var bytes = Enumerable.Range(0, 10).Select(b => (byte)b).ToArray();
             var pv = _converter.CreatePropertyValue(bytes);
-            var lv = (byte[])pv.LiteralValue();
-            Assert.Equal(bytes.Length, lv.Length);
-            Assert.NotSame(bytes, lv);
+            var lv = (string)pv.LiteralValue();
+            Assert.Equal("00010203040506070809", lv);
         }
 
         [Fact]
-        public void ByteArraysLargerThan1kAreConvertedToStrings()
+        public void ByteArraysLargerThan1kAreLimitedAndConvertedToStrings()
         {
             var bytes = Enumerable.Range(0, 1025).Select(b => (byte)b).ToArray();
             var pv = _converter.CreatePropertyValue(bytes);


### PR DESCRIPTION
**What issue does this PR address?**

#1133 

**Does this PR introduce a breaking change?**

No

**Please check if the PR fulfills these requirements**
- [x] The commit follows our [guidelines](https://github.com/serilog/serilog/blob/dev/CONTRIBUTING.md)
- [x] Unit Tests for the changes have been added (for bug fixes / features)

**Other information**:

It is a very straightforward fix and [probably](https://stackoverflow.com/questions/311165/how-do-you-convert-a-byte-array-to-a-hexadecimal-string-and-vice-versa) not as fast as it can be. If you want I can measure and try to improve perfomance.