### PR TITLE
Created Logger should not hold reference to its configuration

### DIFF
--- a/src/Serilog/LoggerConfiguration.cs
+++ b/src/Serilog/LoggerConfiguration.cs
@@ -136,12 +136,6 @@ namespace Serilog
                 throw new InvalidOperationException("CreateLogger() was previously called and can only be called once.");
             _loggerCreated = true;
 
-            Action dispose = () =>
-            {
-                foreach (var disposable in _logEventSinks.Concat(_auditSinks).OfType<IDisposable>())
-                    disposable.Dispose();
-            };
-
             ILogEventSink sink = new SafeAggregateSink(_logEventSinks);
 
             var auditing = _auditSinks.Any();
@@ -185,9 +179,18 @@ namespace Serilog
                 overrideMap = new LevelOverrideMap(_overrides, _minimumLevel, _levelSwitch);
             }
 
+            var disposableSinks = _logEventSinks.Concat(_auditSinks).OfType<IDisposable>().ToList();
+            void Dispose()
+            {
+                foreach (var disposable in disposableSinks)
+                {
+                    disposable.Dispose();
+                }
+            }
+
             return _levelSwitch == null ?
-                new Logger(processor, _minimumLevel, sink, enricher, dispose, overrideMap) :
-                new Logger(processor, _levelSwitch, sink, enricher, dispose, overrideMap);
+                new Logger(processor, _minimumLevel, sink, enricher, Dispose, overrideMap) :
+                new Logger(processor, _levelSwitch, sink, enricher, Dispose, overrideMap);
         }
     }
 }

--- a/src/Serilog/LoggerConfiguration.cs
+++ b/src/Serilog/LoggerConfiguration.cs
@@ -179,7 +179,7 @@ namespace Serilog
                 overrideMap = new LevelOverrideMap(_overrides, _minimumLevel, _levelSwitch);
             }
 
-            var disposableSinks = _logEventSinks.Concat(_auditSinks).OfType<IDisposable>().ToList();
+            var disposableSinks = _logEventSinks.Concat(_auditSinks).OfType<IDisposable>().ToArray();
             void Dispose()
             {
                 foreach (var disposable in disposableSinks)

--- a/test/Serilog.Tests/LoggerConfigurationTests.cs
+++ b/test/Serilog.Tests/LoggerConfigurationTests.cs
@@ -29,6 +29,19 @@ namespace Serilog.Tests
         }
 
         [Fact]
+        public void LoggerShouldNotReferenceToItsConfigurationAfterBeingCreated()
+        {
+            var loggerConfiguration = new LoggerConfiguration();
+            var wr = new WeakReference(loggerConfiguration);
+            var logger = loggerConfiguration.CreateLogger();
+
+            GC.Collect();
+
+            Assert.False(wr.IsAlive);
+            GC.KeepAlive(logger);
+        }
+
+        [Fact]
         public void CreateLoggerThrowsIfCalledMoreThanOnce()
         {
             var loggerConfiguration = new LoggerConfiguration();


### PR DESCRIPTION
**What issue does this PR address?**
Logger references to its configuration instance via `Dispose` closure that captures it.

**Does this PR introduce a breaking change?**
No.

**Please check if the PR fulfills these requirements**
- [x] The commit follows our [guidelines](https://github.com/serilog/serilog/blob/dev/CONTRIBUTING.md)
- [x] Unit Tests for the changes have been added (for bug fixes / features)

**Other information**:
After checking implications of introducing new state (`.WriteTo`) for `LoggerConfiguration` in the neighboring [pr](https://github.com/serilog/serilog/pull/1165) found that current `CreateLogger()` captures `LoggerConfiguration` instances.