### PR TITLE
Add partial support for .Destructure.XXX() methods in `KeyValuePairSettings`

### DIFF
--- a/src/Serilog/Settings/KeyValuePairs/CallableConfigurationMethodFinder.cs
+++ b/src/Serilog/Settings/KeyValuePairs/CallableConfigurationMethodFinder.cs
@@ -23,37 +23,11 @@ namespace Serilog.Settings.KeyValuePairs
 {
     static class CallableConfigurationMethodFinder
     {
-        internal static LoggerConfiguration FromLogContext(LoggerEnrichmentConfiguration loggerEnrichmentConfiguration)
-        {
-            return loggerEnrichmentConfiguration.FromLogContext();
-        }
-
-        static readonly MethodInfo SurrogateEnrichFromLogContextConfigurationMethod = typeof(CallableConfigurationMethodFinder).GetTypeInfo().DeclaredMethods.Single(m => m.Name == nameof(FromLogContext));
-
-        internal static LoggerConfiguration ToMaximumCollectionCount(LoggerDestructuringConfiguration loggerDestructuringConfiguration,
-            int maximumCollectionCount)
-        {
-            return loggerDestructuringConfiguration.ToMaximumCollectionCount(maximumCollectionCount);
-        }
-
-        static readonly MethodInfo SurrogateDestructureToMaximumCollectionCountConfigurationMethod = typeof(CallableConfigurationMethodFinder).GetTypeInfo().DeclaredMethods.Single(m => m.Name == nameof(ToMaximumCollectionCount));
-
-        internal static LoggerConfiguration ToMaximumDepth(LoggerDestructuringConfiguration loggerDestructuringConfiguration,
-            int maximumDestructuringDepth)
-        {
-            return loggerDestructuringConfiguration.ToMaximumDepth(maximumDestructuringDepth);
-        }
-
-        static readonly MethodInfo SurrogateDestructureToMaximumDepthConfigurationMethod = typeof(CallableConfigurationMethodFinder).GetTypeInfo().DeclaredMethods.Single(m => m.Name == nameof(ToMaximumDepth));
-
-        internal static LoggerConfiguration ToMaximumStringLength(LoggerDestructuringConfiguration loggerDestructuringConfiguration,
-            int maximumStringLength)
-        {
-            return loggerDestructuringConfiguration.ToMaximumStringLength(maximumStringLength);
-        }
-
-        static readonly MethodInfo SurrogateDestructureToMaximumStringLengthConfigurationMethod = typeof(CallableConfigurationMethodFinder).GetTypeInfo().DeclaredMethods.Single(m => m.Name == nameof(ToMaximumStringLength));
-
+        static readonly MethodInfo[] SurrogateMethodCandidates = typeof(SurrogateConfigurationMethods).GetTypeInfo().DeclaredMethods.ToArray();
+        static readonly MethodInfo SurrogateEnrichFromLogContextConfigurationMethod = SurrogateMethodCandidates.Single(m => m.Name == nameof(SurrogateConfigurationMethods.FromLogContext));
+        static readonly MethodInfo SurrogateDestructureToMaximumCollectionCountConfigurationMethod = SurrogateMethodCandidates.Single(m => m.Name == nameof(SurrogateConfigurationMethods.ToMaximumCollectionCount));
+        static readonly MethodInfo SurrogateDestructureToMaximumDepthConfigurationMethod = SurrogateMethodCandidates.Single(m => m.Name == nameof(SurrogateConfigurationMethods.ToMaximumDepth));
+        static readonly MethodInfo SurrogateDestructureToMaximumStringLengthConfigurationMethod = SurrogateMethodCandidates.Single(m => m.Name == nameof(SurrogateConfigurationMethods.ToMaximumStringLength));
 
         internal static IList<MethodInfo> FindConfigurationMethods(IEnumerable<Assembly> configurationAssemblies, Type configType)
         {

--- a/src/Serilog/Settings/KeyValuePairs/CallableConfigurationMethodFinder.cs
+++ b/src/Serilog/Settings/KeyValuePairs/CallableConfigurationMethodFinder.cs
@@ -27,8 +27,29 @@ namespace Serilog.Settings.KeyValuePairs
         {
             return loggerEnrichmentConfiguration.FromLogContext();
         }
-
         static readonly MethodInfo SurrogateFromLogContextConfigurationMethod = typeof(CallableConfigurationMethodFinder).GetTypeInfo().DeclaredMethods.Single(m => m.Name == nameof(FromLogContext));
+
+        internal static LoggerConfiguration ToMaximumCollectionCount(LoggerDestructuringConfiguration loggerDestructuringConfiguration,
+            int maximumCollectionCount)
+        {
+            return loggerDestructuringConfiguration.ToMaximumCollectionCount(maximumCollectionCount);
+        }
+        static readonly MethodInfo SurrogateFromDestructureToMaximumCollectionCountConfigurationMethod = typeof(CallableConfigurationMethodFinder).GetTypeInfo().DeclaredMethods.Single(m => m.Name == nameof(ToMaximumCollectionCount));
+
+        internal static LoggerConfiguration ToMaximumDepth(LoggerDestructuringConfiguration loggerDestructuringConfiguration,
+            int maximumDestructuringDepth)
+        {
+            return loggerDestructuringConfiguration.ToMaximumDepth(maximumDestructuringDepth);
+        }
+        static readonly MethodInfo SurrogateFromDestructureToMaximumDepthConfigurationMethod = typeof(CallableConfigurationMethodFinder).GetTypeInfo().DeclaredMethods.Single(m => m.Name == nameof(ToMaximumDepth));
+
+        internal static LoggerConfiguration ToMaximumStringLength(LoggerDestructuringConfiguration loggerDestructuringConfiguration,
+            int maximumStringLength)
+        {
+            return loggerDestructuringConfiguration.ToMaximumStringLength(maximumStringLength);
+        }
+        static readonly MethodInfo SurrogateFromDestructureToMaximumStringLengthConfigurationMethod = typeof(CallableConfigurationMethodFinder).GetTypeInfo().DeclaredMethods.Single(m => m.Name == nameof(ToMaximumStringLength));
+
 
         internal static IList<MethodInfo> FindConfigurationMethods(IEnumerable<Assembly> configurationAssemblies, Type configType)
         {
@@ -45,6 +66,14 @@ namespace Serilog.Settings.KeyValuePairs
             // hack ensures we find it.
             if (configType == typeof(LoggerEnrichmentConfiguration))
                 methods.Add(SurrogateFromLogContextConfigurationMethod);
+
+            // Some of the useful Destructure configuration methods are defined as methods rather than extension methods
+            if (configType == typeof(LoggerDestructuringConfiguration))
+            {
+                methods.Add(SurrogateFromDestructureToMaximumCollectionCountConfigurationMethod);
+                methods.Add(SurrogateFromDestructureToMaximumDepthConfigurationMethod);
+                methods.Add(SurrogateFromDestructureToMaximumStringLengthConfigurationMethod);
+            }
 
             return methods;
         }

--- a/src/Serilog/Settings/KeyValuePairs/CallableConfigurationMethodFinder.cs
+++ b/src/Serilog/Settings/KeyValuePairs/CallableConfigurationMethodFinder.cs
@@ -27,28 +27,32 @@ namespace Serilog.Settings.KeyValuePairs
         {
             return loggerEnrichmentConfiguration.FromLogContext();
         }
-        static readonly MethodInfo SurrogateFromLogContextConfigurationMethod = typeof(CallableConfigurationMethodFinder).GetTypeInfo().DeclaredMethods.Single(m => m.Name == nameof(FromLogContext));
+
+        static readonly MethodInfo SurrogateEnrichFromLogContextConfigurationMethod = typeof(CallableConfigurationMethodFinder).GetTypeInfo().DeclaredMethods.Single(m => m.Name == nameof(FromLogContext));
 
         internal static LoggerConfiguration ToMaximumCollectionCount(LoggerDestructuringConfiguration loggerDestructuringConfiguration,
             int maximumCollectionCount)
         {
             return loggerDestructuringConfiguration.ToMaximumCollectionCount(maximumCollectionCount);
         }
-        static readonly MethodInfo SurrogateFromDestructureToMaximumCollectionCountConfigurationMethod = typeof(CallableConfigurationMethodFinder).GetTypeInfo().DeclaredMethods.Single(m => m.Name == nameof(ToMaximumCollectionCount));
+
+        static readonly MethodInfo SurrogateDestructureToMaximumCollectionCountConfigurationMethod = typeof(CallableConfigurationMethodFinder).GetTypeInfo().DeclaredMethods.Single(m => m.Name == nameof(ToMaximumCollectionCount));
 
         internal static LoggerConfiguration ToMaximumDepth(LoggerDestructuringConfiguration loggerDestructuringConfiguration,
             int maximumDestructuringDepth)
         {
             return loggerDestructuringConfiguration.ToMaximumDepth(maximumDestructuringDepth);
         }
-        static readonly MethodInfo SurrogateFromDestructureToMaximumDepthConfigurationMethod = typeof(CallableConfigurationMethodFinder).GetTypeInfo().DeclaredMethods.Single(m => m.Name == nameof(ToMaximumDepth));
+
+        static readonly MethodInfo SurrogateDestructureToMaximumDepthConfigurationMethod = typeof(CallableConfigurationMethodFinder).GetTypeInfo().DeclaredMethods.Single(m => m.Name == nameof(ToMaximumDepth));
 
         internal static LoggerConfiguration ToMaximumStringLength(LoggerDestructuringConfiguration loggerDestructuringConfiguration,
             int maximumStringLength)
         {
             return loggerDestructuringConfiguration.ToMaximumStringLength(maximumStringLength);
         }
-        static readonly MethodInfo SurrogateFromDestructureToMaximumStringLengthConfigurationMethod = typeof(CallableConfigurationMethodFinder).GetTypeInfo().DeclaredMethods.Single(m => m.Name == nameof(ToMaximumStringLength));
+
+        static readonly MethodInfo SurrogateDestructureToMaximumStringLengthConfigurationMethod = typeof(CallableConfigurationMethodFinder).GetTypeInfo().DeclaredMethods.Single(m => m.Name == nameof(ToMaximumStringLength));
 
 
         internal static IList<MethodInfo> FindConfigurationMethods(IEnumerable<Assembly> configurationAssemblies, Type configType)
@@ -65,14 +69,14 @@ namespace Serilog.Settings.KeyValuePairs
             // Unlike the other configuration methods, FromLogContext is an instance method rather than an extension. This
             // hack ensures we find it.
             if (configType == typeof(LoggerEnrichmentConfiguration))
-                methods.Add(SurrogateFromLogContextConfigurationMethod);
+                methods.Add(SurrogateEnrichFromLogContextConfigurationMethod);
 
             // Some of the useful Destructure configuration methods are defined as methods rather than extension methods
             if (configType == typeof(LoggerDestructuringConfiguration))
             {
-                methods.Add(SurrogateFromDestructureToMaximumCollectionCountConfigurationMethod);
-                methods.Add(SurrogateFromDestructureToMaximumDepthConfigurationMethod);
-                methods.Add(SurrogateFromDestructureToMaximumStringLengthConfigurationMethod);
+                methods.Add(SurrogateDestructureToMaximumCollectionCountConfigurationMethod);
+                methods.Add(SurrogateDestructureToMaximumDepthConfigurationMethod);
+                methods.Add(SurrogateDestructureToMaximumStringLengthConfigurationMethod);
             }
 
             return methods;

--- a/src/Serilog/Settings/KeyValuePairs/KeyValuePairSettings.cs
+++ b/src/Serilog/Settings/KeyValuePairs/KeyValuePairSettings.cs
@@ -34,12 +34,13 @@ namespace Serilog.Settings.KeyValuePairs
         const string EnrichWithDirective = "enrich";
         const string EnrichWithPropertyDirective = "enrich:with-property";
         const string FilterDirective = "filter";
+        const string DestructureDirective = "destructure";
 
         const string UsingDirectiveFullFormPrefix = "using:";
         const string EnrichWithPropertyDirectivePrefix = "enrich:with-property:";
         const string MinimumLevelOverrideDirectivePrefix = "minimum-level:override:";
 
-        const string CallableDirectiveRegex = @"^(?<directive>audit-to|write-to|enrich|filter):(?<method>[A-Za-z0-9]*)(\.(?<argument>[A-Za-z0-9]*)){0,1}$";
+        const string CallableDirectiveRegex = @"^(?<directive>audit-to|write-to|enrich|filter|destructure):(?<method>[A-Za-z0-9]*)(\.(?<argument>[A-Za-z0-9]*)){0,1}$";
         const string LevelSwitchDeclarationDirectiveRegex = @"^level-switch:(?<switchName>.*)$";
         const string LevelSwitchNameRegex = @"^\$[A-Za-z]+[A-Za-z0-9]*$";
 
@@ -53,7 +54,8 @@ namespace Serilog.Settings.KeyValuePairs
             MinimumLevelControlledByDirective,
             EnrichWithPropertyDirective,
             EnrichWithDirective,
-            FilterDirective
+            FilterDirective,
+            DestructureDirective
         };
 
         static readonly Dictionary<string, Type> CallableDirectiveReceiverTypes = new Dictionary<string, Type>
@@ -61,7 +63,8 @@ namespace Serilog.Settings.KeyValuePairs
             ["audit-to"] = typeof(LoggerAuditSinkConfiguration),
             ["write-to"] = typeof(LoggerSinkConfiguration),
             ["enrich"] = typeof(LoggerEnrichmentConfiguration),
-            ["filter"] = typeof(LoggerFilterConfiguration)
+            ["filter"] = typeof(LoggerFilterConfiguration),
+            ["destructure"] = typeof(LoggerDestructuringConfiguration),
         };
 
         static readonly Dictionary<Type, Func<LoggerConfiguration, object>> CallableDirectiveReceivers = new Dictionary<Type, Func<LoggerConfiguration, object>>
@@ -69,7 +72,8 @@ namespace Serilog.Settings.KeyValuePairs
             [typeof(LoggerAuditSinkConfiguration)] = lc => lc.AuditTo,
             [typeof(LoggerSinkConfiguration)] = lc => lc.WriteTo,
             [typeof(LoggerEnrichmentConfiguration)] = lc => lc.Enrich,
-            [typeof(LoggerFilterConfiguration)] = lc => lc.Filter
+            [typeof(LoggerFilterConfiguration)] = lc => lc.Filter,
+            [typeof(LoggerDestructuringConfiguration)] = lc => lc.Destructure,
         };
 
         readonly IReadOnlyDictionary<string, string> _settings;

