### PR TITLE
Fixes a number of issues with `LoggerSinkConfiguration.Wrap()`

### DIFF
--- a/Serilog.sln.DotSettings
+++ b/Serilog.sln.DotSettings
@@ -126,6 +126,7 @@
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/FORCE_IFELSE_BRACES_STYLE/@EntryValue">DO_NOT_CHANGE</s:String>
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/FORCE_USING_BRACES_STYLE/@EntryValue">DO_NOT_CHANGE</s:String>
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/FORCE_WHILE_BRACES_STYLE/@EntryValue">DO_NOT_CHANGE</s:String>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/PLACE_ACCESSORHOLDER_ATTRIBUTE_ON_SAME_LINE_EX/@EntryValue">NEVER</s:String>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/SPACE_BEFORE_FIXED_PARENTHESES/@EntryValue">False</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/SPACE_BEFORE_SIZEOF_PARENTHESES/@EntryValue">False</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/SPACE_BEFORE_TYPEOF_PARENTHESES/@EntryValue">False</s:Boolean>
@@ -537,9 +538,14 @@ II.2.12 &lt;HandlesEvent /&gt;&#xD;
 	<s:String x:Key="/Default/CodeStyle/Naming/VBNaming/PredefinedNamingRules/=StaticReadonly/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/VBNaming/PredefinedNamingRules/=TypeParameters/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="T" Suffix="" Style="AaBb" /&gt;</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/VBNaming/PredefinedNamingRules/=TypesAndNamespaces/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpAttributeForSingleLineMethodUpgrade/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpFileLayoutPatternsUpgrade/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpKeepExistingMigration/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpPlaceEmbeddedOnSameLineMigration/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpRenamePlacementToArrangementMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EAddAccessorOwnerDeclarationBracesMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EAlwaysTreatStructAsNotReorderableMigration/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002ECSharpPlaceAttributeOnSameLineMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateBlankLinesAroundFieldToBlankLinesAroundProperty/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateThisQualifierSettings/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002EJavaScript_002ECodeStyle_002ESettingsUpgrade_002EJsCodeFormatterSettingsUpgrader/@EntryIndexedValue">True</s:Boolean>

--- a/src/Serilog/Configuration/LoggerSinkConfiguration.cs
+++ b/src/Serilog/Configuration/LoggerSinkConfiguration.cs
@@ -221,7 +221,7 @@ namespace Serilog.Configuration
 
             configureWrappedSink(capturingLoggerSinkConfiguration);
 
-            if (!sinksToWrap.Any())
+            if (sinksToWrap.Count == 0)
                 return loggerSinkConfiguration._loggerConfiguration;
 
             var enclosed = sinksToWrap.Count == 1 ?

--- a/src/Serilog/LoggerConfiguration.cs
+++ b/src/Serilog/LoggerConfiguration.cs
@@ -43,6 +43,14 @@ namespace Serilog
         int _maximumCollectionCount = int.MaxValue;
         bool _loggerCreated;
 
