### PR TITLE
Take into account custom `IFormatProvider` when format is `{Message:lj}`

### DIFF
--- a/src/Serilog/Rendering/MessageTemplateRenderer.cs
+++ b/src/Serilog/Rendering/MessageTemplateRenderer.cs
@@ -51,7 +51,7 @@ namespace Serilog.Rendering
                 }
                 else
                 {
-                    var pt = (PropertyToken) token;
+                    var pt = (PropertyToken)token;
                     RenderPropertyToken(pt, properties, output, formatProvider, isLiteral, isJson);
                 }
             }
@@ -92,9 +92,12 @@ namespace Serilog.Rendering
 
         static void RenderValue(LogEventPropertyValue propertyValue, bool literal, bool json, TextWriter output, string format, IFormatProvider formatProvider)
         {
-            if (literal && propertyValue is ScalarValue sv && sv.Value is string str)
+            // _literal_ means scalar values are not wrapped in "quotes"
+            // _json_ means ... json
+            // _literal_ AND _json_ means scalar values without quotes and structured values as json
+            if (literal && propertyValue is ScalarValue sv)
             {
-                output.Write(str);
+                RenderLiteralScalar(sv, output, format, formatProvider);
             }
             else if (json)
             {
@@ -104,6 +107,18 @@ namespace Serilog.Rendering
             {
                 propertyValue.Render(output, format, formatProvider);
             }
+        }
+
+        static void RenderLiteralScalar(ScalarValue scalarValue, TextWriter output, string format, IFormatProvider formatProvider)
+        {
+            if (scalarValue.Value is string str)
+            {
+                // render without double quotes. _format_ makes no sense for strings
+                output.Write(str);
+                return;
+            }
+
+            scalarValue.Render(output, format, formatProvider);
         }
     }
 }

--- a/test/Serilog.Tests/Formatting/Display/MessageTemplateTextFormatterTests.cs
+++ b/test/Serilog.Tests/Formatting/Display/MessageTemplateTextFormatterTests.cs
@@ -309,7 +309,7 @@ namespace Serilog.Tests.Formatting.Display
         [Theory]
         [Trait("Bugfix", "#1115")]
         [InlineData("", true)]
-        [InlineData(":lj", true)]
+        [InlineData(":lj", false)]
         [InlineData(":j", false)]
         [InlineData(":l", true)]
         public void FormatProviderIsUsedForNonJsonFormatWithStructure(string format, bool shouldUseCustomFormatter)


### PR DESCRIPTION
Try to fix #1115 

Based on discussions around the issue about where it should make sense to consider the user-provider `IFormatProvider` : 
- `:j` is a serialization format so it should not be customizable
- `:lj` is targeted towards human beings, so it should be customizable (it is not right now)
- `:l` should be customizable (it is already)
- ` ` should be customizable (it is already)

It makes sense to try and fix `:lj` given that it is the default *Output template* for *Serilog.Sinks.Console* and *Serilog.Sinks.File* (they use 
`"[{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj}{NewLine}{Exception}"` and 
`"{Timestamp:yyyy-MM-dd HH:mm:ss.fff zzz} [{Level:u3}] {Message:lj}{NewLine}{Exception}"` respectively ).