--- a/src/Serilog/Settings/KeyValuePairs/SurrogateConfigurationMethods.cs
+++ b/src/Serilog/Settings/KeyValuePairs/SurrogateConfigurationMethods.cs
@@ -1,0 +1,56 @@
+﻿// Copyright 2013-2018 Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Serilog.Configuration;
+
+namespace Serilog.Settings.KeyValuePairs
+{
+    /// <summary>
+    /// Contains "fake extension" methods for the Serilog configuration API.
+    /// By default the settings knows how to find extension methods, but some configuration
+    /// are actually "regular" method calls and would not be found otherwise.
+    ///
+    /// This static class contains internal methods that can be used instead.
+    ///
+    /// See also <seealso cref="CallableConfigurationMethodFinder"/>
+    /// </summary>
+    static class SurrogateConfigurationMethods
+    {
+        internal static LoggerConfiguration FromLogContext(LoggerEnrichmentConfiguration loggerEnrichmentConfiguration)
+        {
+            return loggerEnrichmentConfiguration.FromLogContext();
+        }
+
+        internal static LoggerConfiguration ToMaximumCollectionCount(LoggerDestructuringConfiguration loggerDestructuringConfiguration,
+            int maximumCollectionCount)
+        {
+            return loggerDestructuringConfiguration.ToMaximumCollectionCount(maximumCollectionCount);
+        }
+
+        internal static LoggerConfiguration ToMaximumDepth(LoggerDestructuringConfiguration loggerDestructuringConfiguration,
+            int maximumDestructuringDepth)
+        {
+            return loggerDestructuringConfiguration.ToMaximumDepth(maximumDestructuringDepth);
+        }
+
+        internal static LoggerConfiguration ToMaximumStringLength(LoggerDestructuringConfiguration loggerDestructuringConfiguration,
+            int maximumStringLength)
+        {
+            return loggerDestructuringConfiguration.ToMaximumStringLength(maximumStringLength);
+        }
+
+        
+
+    }
+}

