### PR TITLE
Allow SilentLogger to be contructed as singleton

### DIFF
--- a/src/Serilog/Core/Logger.cs
+++ b/src/Serilog/Core/Logger.cs
@@ -1377,6 +1377,6 @@ namespace Serilog.Core
         /// <summary>
         /// An <see cref="ILogger"/> instance that efficiently ignores all method calls.
         /// </summary>
-        public static ILogger None { get; } = new SilentLogger();
+        public static ILogger None { get; } = SilentLogger.None;
     }
 }

--- a/src/Serilog/Core/Logger.cs
+++ b/src/Serilog/Core/Logger.cs
@@ -1377,6 +1377,6 @@ namespace Serilog.Core
         /// <summary>
         /// An <see cref="ILogger"/> instance that efficiently ignores all method calls.
         /// </summary>
-        public static ILogger None { get; } = SilentLogger.None;
+        public static ILogger None { get; } = SilentLogger.Instance;
     }
 }

--- a/src/Serilog/Core/Pipeline/SilentLogger.cs
+++ b/src/Serilog/Core/Pipeline/SilentLogger.cs
@@ -20,7 +20,7 @@ namespace Serilog.Core.Pipeline
 {
     class SilentLogger : ILogger
     {
-        public readonly static ILogger None = new SilentLogger();
+        public static readonly ILogger Instance = new SilentLogger();
 
         public ILogger ForContext(ILogEventEnricher enricher)
         {

--- a/src/Serilog/Core/Pipeline/SilentLogger.cs
+++ b/src/Serilog/Core/Pipeline/SilentLogger.cs
@@ -20,6 +20,8 @@ namespace Serilog.Core.Pipeline
 {
     class SilentLogger : ILogger
     {
+        public readonly static ILogger None = new SilentLogger();
+
         public ILogger ForContext(ILogEventEnricher enricher)
         {
             return this;

--- a/src/Serilog/Core/Pipeline/SilentLogger.cs
+++ b/src/Serilog/Core/Pipeline/SilentLogger.cs
@@ -22,6 +22,10 @@ namespace Serilog.Core.Pipeline
     {
         public static readonly ILogger Instance = new SilentLogger();
 
+        private SilentLogger()
+        {
+        }
+
         public ILogger ForContext(ILogEventEnricher enricher)
         {
             return this;

--- a/src/Serilog/Log.cs
+++ b/src/Serilog/Log.cs
@@ -40,7 +40,7 @@ namespace Serilog
     /// </remarks>
     public static class Log
     {
-        static ILogger _logger = new SilentLogger();
+        static ILogger _logger = SilentLogger.None;
 
         /// <summary>
         /// The globally-shared logger.

--- a/src/Serilog/Log.cs
+++ b/src/Serilog/Log.cs
@@ -40,7 +40,7 @@ namespace Serilog
     /// </remarks>
     public static class Log
     {
-        static ILogger _logger = SilentLogger.None;
+        static ILogger _logger = SilentLogger.Instance;
 
         /// <summary>
         /// The globally-shared logger.

--- a/src/Serilog/Log.cs
+++ b/src/Serilog/Log.cs
@@ -61,7 +61,7 @@ namespace Serilog
         /// </summary>
         public static void CloseAndFlush()
         {
-            ILogger logger = Interlocked.Exchange(ref _logger, new SilentLogger());
+            ILogger logger = Interlocked.Exchange(ref _logger, SilentLogger.Instance);
 
             (logger as IDisposable)?.Dispose();
         }

--- a/test/Serilog.Tests/Core/LoggerTests.cs
+++ b/test/Serilog.Tests/Core/LoggerTests.cs
@@ -137,7 +137,11 @@ namespace Serilog.Tests.Core
         [Fact]
         public void TheNoneLoggerIsSingleton()
         {
-            Assert.Same(Log.Logger, Logger.None);
+            lock (new object())
+            {
+                Log.CloseAndFlush();
+                Assert.Same(Log.Logger, Logger.None);
+            }
         }
     }
 }

--- a/test/Serilog.Tests/Core/LoggerTests.cs
+++ b/test/Serilog.Tests/Core/LoggerTests.cs
@@ -133,5 +133,11 @@ namespace Serilog.Tests.Core
             var secondCall = Logger.None;
             Assert.Equal(firstCall, secondCall);
         }
-	}
+
+        [Fact]
+        public void TheNoneLoggerIsSingleton()
+        {
+            Assert.Same(Log.Logger, Logger.None);
+        }
+    }
 }

--- a/test/Serilog.Tests/MethodOverloadConventionTests.cs
+++ b/test/Serilog.Tests/MethodOverloadConventionTests.cs
@@ -933,7 +933,7 @@ namespace Serilog.Tests
             }
 
             if (loggerType == typeof(SilentLogger))
-                return new SilentLogger();
+                return SilentLogger.Instance;
 
             throw new ArgumentException($"Logger Type of {loggerType} is not supported");
         }


### PR DESCRIPTION
**What issue does this PR address?**
Fix #1195: This allows comparision Log.Logger = Logger.None

**Does this PR introduce a breaking change?**
No, the change should not have any breaking effect to the clients

**Please check if the PR fulfills these requirements**
- [x] The commit follows our [guidelines](https://github.com/serilog/serilog/blob/dev/CONTRIBUTING.md)
- [x] Unit Tests for the changes have been added (for bug fixes / features)

**Other information**:
I do not believe it is appropriate/there is a need to override Equals() method as it is not a value type but I am happy to take any suggestions.