### PR TITLE
Support for .Destructure.AsScalar(scalarType) in KeyValueSettings

### DIFF
--- a/src/Serilog/Settings/KeyValuePairs/CallableConfigurationMethodFinder.cs
+++ b/src/Serilog/Settings/KeyValuePairs/CallableConfigurationMethodFinder.cs
@@ -25,6 +25,7 @@ namespace Serilog.Settings.KeyValuePairs
     {
         static readonly MethodInfo[] SurrogateMethodCandidates = typeof(SurrogateConfigurationMethods).GetTypeInfo().DeclaredMethods.ToArray();
         static readonly MethodInfo SurrogateEnrichFromLogContextConfigurationMethod = SurrogateMethodCandidates.Single(m => m.Name == nameof(SurrogateConfigurationMethods.FromLogContext));
+        static readonly MethodInfo SurrogateDestructureAsScalarConfigurationMethod = SurrogateMethodCandidates.Single(m => m.Name == nameof(SurrogateConfigurationMethods.AsScalar));
         static readonly MethodInfo SurrogateDestructureToMaximumCollectionCountConfigurationMethod = SurrogateMethodCandidates.Single(m => m.Name == nameof(SurrogateConfigurationMethods.ToMaximumCollectionCount));
         static readonly MethodInfo SurrogateDestructureToMaximumDepthConfigurationMethod = SurrogateMethodCandidates.Single(m => m.Name == nameof(SurrogateConfigurationMethods.ToMaximumDepth));
         static readonly MethodInfo SurrogateDestructureToMaximumStringLengthConfigurationMethod = SurrogateMethodCandidates.Single(m => m.Name == nameof(SurrogateConfigurationMethods.ToMaximumStringLength));
@@ -48,6 +49,7 @@ namespace Serilog.Settings.KeyValuePairs
             // Some of the useful Destructure configuration methods are defined as methods rather than extension methods
             if (configType == typeof(LoggerDestructuringConfiguration))
             {
+                methods.Add(SurrogateDestructureAsScalarConfigurationMethod);
                 methods.Add(SurrogateDestructureToMaximumCollectionCountConfigurationMethod);
                 methods.Add(SurrogateDestructureToMaximumDepthConfigurationMethod);
                 methods.Add(SurrogateDestructureToMaximumStringLengthConfigurationMethod);

--- a/src/Serilog/Settings/KeyValuePairs/SettingValueConversions.cs
+++ b/src/Serilog/Settings/KeyValuePairs/SettingValueConversions.cs
@@ -30,7 +30,8 @@ namespace Serilog.Settings.KeyValuePairs
         static Dictionary<Type, Func<string, object>> ExtendedTypeConversions = new Dictionary<Type, Func<string, object>>
             {
                 { typeof(Uri), s => new Uri(s) },
-                { typeof(TimeSpan), s => TimeSpan.Parse(s) }
+                { typeof(TimeSpan), s => TimeSpan.Parse(s) },
+                { typeof(Type), s => Type.GetType(s, throwOnError:true) },
             };
 
         public static object ConvertToType(string value, Type toType)

--- a/src/Serilog/Settings/KeyValuePairs/SurrogateConfigurationMethods.cs
+++ b/src/Serilog/Settings/KeyValuePairs/SurrogateConfigurationMethods.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System;
 using Serilog.Configuration;
 
 namespace Serilog.Settings.KeyValuePairs
@@ -32,6 +33,13 @@ namespace Serilog.Settings.KeyValuePairs
             return loggerEnrichmentConfiguration.FromLogContext();
         }
 
+
+        internal static LoggerConfiguration AsScalar(LoggerDestructuringConfiguration loggerDestructuringConfiguration,
+            Type scalarType)
+        {
+            return loggerDestructuringConfiguration.AsScalar(scalarType);
+        }
+
         internal static LoggerConfiguration ToMaximumCollectionCount(LoggerDestructuringConfiguration loggerDestructuringConfiguration,
             int maximumCollectionCount)
         {
@@ -50,7 +58,7 @@ namespace Serilog.Settings.KeyValuePairs
             return loggerDestructuringConfiguration.ToMaximumStringLength(maximumStringLength);
         }
 
-        
+
 
     }
 }