--- a/test/Serilog.Tests/Settings/CallableConfigurationMethodFinderTests.cs
+++ b/test/Serilog.Tests/Settings/CallableConfigurationMethodFinderTests.cs
@@ -26,5 +26,24 @@ namespace Serilog.Tests.Settings
             Assert.Contains("FromLogContext", eventEnrichers);
             Assert.Contains("WithDummyThreadId", eventEnrichers);
         }
+
+        [Fact]
+        public void FindsDestructureSpecificConfigurationMethods()
+        {
+            var destructuringMethods = CallableConfigurationMethodFinder
+                .FindConfigurationMethods(new[]
+                {
+                    typeof(Log).GetTypeInfo().Assembly,
+                    typeof(DummyThreadIdEnricher).GetTypeInfo().Assembly,
+                }, typeof(LoggerDestructuringConfiguration))
+                .Select(m => m.Name)
+                .Distinct()
+                .ToList();
+            
+            Assert.Contains(nameof(LoggerDestructuringConfiguration.ToMaximumCollectionCount), destructuringMethods);
+            Assert.Contains(nameof(LoggerDestructuringConfiguration.ToMaximumDepth), destructuringMethods);
+            Assert.Contains(nameof(LoggerDestructuringConfiguration.ToMaximumStringLength), destructuringMethods);
+            Assert.Contains(nameof(DummyLoggerConfigurationExtensions.WithDummyHardCodedString), destructuringMethods);
+        }
     }
 }

