### PR TITLE
Enable OSX builds on travis again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,13 @@
 language: csharp
+dotnet: 2.1.4
 
 matrix:
   include:
+    - os: osx # osx_image: xcode8.3 Default	Xcode 8.3.3	OS X 10.12	1.8.0_112-b16
+      osx_image: xcode9.2
     - os: linux
       dist: trusty
       sudo: required
-      dotnet: 2.1.4
       group: edge
 script:
   - ./build.sh


### PR DESCRIPTION
**What issue does this PR address?**
Builds aren't tested on OSX, yet some developers actually like to use OSX to improve serilog.

**Does this PR introduce a breaking change?**
No

**Please check if the PR fulfills these requirements**
- [X] The commit follows our [guidelines](https://github.com/serilog/serilog/blob/dev/CONTRIBUTING.md)
- [X] Unit Tests for the changes have been added (for bug fixes / features)

**Other information**:
Way back in #939 we disabled OSX builds because (at the time) Travis + OSX was quite unstable and causing regular issues. Now seems like a good time to try it again, and see if those issues still exist.