--- a/test/Serilog.Tests/Settings/CallableConfigurationMethodFinderTests.cs
+++ b/test/Serilog.Tests/Settings/CallableConfigurationMethodFinderTests.cs
@@ -40,6 +40,7 @@ namespace Serilog.Tests.Settings
                 .Distinct()
                 .ToList();
             
+            Assert.Contains(nameof(LoggerDestructuringConfiguration.AsScalar), destructuringMethods);
             Assert.Contains(nameof(LoggerDestructuringConfiguration.ToMaximumCollectionCount), destructuringMethods);
             Assert.Contains(nameof(LoggerDestructuringConfiguration.ToMaximumDepth), destructuringMethods);
             Assert.Contains(nameof(LoggerDestructuringConfiguration.ToMaximumStringLength), destructuringMethods);

--- a/test/Serilog.Tests/Settings/KeyValuePairSettingsTests.cs
+++ b/test/Serilog.Tests/Settings/KeyValuePairSettingsTests.cs
@@ -472,16 +472,32 @@ namespace Serilog.Tests.Settings
             Assert.Equal("\"hardcoded\"", formattedProperty);
         }
 
-        [Theory]
-        [InlineData("System.Version")]
-        [InlineData("System.Version, System.Runtime, Version=4.2.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a")]
-        public void DestructuringAsScalarIsApplied(string typeName)
+        [Fact]
+        public void DestructuringAsScalarIsAppliedWithShortTypeName()
         {
             LogEvent evt = null;
             var log = new LoggerConfiguration()
                 .ReadFrom.KeyValuePairs(new Dictionary<string, string>
                 {
-                    ["destructure:AsScalar.scalarType"] = typeName
+                    ["destructure:AsScalar.scalarType"] = "System.Version"
+                })
+                .WriteTo.Sink(new DelegatingSink(e => evt = e))
+                .CreateLogger();
+
+            log.Information("Destructuring as scalar {@Scalarized}", new Version(2,3));
+            var prop = evt.Properties["Scalarized"];
+
+            Assert.IsType<ScalarValue>(prop);
+        }
+
+        [Fact]
+        public void DestructuringAsScalarIsAppliedWithAssemblyQualifiedName()
+        {
+            LogEvent evt = null;
+            var log = new LoggerConfiguration()
+                .ReadFrom.KeyValuePairs(new Dictionary<string, string>
+                {
+                    ["destructure:AsScalar.scalarType"] = typeof(Version).AssemblyQualifiedName
                 })
                 .WriteTo.Sink(new DelegatingSink(e => evt = e))
                 .CreateLogger();

--- a/test/Serilog.Tests/Settings/KeyValuePairSettingsTests.cs
+++ b/test/Serilog.Tests/Settings/KeyValuePairSettingsTests.cs
@@ -466,10 +466,30 @@ namespace Serilog.Tests.Settings
                 .WriteTo.Sink(new DelegatingSink(e => evt = e))
                 .CreateLogger();
 
-            log.Information("Destructuring a big collection {@Input}", new { Foo = "Bar" });
+            log.Information("Destructuring with hard-coded policy {@Input}", new { Foo = "Bar" });
             var formattedProperty = evt.Properties["Input"].ToString();
 
             Assert.Equal("\"hardcoded\"", formattedProperty);
+        }
+
+        [Theory]
+        [InlineData("System.Version")]
+        [InlineData("System.Version, System.Runtime, Version=4.2.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a")]
+        public void DestructuringAsScalarIsApplied(string typeName)
+        {
+            LogEvent evt = null;
+            var log = new LoggerConfiguration()
+                .ReadFrom.KeyValuePairs(new Dictionary<string, string>
+                {
+                    ["destructure:AsScalar.scalarType"] = typeName
+                })
+                .WriteTo.Sink(new DelegatingSink(e => evt = e))
+                .CreateLogger();
+
+            log.Information("Destructuring as scalar {@Scalarized}", new Version(2,3));
+            var prop = evt.Properties["Scalarized"];
+
+            Assert.IsType<ScalarValue>(prop);
         }
 
     }