+        /// <summary>
+        /// Construct a <see cref="LoggerConfiguration"/>.
+        /// </summary>
+        public LoggerConfiguration()
+        {
+            WriteTo = new LoggerSinkConfiguration(this, s => _logEventSinks.Add(s), ApplyInheritedConfiguration);
+        }
+
         void ApplyInheritedConfiguration(LoggerConfiguration child)
         {
             if (_levelSwitch != null)
@@ -54,7 +62,7 @@ namespace Serilog
         /// <summary>
         /// Configures the sinks that log events will be emitted to.
         /// </summary>
-        public LoggerSinkConfiguration WriteTo => new LoggerSinkConfiguration(this, s => _logEventSinks.Add(s), ApplyInheritedConfiguration);
+        public LoggerSinkConfiguration WriteTo { get; internal set; }
 
         /// <summary>
         /// Configures sinks for auditing, instead of regular (safe) logging. When auditing is used,

--- a/test/Serilog.Tests/LoggerConfigurationTests.cs
+++ b/test/Serilog.Tests/LoggerConfigurationTests.cs
@@ -533,7 +533,7 @@ namespace Serilog.Tests
         {
             var logger = new LoggerConfiguration()
                 .AuditTo.Sink(new CollectingSink())
-                .WriteTo.Sink(new DelegatingSink(e => { throw new Exception("Boom!"); }))
+                .WriteTo.Sink(new DelegatingSink(e => throw new Exception("Boom!")))
                 .CreateLogger();
 
             logger.Write(Some.InformationEvent());
@@ -545,7 +545,7 @@ namespace Serilog.Tests
         public void ExceptionsThrownByFiltersAreNotPropagated()
         {
             var logger = new LoggerConfiguration()
-                .Filter.ByExcluding(e => { throw new Exception("Boom!"); })
+                .Filter.ByExcluding(e => throw new Exception("Boom!"))
                 .CreateLogger();
 
             logger.Write(Some.InformationEvent());
@@ -560,7 +560,7 @@ namespace Serilog.Tests
         {
             var logger = new LoggerConfiguration()
                 .WriteTo.Sink(new CollectingSink())
-                .Destructure.ByTransforming<Value>(v => { throw new Exception("Boom!"); })
+                .Destructure.ByTransforming<Value>(v => throw new Exception("Boom!"))
                 .CreateLogger();
 
             logger.Information("{@Value}", new Value());
@@ -571,10 +571,7 @@ namespace Serilog.Tests
         class ThrowingProperty
         {
             // ReSharper disable once UnusedMember.Local
-            public string Property
-            {
-                get { throw new Exception("Boom!"); }
-            }
+            public string Property => throw new Exception("Boom!");
         }
 
         [Fact]
@@ -586,10 +583,69 @@ namespace Serilog.Tests
                 .WriteTo.Dummy(w => w.Sink(sink))
                 .CreateLogger();
 
-            logger.Write(Some.InformationEvent());
+            var evt = Some.InformationEvent();
+            logger.Write(evt);
 
-            Assert.NotEmpty(DummyWrappingSink.Emitted);
-            Assert.NotEmpty(sink.Events);
+            Assert.Same(evt, DummyWrappingSink.Emitted.Single());
+            Assert.Same(evt, sink.SingleEvent);
+        }
+
+        [Fact]
+        public void WrappingDoesNotPermitEnrichment()
+        {
+            var sink = new CollectingSink();
+            var propertyName = Some.String();
+            var logger = new LoggerConfiguration()
+                .WriteTo.Dummy(w => w.Sink(sink)
+                    .Enrich.WithProperty(propertyName, 1))
+                .CreateLogger();
+
+            var evt = Some.InformationEvent();
+            logger.Write(evt);
+
+            Assert.Same(evt, sink.SingleEvent);
+            Assert.False(evt.Properties.ContainsKey(propertyName));
+        }
+
+        [Fact]
+        public void WrappingIsAppliedWhenChaining()
+        {
+            DummyWrappingSink.Emitted.Clear();
+            var sink1 = new CollectingSink();
+            var sink2 = new CollectingSink();
+            var logger = new LoggerConfiguration()
+                .WriteTo.Dummy(w => w.Sink(sink1)
+                    .WriteTo.Sink(sink2))
+                .CreateLogger();
+
+            var evt = Some.InformationEvent();
+            logger.Write(evt);
+
+            Assert.Same(evt, DummyWrappingSink.Emitted.Single());
+            Assert.Same(evt, sink1.SingleEvent);
+            Assert.Same(evt, sink2.SingleEvent);
+        }
+
+        [Fact]
+        public void WrappingIsAppliedWhenCallingMultipleTimes()
+        {
+            DummyWrappingSink.Emitted.Clear();
+            var sink1 = new CollectingSink();
+            var sink2 = new CollectingSink();
+            var logger = new LoggerConfiguration()
+                .WriteTo.Dummy(w =>
+                {
+                    w.Sink(sink1);
+                    w.Sink(sink2);
+                })
+                .CreateLogger();
+
+            var evt = Some.InformationEvent();
+            logger.Write(evt);
+
+            Assert.Same(evt, DummyWrappingSink.Emitted.Single());
+            Assert.Same(evt, sink1.SingleEvent);
+            Assert.Same(evt, sink2.SingleEvent);
         }
 
         [Fact]


### PR DESCRIPTION
These were identified via the discussion in #1154.

 - Ensures that `wt.X(); wt.Y()` and `wt.X().WriteTo.Y()` are equivalent
 - Ensures a failing sink doesn't block events from reaching others inside the same wrapper, much as using a secondary logger would do
 - Prevents chained calls from accidentally breaking thread-safety rules by turning `Enrich` inside wrappers into a no-op

**What issue does this PR address?**


**Does this PR introduce a breaking change?**


**Please check if the PR fulfills these requirements**
- [ ] The commit follows our [guidelines](https://github.com/serilog/serilog/blob/dev/CONTRIBUTING.md)
- [ ] Unit Tests for the changes have been added (for bug fixes / features)

**Other information**:
