### PR TITLE
Decoration is useful pattern when you try to do AOP

### DIFF
--- a/src/Serilog/LoggerConfiguration.cs
+++ b/src/Serilog/LoggerConfiguration.cs
@@ -44,11 +44,17 @@ namespace Serilog
         bool _loggerCreated;
 
         /// <summary>
-        /// Construct a <see cref="LoggerConfiguration"/>.
+        /// Construct a <see cref="LoggerConfiguration" />.
         /// </summary>
-        public LoggerConfiguration()
+        /// <param name="sinkMap">The sink map.</param>
+        public LoggerConfiguration(Func<ILogEventSink, ILogEventSink> sinkMap = null)
         {
-            WriteTo = new LoggerSinkConfiguration(this, s => _logEventSinks.Add(s), ApplyInheritedConfiguration);
+            Action<ILogEventSink> action = s =>
+                {
+                    s = sinkMap?.Invoke(s) ?? s;
+                    _logEventSinks.Add(s);
+                };
+            WriteTo = new LoggerSinkConfiguration(this, action, ApplyInheritedConfiguration);
         }
 
         void ApplyInheritedConfiguration(LoggerConfiguration child)

--- a/test/Serilog.Tests/Core/LoggerTests.cs
+++ b/test/Serilog.Tests/Core/LoggerTests.cs
@@ -133,5 +133,32 @@ namespace Serilog.Tests.Core
             var secondCall = Logger.None;
             Assert.Equal(firstCall, secondCall);
         }
-	}
+
+    
+        [Fact]
+        public void SinkDecorationHandleAndPass()
+        {
+            var decorated = new CollectingSink();
+            // decoration is useful pattern when you try to do AOP
+            // you can use it to
+            // - send metric like duration of sink execution
+            // - filter or routing at sink level
+            // - and more
+            DecorateSink decorator = null;
+            var logger = new LoggerConfiguration(s =>
+                        {
+                            decorator = new DecorateSink(s);
+                            return decorator;
+                        })
+                .WriteTo.Sink(decorated)
+                .CreateLogger();
+
+            var e = Some.InformationEvent();
+            logger.Write(e);
+
+            Assert.Same(e, decorated.SingleEvent);
+            Assert.NotNull(decorator);
+            Assert.Same(decorator.SingleEvent, decorated.SingleEvent);
+        }
+    }
 }

--- a/test/Serilog.Tests/Support/DecorateSink.cs
+++ b/test/Serilog.Tests/Support/DecorateSink.cs
@@ -1,0 +1,28 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Serilog.Core;
+using Serilog.Events;
+
+namespace Serilog.Tests.Support
+{
+    class DecorateSink : ILogEventSink
+    {
+        public DecorateSink(ILogEventSink decoratedSink)
+        {
+            _decoratedSink = decoratedSink;
+        }
+
+        readonly List<LogEvent> _events = new List<LogEvent>();
+        private readonly ILogEventSink _decoratedSink;
+
+        public List<LogEvent> Events { get { return _events; } }
+
+        public LogEvent SingleEvent { get { return _events.Single(); } }
+ 
+        public void Emit(LogEvent logEvent)
+        {
+            _events.Add(logEvent);
+            _decoratedSink.Emit(logEvent);
+        }
+    }
+}


### PR DESCRIPTION
**What issue does this PR address?**
Enable to easily wrap Sinks in order to provide cross concern 
functionality like: 
 - send metric like duration of sink execution
 - filter or routing at sink level
 - and more

**Does this PR introduce a breaking change?**
It use optional parameter in order to enable existing code to compile as is 

*Other information**:
I have context level activation logic which is external to the SeriLog project and I need away to set it per sink.
For example I may want some logs (according to their context into a File Sink and Other into ELK Sink.

I don't like to have separate fork for having this functionality.