### PR TITLE
[WIP] Capture any `IDictionary<>` as dictionary instead of sequence

### DIFF
--- a/src/Serilog/Capturing/PropertyValueConverter.cs
+++ b/src/Serilog/Capturing/PropertyValueConverter.cs
@@ -311,8 +311,16 @@ namespace Serilog.Capturing
 
         bool TryGetDictionary(object value, Type valueType, out IDictionary dictionary)
         {
+#if NETSTANDARD1_0 || NETSTANDARD1_3
+        var implementedInterfaces = valueType.GetTypeInfo().ImplementedInterfaces;
+#else
+        var implementedInterfaces = valueType.GetInterfaces();
+#endif
+
+
             if (valueType.IsConstructedGenericType &&
-                valueType.GetGenericTypeDefinition() == typeof(Dictionary<,>) &&
+                implementedInterfaces.Any(
+                    interfaceType => interfaceType.GetTypeInfo().IsGenericType && interfaceType.GetGenericTypeDefinition() == typeof(IDictionary<,>)) &&
                 IsValidDictionaryKeyType(valueType.GenericTypeArguments[0]))
             {
                 dictionary = (IDictionary)value;

--- a/test/Serilog.Tests/Capturing/PropertyValueConverterTests.cs
+++ b/test/Serilog.Tests/Capturing/PropertyValueConverterTests.cs
@@ -166,6 +166,20 @@ namespace Serilog.Tests.Capturing
             Assert.Equal(1, dv.Elements.Count);
         }
 
+        public class CustomDictionary<K, V> : Dictionary<K, V>
+        {
+
+        }
+
+        [Fact]
+        public void ByDefaultAScalarCustomDictionaryIsADictionaryValue()
+        {
+            var pv = _converter.CreatePropertyValue(new CustomDictionary<int, string> { { 1, "hello" } }, Destructuring.Default);
+            Assert.IsType<DictionaryValue>(pv);
+            var dv = (DictionaryValue)pv;
+            Assert.Equal(1, dv.Elements.Count);
+        }
+
         [Fact]
         public void ByDefaultANonScalarDictionaryIsASequenceValue()
         {


### PR DESCRIPTION
**What issue does this PR address?**
Capturing properties as dictionaries is rigid, it works only for `Dictionary` objects. It does not capture dictionaries even if class implements `IDictionary` interface. 

**Does this PR introduce a breaking change?**
Yes, previously class other than `Dictionary` but implementing `IDictionary<>` would be destructured as sequence, after the PR it will be destructured as dictionary


**Please check if the PR fulfills these requirements**
- [x] The commit follows our [guidelines](https://github.com/serilog/serilog/blob/dev/CONTRIBUTING.md)
- [x] Unit Tests for the changes have been added (for bug fixes / features)

**Other information**:
Currently, the PR is just a suggestion. In the `Serilog.Exceptions` I had an idea of using custom dictionary implementation to improve performance, but I had to resign because `Serilog` would not capture my custom dictionary as the dictionary.

Please let me know what you think about it. If you will think that such change is worthwhile I will refactor and add more tests.