### PR TITLE
Fix output template padding of non-String values

### DIFF
--- a/src/Serilog/Formatting/Display/MessageTemplateTextFormatter.cs
+++ b/src/Serilog/Formatting/Display/MessageTemplateTextFormatter.cs
@@ -116,7 +116,7 @@ namespace Serilog.Formatting.Display
                         }
                         else
                         {
-                            propertyValue.Render(output, pt.Format, _formatProvider);
+                            propertyValue.Render(writer, pt.Format, _formatProvider);
                         }
                     }
 

--- a/test/Serilog.Tests/Formatting/Display/MessageTemplateTextFormatterTests.cs
+++ b/test/Serilog.Tests/Formatting/Display/MessageTemplateTextFormatterTests.cs
@@ -101,7 +101,7 @@ namespace Serilog.Tests.Formatting.Display
         [InlineData(LogEventLevel.Warning, 8, "Warning")]
         public void FixedLengthLevelIsSupported(
             LogEventLevel level,
-            int width, 
+            int width,
             string expected)
         {
             var formatter = new MessageTemplateTextFormatter($"{{Level:t{width}}}", CultureInfo.InvariantCulture);
@@ -274,6 +274,20 @@ namespace Serilog.Tests.Formatting.Display
             formatter.Format(evt, sw);
 
             var expected = new StructureValue(Enumerable.Empty<LogEventProperty>()).ToString();
+            Assert.Equal(expected, sw.ToString());
+        }
+
+        [Theory]
+        [InlineData(15, "", "15")]
+        [InlineData(15, ",5", "   15")]
+        [InlineData(15, ",-5", "15   ")]
+        public void PaddingIsApplied(int n, string format, string expected)
+        {
+            var formatter = new MessageTemplateTextFormatter("{ThreadId" + format + "}", null);
+            var evt = Some.InformationEvent();
+            evt.AddOrUpdateProperty(new LogEventProperty("ThreadId", new ScalarValue(n)));
+            var sw = new StringWriter();
+            formatter.Format(evt, sw);
             Assert.Equal(expected, sw.ToString());
         }
     }


### PR DESCRIPTION
**What issue does this PR address?**

Fixes https://github.com/serilog/serilog-sinks-rollingfile/issues/71

**Does this PR introduce a breaking change?**

Could break parsing of log files that depends on the incorrect behavior; it looks like the issue was probably introduced about a year ago in https://github.com/serilog/serilog/commit/d2dd76d which shipped with Serilog 2.5.

**Please check if the PR fulfills these requirements**
- [x] The commit follows our [guidelines](https://github.com/serilog/serilog/blob/dev/CONTRIBUTING.md)
- [x] Unit Tests for the changes have been added (for bug fixes / features)

**Other information**:
