### PR TITLE
Config method support

### DIFF
--- a/src/Serilog/Settings/KeyValuePairs/CallableConfigurationMethodFinder.cs
+++ b/src/Serilog/Settings/KeyValuePairs/CallableConfigurationMethodFinder.cs
@@ -36,7 +36,7 @@ namespace Serilog.Settings.KeyValuePairs
 
             // some configuration methods are not extension methods. They are added manually
             // so they can be discovered
-            
+
             // WriteTo.Sink(params ILogEventSink[]) is not an extension method
             // and we want to expose WriteTo.Sink(ILogEventSink sink) to the config system
             if (configType == typeof(LoggerSinkConfiguration))
@@ -54,6 +54,10 @@ namespace Serilog.Settings.KeyValuePairs
             // Some of the useful Destructure configuration methods are defined as methods rather than extension methods
             if (configType == typeof(LoggerDestructuringConfiguration))
                 methods.AddRange(SurrogateConfigurationMethods.Destructure);
+
+            // Some of the useful Filter configuration methods are defined as methods rather than extension methods
+            if (configType == typeof(LoggerFilterConfiguration))
+                methods.AddRange(SurrogateConfigurationMethods.Filter);
 
             return methods;
         }

--- a/src/Serilog/Settings/KeyValuePairs/CallableConfigurationMethodFinder.cs
+++ b/src/Serilog/Settings/KeyValuePairs/CallableConfigurationMethodFinder.cs
@@ -23,18 +23,6 @@ namespace Serilog.Settings.KeyValuePairs
 {
     static class CallableConfigurationMethodFinder
     {
-        static readonly MethodInfo[] SurrogateMethodCandidates = typeof(SurrogateConfigurationMethods).GetTypeInfo().DeclaredMethods.ToArray();
-
-        static readonly MethodInfo SurrogateWriteToSinkConfigurationMethod = SurrogateMethodCandidates.Single(m => m.Name == nameof(SurrogateConfigurationMethods.Sink));
-
-        static readonly MethodInfo SurrogateEnrichFromLogContextConfigurationMethod = SurrogateMethodCandidates.Single(m => m.Name == nameof(SurrogateConfigurationMethods.FromLogContext));
-        static readonly MethodInfo SurrogateDestructureAsScalarConfigurationMethod = SurrogateMethodCandidates.Single(m => m.Name == nameof(SurrogateConfigurationMethods.AsScalar));
-        static readonly MethodInfo SurrogateDestructureToMaximumCollectionCountConfigurationMethod = SurrogateMethodCandidates.Single(m => m.Name == nameof(SurrogateConfigurationMethods.ToMaximumCollectionCount));
-        static readonly MethodInfo SurrogateDestructureToMaximumDepthConfigurationMethod = SurrogateMethodCandidates.Single(m => m.Name == nameof(SurrogateConfigurationMethods.ToMaximumDepth));
-        static readonly MethodInfo SurrogateDestructureToMaximumStringLengthConfigurationMethod = SurrogateMethodCandidates.Single(m => m.Name == nameof(SurrogateConfigurationMethods.ToMaximumStringLength));
-        static readonly MethodInfo SurrogateDestructureWithConfigurationMethod = SurrogateMethodCandidates.Single(m => m.Name == nameof(SurrogateConfigurationMethods.With));
-        
-
         internal static IList<MethodInfo> FindConfigurationMethods(IEnumerable<Assembly> configurationAssemblies, Type configType)
         {
             var methods = configurationAssemblies
@@ -52,22 +40,20 @@ namespace Serilog.Settings.KeyValuePairs
             // WriteTo.Sink(params ILogEventSink[]) is not an extension method
             // and we want to expose WriteTo.Sink(ILogEventSink sink) to the config system
             if (configType == typeof(LoggerSinkConfiguration))
-                methods.Add(SurrogateWriteToSinkConfigurationMethod);
+                methods.AddRange(SurrogateConfigurationMethods.WriteTo);
+
+            // AuditTo.Sink(params ILogEventSink[]) is not an extension method
+            // and we want to expose WriteTo.Sink(ILogEventSink sink) to the config system
+            if (configType == typeof(LoggerAuditSinkConfiguration))
+                methods.AddRange(SurrogateConfigurationMethods.AuditTo);
 
             // FromLogContext is an instance method rather than an extension. 
             if (configType == typeof(LoggerEnrichmentConfiguration))
-                methods.Add(SurrogateEnrichFromLogContextConfigurationMethod);
+                methods.AddRange(SurrogateConfigurationMethods.Enrich);
 
             // Some of the useful Destructure configuration methods are defined as methods rather than extension methods
             if (configType == typeof(LoggerDestructuringConfiguration))
-            {
-                methods.Add(SurrogateDestructureAsScalarConfigurationMethod);
-                methods.Add(SurrogateDestructureToMaximumCollectionCountConfigurationMethod);
-                methods.Add(SurrogateDestructureToMaximumDepthConfigurationMethod);
-                methods.Add(SurrogateDestructureToMaximumStringLengthConfigurationMethod);
-                methods.Add(SurrogateDestructureWithConfigurationMethod);
-            }
-
+                methods.AddRange(SurrogateConfigurationMethods.Destructure);
 
             return methods;
         }

--- a/src/Serilog/Settings/KeyValuePairs/SurrogateConfigurationMethods.cs
+++ b/src/Serilog/Settings/KeyValuePairs/SurrogateConfigurationMethods.cs
@@ -15,6 +15,7 @@
 using System;
 using Serilog.Configuration;
 using Serilog.Core;
+using Serilog.Events;
 
 namespace Serilog.Settings.KeyValuePairs
 {
@@ -29,6 +30,15 @@ namespace Serilog.Settings.KeyValuePairs
     /// </summary>
     static class SurrogateConfigurationMethods
     {
+        internal static LoggerConfiguration Sink(
+            LoggerSinkConfiguration loggerSinkConfiguration,
+            ILogEventSink sink,
+            LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
+            LoggingLevelSwitch levelSwitch = null)
+        {
+            return loggerSinkConfiguration.Sink(sink, restrictedToMinimumLevel, levelSwitch);
+        }
+
         internal static LoggerConfiguration FromLogContext(LoggerEnrichmentConfiguration loggerEnrichmentConfiguration)
         {
             return loggerEnrichmentConfiguration.FromLogContext();

--- a/src/Serilog/Settings/KeyValuePairs/SurrogateConfigurationMethods.cs
+++ b/src/Serilog/Settings/KeyValuePairs/SurrogateConfigurationMethods.cs
@@ -42,6 +42,7 @@ namespace Serilog.Settings.KeyValuePairs
         internal static readonly MethodInfo[] AuditTo = SurrogateMethodCandidates[typeof(LoggerAuditSinkConfiguration)];
         internal static readonly MethodInfo[] Enrich = SurrogateMethodCandidates[typeof(LoggerEnrichmentConfiguration)];
         internal static readonly MethodInfo[] Destructure = SurrogateMethodCandidates[typeof(LoggerDestructuringConfiguration)];
+        internal static readonly MethodInfo[] Filter = SurrogateMethodCandidates[typeof(LoggerFilterConfiguration)];
 
         internal static LoggerConfiguration Sink(
             LoggerSinkConfiguration loggerSinkConfiguration,
@@ -99,6 +100,12 @@ namespace Serilog.Settings.KeyValuePairs
             int maximumStringLength)
         {
             return loggerDestructuringConfiguration.ToMaximumStringLength(maximumStringLength);
+        }
+
+        internal static LoggerConfiguration With(LoggerFilterConfiguration loggerFilterConfiguration,
+            ILogEventFilter filter)
+        {
+            return loggerFilterConfiguration.With(filter);
         }
     }
 }

--- a/src/Serilog/Settings/KeyValuePairs/SurrogateConfigurationMethods.cs
+++ b/src/Serilog/Settings/KeyValuePairs/SurrogateConfigurationMethods.cs
@@ -61,6 +61,11 @@ namespace Serilog.Settings.KeyValuePairs
             return auditSinkConfiguration.Sink(sink, restrictedToMinimumLevel, levelSwitch);
         }
 
+        internal static LoggerConfiguration With(LoggerEnrichmentConfiguration loggerEnrichmentConfiguration, ILogEventEnricher enricher)
+        {
+            return loggerEnrichmentConfiguration.With(enricher);
+        }
+
         internal static LoggerConfiguration FromLogContext(LoggerEnrichmentConfiguration loggerEnrichmentConfiguration)
         {
             return loggerEnrichmentConfiguration.FromLogContext();

--- a/test/Serilog.Tests/LoggerConfigurationTests.cs
+++ b/test/Serilog.Tests/LoggerConfigurationTests.cs
@@ -590,7 +590,7 @@ namespace Serilog.Tests
         [Fact]
         public void WrappingDecoratesTheConfiguredSink()
         {
-            DummyWrappingSink.Emitted.Clear();
+            DummyWrappingSink.Reset();
             var sink = new CollectingSink();
             var logger = new LoggerConfiguration()
                 .WriteTo.Dummy(w => w.Sink(sink))
@@ -623,7 +623,7 @@ namespace Serilog.Tests
         [Fact]
         public void WrappingIsAppliedWhenChaining()
         {
-            DummyWrappingSink.Emitted.Clear();
+            DummyWrappingSink.Reset();
             var sink1 = new CollectingSink();
             var sink2 = new CollectingSink();
             var logger = new LoggerConfiguration()
@@ -642,7 +642,7 @@ namespace Serilog.Tests
         [Fact]
         public void WrappingIsAppliedWhenCallingMultipleTimes()
         {
-            DummyWrappingSink.Emitted.Clear();
+            DummyWrappingSink.Reset();
             var sink1 = new CollectingSink();
             var sink2 = new CollectingSink();
             var logger = new LoggerConfiguration()
@@ -678,7 +678,7 @@ namespace Serilog.Tests
         [Fact]
         public void WrappingSinkRespectsLogEventLevelSetting()
         {
-            DummyWrappingSink.Emitted.Clear();
+            DummyWrappingSink.Reset();
             var sink = new CollectingSink();
             var logger = new LoggerConfiguration()
                 .WriteTo.DummyWrap(w => w.Sink(sink), LogEventLevel.Error, null)
@@ -693,7 +693,7 @@ namespace Serilog.Tests
         [Fact]
         public void WrappingSinkRespectsLevelSwitchSetting()
         {
-            DummyWrappingSink.Emitted.Clear();
+            DummyWrappingSink.Reset();
             var sink = new CollectingSink();
             var logger = new LoggerConfiguration()
                 .WriteTo.DummyWrap(
@@ -710,7 +710,7 @@ namespace Serilog.Tests
         [Fact]
         public void WrappingSinkRespectsSetting()
         {
-            DummyWrappingSink.Emitted.Clear();
+            DummyWrappingSink.Reset();
             var sink = new CollectingSink();
             var logger = new LoggerConfiguration()
                 .WriteTo.DummyWrap(

--- a/test/Serilog.Tests/Settings/CallableConfigurationMethodFinderTests.cs
+++ b/test/Serilog.Tests/Settings/CallableConfigurationMethodFinderTests.cs
@@ -10,6 +10,22 @@ namespace Serilog.Tests.Settings
     public class CallableConfigurationMethodFinderTests
     {
         [Fact]
+        public void FindsSinkSpecificConfigurationMethods()
+        {
+            var eventEnrichers = CallableConfigurationMethodFinder
+                .FindConfigurationMethods(new[]
+                {
+                    typeof(Log).GetTypeInfo().Assembly,
+                    typeof(DummyLoggerConfigurationExtensions).GetTypeInfo().Assembly
+                }, typeof(LoggerSinkConfiguration))
+                .Select(m => m.Name)
+                .Distinct()
+                .ToList();
+
+            Assert.Contains("Sink", eventEnrichers);
+        }
+
+        [Fact]
         public void FindsEnricherSpecificConfigurationMethods()
         {
             var eventEnrichers = CallableConfigurationMethodFinder
@@ -22,7 +38,6 @@ namespace Serilog.Tests.Settings
                 .Distinct()
                 .ToList();
 
-
             Assert.Contains("FromLogContext", eventEnrichers);
             Assert.Contains("WithDummyThreadId", eventEnrichers);
         }
@@ -34,7 +49,7 @@ namespace Serilog.Tests.Settings
                 .FindConfigurationMethods(new[]
                 {
                     typeof(Log).GetTypeInfo().Assembly,
-                    typeof(DummyThreadIdEnricher).GetTypeInfo().Assembly,
+                    typeof(DummyLoggerConfigurationExtensions).GetTypeInfo().Assembly,
                 }, typeof(LoggerDestructuringConfiguration))
                 .Select(m => m.Name)
                 .Distinct()

--- a/test/Serilog.Tests/Settings/CallableConfigurationMethodFinderTests.cs
+++ b/test/Serilog.Tests/Settings/CallableConfigurationMethodFinderTests.cs
@@ -12,7 +12,7 @@ namespace Serilog.Tests.Settings
         [Fact]
         public void FindsSinkSpecificConfigurationMethods()
         {
-            var eventEnrichers = CallableConfigurationMethodFinder
+            var sinkMethods = CallableConfigurationMethodFinder
                 .FindConfigurationMethods(new[]
                 {
                     typeof(Log).GetTypeInfo().Assembly,
@@ -22,13 +22,29 @@ namespace Serilog.Tests.Settings
                 .Distinct()
                 .ToList();
 
-            Assert.Contains("Sink", eventEnrichers);
+            Assert.Contains("Sink", sinkMethods);
+        }
+
+        [Fact]
+        public void FindsAuditSinkSpecificConfigurationMethods()
+        {
+            var auditSinkMethods = CallableConfigurationMethodFinder
+                .FindConfigurationMethods(new[]
+                {
+                    typeof(Log).GetTypeInfo().Assembly,
+                    typeof(DummyLoggerConfigurationExtensions).GetTypeInfo().Assembly
+                }, typeof(LoggerAuditSinkConfiguration))
+                .Select(m => m.Name)
+                .Distinct()
+                .ToList();
+
+            Assert.Contains("Sink", auditSinkMethods);
         }
 
         [Fact]
         public void FindsEnricherSpecificConfigurationMethods()
         {
-            var eventEnrichers = CallableConfigurationMethodFinder
+            var enricherMethods = CallableConfigurationMethodFinder
                 .FindConfigurationMethods(new[]
                 {
                     typeof(Log).GetTypeInfo().Assembly,
@@ -38,8 +54,8 @@ namespace Serilog.Tests.Settings
                 .Distinct()
                 .ToList();
 
-            Assert.Contains("FromLogContext", eventEnrichers);
-            Assert.Contains("WithDummyThreadId", eventEnrichers);
+            Assert.Contains("FromLogContext", enricherMethods);
+            Assert.Contains("WithDummyThreadId", enricherMethods);
         }
 
         [Fact]

--- a/test/Serilog.Tests/Settings/CallableConfigurationMethodFinderTests.cs
+++ b/test/Serilog.Tests/Settings/CallableConfigurationMethodFinderTests.cs
@@ -82,5 +82,21 @@ namespace Serilog.Tests.Settings
             Assert.Contains(nameof(DummyLoggerConfigurationExtensions.WithDummyHardCodedString), destructuringMethods);
             Assert.Contains(nameof(LoggerDestructuringConfiguration.With), destructuringMethods);
         }
+
+        [Fact]
+        public void FindsFilterSpecificConfigurationMethods()
+        {
+            var searchInAssemblies = new[] { SerilogAssembly, TestDummiesAssembly };
+
+            var filterMethods = CallableConfigurationMethodFinder
+                .FindConfigurationMethods(
+                    searchInAssemblies,
+                    typeof(LoggerFilterConfiguration))
+                .Select(m => m.Name)
+                .Distinct()
+                .ToList();
+
+            Assert.Contains(nameof(LoggerFilterConfiguration.With), filterMethods);
+        }
     }
 }

--- a/test/Serilog.Tests/Settings/CallableConfigurationMethodFinderTests.cs
+++ b/test/Serilog.Tests/Settings/CallableConfigurationMethodFinderTests.cs
@@ -9,68 +9,72 @@ namespace Serilog.Tests.Settings
 {
     public class CallableConfigurationMethodFinderTests
     {
+        static readonly Assembly SerilogAssembly = typeof(Log).GetTypeInfo().Assembly;
+        static readonly Assembly TestDummiesAssembly = typeof(DummyLoggerConfigurationExtensions).GetTypeInfo().Assembly;
+
         [Fact]
         public void FindsSinkSpecificConfigurationMethods()
         {
+            var searchInAssemblies = new[] { SerilogAssembly, TestDummiesAssembly };
+
             var sinkMethods = CallableConfigurationMethodFinder
-                .FindConfigurationMethods(new[]
-                {
-                    typeof(Log).GetTypeInfo().Assembly,
-                    typeof(DummyLoggerConfigurationExtensions).GetTypeInfo().Assembly
-                }, typeof(LoggerSinkConfiguration))
+                .FindConfigurationMethods(
+                    searchInAssemblies,
+                    typeof(LoggerSinkConfiguration))
                 .Select(m => m.Name)
                 .Distinct()
                 .ToList();
 
-            Assert.Contains("Sink", sinkMethods);
+            Assert.Contains(nameof(LoggerSinkConfiguration.Sink), sinkMethods);
         }
 
         [Fact]
         public void FindsAuditSinkSpecificConfigurationMethods()
         {
+            var searchInAssemblies = new[] { SerilogAssembly, TestDummiesAssembly };
+
             var auditSinkMethods = CallableConfigurationMethodFinder
-                .FindConfigurationMethods(new[]
-                {
-                    typeof(Log).GetTypeInfo().Assembly,
-                    typeof(DummyLoggerConfigurationExtensions).GetTypeInfo().Assembly
-                }, typeof(LoggerAuditSinkConfiguration))
+                .FindConfigurationMethods(
+                    searchInAssemblies,
+                    typeof(LoggerAuditSinkConfiguration))
                 .Select(m => m.Name)
                 .Distinct()
                 .ToList();
 
-            Assert.Contains("Sink", auditSinkMethods);
+            Assert.Contains(nameof(LoggerAuditSinkConfiguration.Sink), auditSinkMethods);
         }
 
         [Fact]
         public void FindsEnricherSpecificConfigurationMethods()
         {
+            var searchInAssemblies = new[] { SerilogAssembly, TestDummiesAssembly };
+
             var enricherMethods = CallableConfigurationMethodFinder
-                .FindConfigurationMethods(new[]
-                {
-                    typeof(Log).GetTypeInfo().Assembly,
-                    typeof(DummyThreadIdEnricher).GetTypeInfo().Assembly
-                }, typeof(LoggerEnrichmentConfiguration))
+                .FindConfigurationMethods(
+                    searchInAssemblies,
+                    typeof(LoggerEnrichmentConfiguration))
                 .Select(m => m.Name)
                 .Distinct()
                 .ToList();
 
-            Assert.Contains("FromLogContext", enricherMethods);
-            Assert.Contains("WithDummyThreadId", enricherMethods);
+            Assert.Contains(nameof(LoggerEnrichmentConfiguration.With), enricherMethods);
+            Assert.Contains(nameof(LoggerEnrichmentConfiguration.FromLogContext), enricherMethods);
+            Assert.Contains(nameof(DummyLoggerConfigurationExtensions.WithDummyThreadId), enricherMethods);
         }
 
         [Fact]
         public void FindsDestructureSpecificConfigurationMethods()
         {
+            var searchInAssemblies = new[] { SerilogAssembly, TestDummiesAssembly };
+
             var destructuringMethods = CallableConfigurationMethodFinder
-                .FindConfigurationMethods(new[]
-                {
-                    typeof(Log).GetTypeInfo().Assembly,
-                    typeof(DummyLoggerConfigurationExtensions).GetTypeInfo().Assembly,
-                }, typeof(LoggerDestructuringConfiguration))
+                .FindConfigurationMethods(
+                    searchInAssemblies,
+                    typeof(LoggerDestructuringConfiguration))
                 .Select(m => m.Name)
                 .Distinct()
                 .ToList();
-            
+
             Assert.Contains(nameof(LoggerDestructuringConfiguration.AsScalar), destructuringMethods);
             Assert.Contains(nameof(LoggerDestructuringConfiguration.ToMaximumCollectionCount), destructuringMethods);
             Assert.Contains(nameof(LoggerDestructuringConfiguration.ToMaximumDepth), destructuringMethods);

--- a/test/Serilog.Tests/Settings/KeyValuePairSettingsTests.cs
+++ b/test/Serilog.Tests/Settings/KeyValuePairSettingsTests.cs
@@ -658,5 +658,24 @@ namespace Serilog.Tests.Settings
             Assert.NotNull(evt);
             Assert.True(evt.Properties.ContainsKey("ThreadId"), "Event should have enriched property ThreadId");
         }
+
+        [Fact]
+        public void FilterWithIsAppliedWithCustomFilter()
+        {
+            LogEvent evt = null;
+            var log = new LoggerConfiguration()
+                .ReadFrom.KeyValuePairs(new Dictionary<string, string>
+                {
+                    ["using:TestDummies"] = typeof(DummyLoggerConfigurationExtensions).GetTypeInfo().Assembly.FullName,
+                    ["filter:With.filter"] = typeof(DummyAnonymousUserFilter).AssemblyQualifiedName
+                })
+                .WriteTo.Sink(new DelegatingSink(e => evt = e))
+                .CreateLogger();
+
+            log.ForContext("User", "anonymous").Write(Some.InformationEvent());
+            Assert.Null(evt);
+            log.ForContext("User", "the user").Write(Some.InformationEvent());
+            Assert.NotNull(evt);
+        }
     }
 }

--- a/test/Serilog.Tests/Settings/KeyValuePairSettingsTests.cs
+++ b/test/Serilog.Tests/Settings/KeyValuePairSettingsTests.cs
@@ -639,5 +639,24 @@ namespace Serilog.Tests.Settings
 
             Assert.Single(DummyRollingFileSink.Emitted);
         }
+
+        [Fact]
+        public void EnrichWithIsAppliedWithCustomEnricher()
+        {
+            LogEvent evt = null;
+            var log = new LoggerConfiguration()
+                .ReadFrom.KeyValuePairs(new Dictionary<string, string>
+                {
+                    ["using:TestDummies"] = typeof(DummyLoggerConfigurationExtensions).GetTypeInfo().Assembly.FullName,
+                    ["enrich:With.enricher"] = typeof(DummyThreadIdEnricher).AssemblyQualifiedName
+                })
+                .WriteTo.Sink(new DelegatingSink(e => evt = e))
+                .CreateLogger();
+
+            log.Write(Some.InformationEvent());
+
+            Assert.NotNull(evt);
+            Assert.True(evt.Properties.ContainsKey("ThreadId"), "Event should have enriched property ThreadId");
+        }
     }
 }

--- a/test/Serilog.Tests/Settings/KeyValuePairSettingsTests.cs
+++ b/test/Serilog.Tests/Settings/KeyValuePairSettingsTests.cs
@@ -583,5 +583,61 @@ namespace Serilog.Tests.Settings
 
             Assert.Single(DummyRollingFileSink.Emitted);
         }
+
+        [Fact]
+        public void AuditToSinkIsAppliedWithCustomSink()
+        {
+            var log = new LoggerConfiguration()
+                .ReadFrom.KeyValuePairs(new Dictionary<string, string>
+                {
+                    ["using:TestDummies"] = typeof(DummyLoggerConfigurationExtensions).GetTypeInfo().Assembly.FullName,
+                    ["audit-to:Sink.sink"] = typeof(DummyRollingFileSink).AssemblyQualifiedName
+                })
+                .CreateLogger();
+
+            DummyRollingFileSink.Reset();
+            log.Write(Some.InformationEvent());
+
+            Assert.Single(DummyRollingFileSink.Emitted);
+        }
+
+        [Fact]
+        public void AuditToSinkIsAppliedWithCustomSinkAndMinimumLevel()
+        {
+            var log = new LoggerConfiguration()
+                .ReadFrom.KeyValuePairs(new Dictionary<string, string>
+                {
+                    ["using:TestDummies"] = typeof(DummyLoggerConfigurationExtensions).GetTypeInfo().Assembly.FullName,
+                    ["audit-to:Sink.sink"] = typeof(DummyRollingFileSink).AssemblyQualifiedName,
+                    ["audit-to:Sink.restrictedToMinimumLevel"] = "Warning"
+                })
+                .CreateLogger();
+
+            DummyRollingFileSink.Reset();
+            log.Write(Some.InformationEvent());
+            log.Write(Some.WarningEvent());
+
+            Assert.Single(DummyRollingFileSink.Emitted);
+        }
+
+        [Fact]
+        public void AuditToSinkIsAppliedWithCustomSinkAndLevelSwitch()
+        {
+            var log = new LoggerConfiguration()
+                .ReadFrom.KeyValuePairs(new Dictionary<string, string>
+                {
+                    ["using:TestDummies"] = typeof(DummyLoggerConfigurationExtensions).GetTypeInfo().Assembly.FullName,
+                    ["level-switch:$switch1"] = "Warning",
+                    ["audit-to:Sink.sink"] = typeof(DummyRollingFileSink).AssemblyQualifiedName,
+                    ["audit-to:Sink.levelSwitch"] = "$switch1"
+                })
+                .CreateLogger();
+
+            DummyRollingFileSink.Reset();
+            log.Write(Some.InformationEvent());
+            log.Write(Some.WarningEvent());
+
+            Assert.Single(DummyRollingFileSink.Emitted);
+        }
     }
 }

--- a/test/TestDummies/DummyAnonymousUserFilter.cs
+++ b/test/TestDummies/DummyAnonymousUserFilter.cs
@@ -1,0 +1,25 @@
+﻿
+using Serilog.Core;
+using Serilog.Events;
+
+namespace TestDummies
+{
+    public class DummyAnonymousUserFilter : ILogEventFilter
+    {
+        public bool IsEnabled(LogEvent logEvent)
+        {
+            if (logEvent.Properties.ContainsKey("User"))
+            {
+                if (logEvent.Properties["User"] is ScalarValue sv)
+                {
+                    if (sv.Value is string s && s == "anonymous")
+                    {
+                        return false;
+                    }
+                }
+            }
+
+            return true;
+        }
+    }
+}

--- a/test/TestDummies/DummyRollingFileAuditSink.cs
+++ b/test/TestDummies/DummyRollingFileAuditSink.cs
@@ -8,13 +8,18 @@ namespace TestDummies
     public class DummyRollingFileAuditSink : ILogEventSink
     {
         [ThreadStatic]
-        // ReSharper disable ThreadStaticFieldHasInitializer
-        public static List<LogEvent> Emitted = new List<LogEvent>();
-        // ReSharper restore ThreadStaticFieldHasInitializer
+        static List<LogEvent> _emitted;
+
+        public static List<LogEvent> Emitted => _emitted ?? (_emitted = new List<LogEvent>());
 
         public void Emit(LogEvent logEvent)
         {
             Emitted.Add(logEvent);
+        }
+
+        public static void Reset()
+        {
+            _emitted = null;
         }
     }
 }

--- a/test/TestDummies/DummyRollingFileSink.cs
+++ b/test/TestDummies/DummyRollingFileSink.cs
@@ -8,13 +8,18 @@ namespace TestDummies
     public class DummyRollingFileSink : ILogEventSink
     {
         [ThreadStatic]
-        // ReSharper disable ThreadStaticFieldHasInitializer
-        public static List<LogEvent> Emitted = new List<LogEvent>();
-        // ReSharper restore ThreadStaticFieldHasInitializer
+        static List<LogEvent> _emitted;
+
+        public static List<LogEvent> Emitted => _emitted ?? (_emitted = new List<LogEvent>());
 
         public void Emit(LogEvent logEvent)
         {
             Emitted.Add(logEvent);
+        }
+
+        public static void Reset()
+        {
+            _emitted = null;
         }
     }
 }

--- a/test/TestDummies/DummyThreadIdEnricher.cs
+++ b/test/TestDummies/DummyThreadIdEnricher.cs
@@ -6,7 +6,9 @@ namespace TestDummies
     public class DummyThreadIdEnricher : ILogEventEnricher
     {
         public void Enrich(LogEvent logEvent, ILogEventPropertyFactory propertyFactory)
-        {          
+        {
+            logEvent.AddPropertyIfAbsent(propertyFactory
+                .CreateProperty("ThreadId", "SomeId"));
         }
     }
 }

--- a/test/TestDummies/DummyWrappingSink.cs
+++ b/test/TestDummies/DummyWrappingSink.cs
@@ -8,11 +8,11 @@ namespace TestDummies
     public class DummyWrappingSink : ILogEventSink
     {
         [ThreadStatic]
-        // ReSharper disable ThreadStaticFieldHasInitializer
-        public static List<LogEvent> Emitted = new List<LogEvent>();
-        // ReSharper restore ThreadStaticFieldHasInitializer
+        static List<LogEvent> _emitted;
 
-        private readonly ILogEventSink _sink;
+        public static List<LogEvent> Emitted => _emitted ?? (_emitted = new List<LogEvent>());
+
+        readonly ILogEventSink _sink;
 
         public DummyWrappingSink(ILogEventSink sink)
         {
@@ -23,6 +23,11 @@ namespace TestDummies
         {
             Emitted.Add(logEvent);
             _sink.Emit(logEvent);
+        }
+
+        public static void Reset()
+        {
+            _emitted = null;
         }
     }
 }


### PR DESCRIPTION
**What issue does this PR address?**
implements #1194 

**Does this PR introduce a breaking change?**
no

**Please check if the PR fulfills these requirements**
- [x] The commit follows our [guidelines](https://github.com/serilog/serilog/blob/dev/CONTRIBUTING.md)
- [x] Unit Tests for the changes have been added (for bug fixes / features)

**Other information**:

Adds support and tests for 
- `WriteTo.Sink(ILogEventSink logEventSink, LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum, LoggingLevelSwitch levelSwitch = null)`
- `AuditTo.Sink(ILogEventSink logEventSink, LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum, LoggingLevelSwitch levelSwitch = null)`
- `Enrich.With(params ILogEventEnricher[] enrichers)` (with surrogate `Enrich.With(ILogEventEnricher enricher)` )
- `Filter.With(params ILogEventFilter[] filters)` (with surrogate `Enrich.With(ILogEventFilter filter)` )