--- a/test/Serilog.Tests/Settings/SettingValueConversionsTests.cs
+++ b/test/Serilog.Tests/Settings/SettingValueConversionsTests.cs
@@ -46,6 +46,20 @@ namespace Serilog.Tests.Settings
         }
 
         [Fact]
+        public void ValuesConvertToTypeFromQualifiedName()
+        {
+            var result = (Type)SettingValueConversions.ConvertToType("System.Version", typeof(Type));
+            Assert.Equal(typeof(Version), result);
+        }
+
+        [Fact]
+        public void ValuesConvertToTypeFromAssemblyQualifiedName()
+        {
+            var result = (Type)SettingValueConversions.ConvertToType("System.Version, System.Runtime, Version=4.2.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a", typeof(Type));
+            Assert.Equal(typeof(Version), result);
+        }
+
+        [Fact]
         public void StringValuesConvertToDefaultInstancesIfTargetIsInterface()
         {
             var result = SettingValueConversions.ConvertToType("Serilog.Formatting.Json.JsonFormatter", typeof(ITextFormatter));
@@ -102,7 +116,7 @@ namespace Serilog.Tests.Settings
                     null, null)]
         [InlineData(null,
                     null, null)]
-        [InlineData(" " ,
+        [InlineData(" ",
                     null, null)]
         // a full-qualified type name should not be considered a static member accessor
         [InlineData("My.NameSpace.Class, MyAssembly, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",

--- a/test/Serilog.Tests/Settings/SettingValueConversionsTests.cs
+++ b/test/Serilog.Tests/Settings/SettingValueConversionsTests.cs
@@ -55,7 +55,8 @@ namespace Serilog.Tests.Settings
         [Fact]
         public void ValuesConvertToTypeFromAssemblyQualifiedName()
         {
-            var result = (Type)SettingValueConversions.ConvertToType("System.Version, System.Runtime, Version=4.2.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a", typeof(Type));
+            var assemblyQualifiedName = typeof(Version).AssemblyQualifiedName;
+            var result = (Type)SettingValueConversions.ConvertToType(assemblyQualifiedName, typeof(Type));
             Assert.Equal(typeof(Version), result);
         }
 


### PR DESCRIPTION
**What issue does this PR address?**
This should fix #1177 

**Does this PR introduce a breaking change?**
no

**Please check if the PR fulfills these requirements**
- [X] The commit follows our [guidelines](https://github.com/serilog/serilog/blob/dev/CONTRIBUTING.md)
- [X] Unit Tests for the changes have been added (for bug fixes / features)

**Other information**:
Adds support for key-value settings like : 

```xml
<add key="serilog:destructure:AsScalar.scalarType" value="MyNamespace.MyType, MyAssembly, Version=4.2.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
```

As a side-effect, it also adds global support for calling **configuration methods that have a parameter of type `Type`**, by accepting the type name.

The type lookup relies on [`Type.GetType(string typeName, bool throwOnError)`](https://docs.microsoft.com/en-us/dotnet/api/system.type.gettype?view=netframework-4.7.1#System_Type_GetType_System_String_System_Boolean_) (with `throwOnError` set to `true`) so it accepts a type name in the form : 

> The assembly-qualified name of the type to get. See AssemblyQualifiedName. If the type is in the currently executing assembly or in Mscorlib.dll, it is sufficient to supply the type name qualified by its namespace.