--- a/test/TestDummies/DummyHardCodedStringDestructuringPolicy.cs
+++ b/test/TestDummies/DummyHardCodedStringDestructuringPolicy.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using Serilog.Core;
+using Serilog.Events;
+
+namespace TestDummies
+{
+    public class DummyHardCodedStringDestructuringPolicy : IDestructuringPolicy
+    {
+        readonly string _hardCodedString;
+
+        public DummyHardCodedStringDestructuringPolicy(string hardCodedString)
+        {
+            _hardCodedString = hardCodedString ?? throw new ArgumentNullException(nameof(hardCodedString));
+        }
+
+        public bool TryDestructure(object value, ILogEventPropertyValueFactory propertyValueFactory, out LogEventPropertyValue result)
+        {
+            result = new ScalarValue(_hardCodedString);
+            return true;
+        }
+    }
+}

--- a/test/TestDummies/DummyLoggerConfigurationExtensions.cs
+++ b/test/TestDummies/DummyLoggerConfigurationExtensions.cs
@@ -86,5 +86,13 @@ namespace TestDummies
                 logEventLevel,
                 levelSwitch);
         }
+
+        public static LoggerConfiguration WithDummyHardCodedString(
+            this LoggerDestructuringConfiguration loggerDestructuringConfiguration,
+            string hardCodedString
+        )
+        {
+            return loggerDestructuringConfiguration.With(new DummyHardCodedStringDestructuringPolicy(hardCodedString));
+        }
     }
 }


### PR DESCRIPTION
Supports Serilog "native" non-generic simple  methods : 
- `.ToMaximumDepth(int maximumDestructuringDepth)`
- `.ToMaximumStringLength(int maximumStringLength)`
- `.ToMaximumCollectionCount(int maximumCollectionCount)`

and also for any *extension method* for `LoggerDestructuringConfiguration`.

Unsupported methods (should they be added ? and how would they be configured ? ) : 
- `.AsScalar(Type scalarType)`
- `.AsScalar<TScalar>()`
- `.With(params IDestructuringPolicy[] destructuringPolicies)`
- `.With<TDestructuringPolicy>()`
- `.ByTransforming<TValue>(Func<TValue, object> transformation)`
- `.ByTransformingWhere<TValue>(Func<Type, bool> predicate, Func<TValue, object> transformation)`       

Most test cases adapted from equivalent PR in serilog/serilog-settings-configuration#110 (thanks @MV10 ! ).

This should fix #1172 and automatically add the functionality for *Serilog.Settings.AppSettings* down the line (see serilog/serilog-settings-appsettings#20 )

If/when merged, we should remember to update the `README`in *Serilog.Settings.AppSettings*.