### PR TITLE
Add support for Destructure.With(IDestructuringPolicy policy) in settings

### DIFF
--- a/src/Serilog/Settings/KeyValuePairs/CallableConfigurationMethodFinder.cs
+++ b/src/Serilog/Settings/KeyValuePairs/CallableConfigurationMethodFinder.cs
@@ -29,6 +29,7 @@ namespace Serilog.Settings.KeyValuePairs
         static readonly MethodInfo SurrogateDestructureToMaximumCollectionCountConfigurationMethod = SurrogateMethodCandidates.Single(m => m.Name == nameof(SurrogateConfigurationMethods.ToMaximumCollectionCount));
         static readonly MethodInfo SurrogateDestructureToMaximumDepthConfigurationMethod = SurrogateMethodCandidates.Single(m => m.Name == nameof(SurrogateConfigurationMethods.ToMaximumDepth));
         static readonly MethodInfo SurrogateDestructureToMaximumStringLengthConfigurationMethod = SurrogateMethodCandidates.Single(m => m.Name == nameof(SurrogateConfigurationMethods.ToMaximumStringLength));
+        static readonly MethodInfo SurrogateDestructureWithConfigurationMethod = SurrogateMethodCandidates.Single(m => m.Name == nameof(SurrogateConfigurationMethods.With));
 
         internal static IList<MethodInfo> FindConfigurationMethods(IEnumerable<Assembly> configurationAssemblies, Type configType)
         {
@@ -53,6 +54,7 @@ namespace Serilog.Settings.KeyValuePairs
                 methods.Add(SurrogateDestructureToMaximumCollectionCountConfigurationMethod);
                 methods.Add(SurrogateDestructureToMaximumDepthConfigurationMethod);
                 methods.Add(SurrogateDestructureToMaximumStringLengthConfigurationMethod);
+                methods.Add(SurrogateDestructureWithConfigurationMethod);
             }
 
             return methods;

--- a/src/Serilog/Settings/KeyValuePairs/SurrogateConfigurationMethods.cs
+++ b/src/Serilog/Settings/KeyValuePairs/SurrogateConfigurationMethods.cs
@@ -14,6 +14,7 @@
 
 using System;
 using Serilog.Configuration;
+using Serilog.Core;
 
 namespace Serilog.Settings.KeyValuePairs
 {
@@ -33,6 +34,11 @@ namespace Serilog.Settings.KeyValuePairs
             return loggerEnrichmentConfiguration.FromLogContext();
         }
 
+        internal static LoggerConfiguration With(LoggerDestructuringConfiguration loggerDestructuringConfiguration,
+            IDestructuringPolicy policy)
+        {
+            return loggerDestructuringConfiguration.With(policy);
+        }
 
         internal static LoggerConfiguration AsScalar(LoggerDestructuringConfiguration loggerDestructuringConfiguration,
             Type scalarType)

--- a/test/Serilog.Tests/Settings/CallableConfigurationMethodFinderTests.cs
+++ b/test/Serilog.Tests/Settings/CallableConfigurationMethodFinderTests.cs
@@ -45,6 +45,7 @@ namespace Serilog.Tests.Settings
             Assert.Contains(nameof(LoggerDestructuringConfiguration.ToMaximumDepth), destructuringMethods);
             Assert.Contains(nameof(LoggerDestructuringConfiguration.ToMaximumStringLength), destructuringMethods);
             Assert.Contains(nameof(DummyLoggerConfigurationExtensions.WithDummyHardCodedString), destructuringMethods);
+            Assert.Contains(nameof(LoggerDestructuringConfiguration.With), destructuringMethods);
         }
     }
 }

--- a/test/Serilog.Tests/Settings/KeyValuePairSettingsTests.cs
+++ b/test/Serilog.Tests/Settings/KeyValuePairSettingsTests.cs
@@ -508,5 +508,24 @@ namespace Serilog.Tests.Settings
             Assert.IsType<ScalarValue>(prop);
         }
 
+        [Fact]
+        public void DestructuringWithIsAppliedWithCustomDestructuringPolicy()
+        {
+            LogEvent evt = null;
+            var log = new LoggerConfiguration()
+                .ReadFrom.KeyValuePairs(new Dictionary<string, string>
+                {
+                    ["using:TestDummies"] = typeof(DummyLoggerConfigurationExtensions).GetTypeInfo().Assembly.FullName,
+                    ["destructure:With.policy"] = typeof(DummyReduceVersionToMajorPolicy).AssemblyQualifiedName
+                })
+                .WriteTo.Sink(new DelegatingSink(e => evt = e))
+                .CreateLogger();
+
+            log.Information("Destructuring with policy {@Version}", new Version(2,3));
+            var prop = evt.Properties["Version"];
+
+            Assert.IsType<ScalarValue>(prop);
+            Assert.Equal(2, (prop as ScalarValue)?.Value);
+        }
     }
 }

--- a/test/TestDummies/DummyReduceVersionToMajorPolicy.cs
+++ b/test/TestDummies/DummyReduceVersionToMajorPolicy.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using Serilog.Core;
+using Serilog.Events;
+
+namespace TestDummies
+{
+    public class DummyReduceVersionToMajorPolicy : IDestructuringPolicy
+    {
+        public bool TryDestructure(object value, ILogEventPropertyValueFactory propertyValueFactory, out LogEventPropertyValue result)
+        {
+            if (value is Version version)
+            {
+                result = new ScalarValue(version.Major);
+                return true;
+            }
+
+            result = null;
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
fixes #1190

The key-value settings will accept the assembly-qualified name of a type implementing IDestructuringPolicy if it has a default constructor
