### PR TITLE
Add tests around support of custom `IFormatProvider`

### DIFF
--- a/test/Serilog.Tests/Formatting/Display/MessageTemplateTextFormatterTests.cs
+++ b/test/Serilog.Tests/Formatting/Display/MessageTemplateTextFormatterTests.cs
@@ -101,7 +101,7 @@ namespace Serilog.Tests.Formatting.Display
         [InlineData(LogEventLevel.Warning, 8, "Warning")]
         public void FixedLengthLevelIsSupported(
             LogEventLevel level,
-            int width, 
+            int width,
             string expected)
         {
             var formatter = new MessageTemplateTextFormatter($"{{Level:t{width}}}", CultureInfo.InvariantCulture);
@@ -245,7 +245,7 @@ namespace Serilog.Tests.Formatting.Display
         public void AppliesJsonFormattingToMessageStructuresWhenSpecified(string format, string expected)
         {
             var formatter = new MessageTemplateTextFormatter("{Message" + format + "}", null);
-            var evt = DelegatingSink.GetLogEvent(l => l.Information("{@Obj}", new {Name = "World"}));
+            var evt = DelegatingSink.GetLogEvent(l => l.Information("{@Obj}", new { Name = "World" }));
             var sw = new StringWriter();
             formatter.Format(evt, sw);
             Assert.Equal(expected, sw.ToString());
@@ -275,6 +275,76 @@ namespace Serilog.Tests.Formatting.Display
 
             var expected = new StructureValue(Enumerable.Empty<LogEventProperty>()).ToString();
             Assert.Equal(expected, sw.ToString());
+        }
+
+        [Theory]
+        [InlineData("", true)]
+        [InlineData(":lj", false)]
+        [InlineData(":jl", false)]
+        [InlineData(":j", false)]
+        [InlineData(":l", true)]
+        public void FormatProviderWithScalarProperties(string format, bool shouldUseCustomFormatter)
+        {
+            var frenchFormatProvider = new CultureInfo("fr-FR");
+            var defaultFormatProvider = CultureInfo.InvariantCulture;
+
+            var date = new DateTime(2018, 01, 01);
+            var number = 12.345;
+
+            var expectedFormattedDate = shouldUseCustomFormatter
+                ? date.ToString(frenchFormatProvider)
+                : date.ToString("O", defaultFormatProvider);
+            var expectedFormattedNumber = shouldUseCustomFormatter
+                ? number.ToString(frenchFormatProvider)
+                : number.ToString(defaultFormatProvider);
+
+            var formatter = new MessageTemplateTextFormatter("{Message" + format + "}", frenchFormatProvider);
+            var evt = DelegatingSink.GetLogEvent(l =>
+            {
+                l.Information("{MyDate}{MyNumber}", date, number);
+            });
+            var sw = new StringWriter();
+            formatter.Format(evt, sw);
+
+            Assert.Contains(expectedFormattedDate, sw.ToString());
+            Assert.Contains(expectedFormattedNumber, sw.ToString());
+        }
+
+        [Theory]
+        [InlineData("", true)]
+        [InlineData(":lj", false)]
+        [InlineData(":jl", false)]
+        [InlineData(":j", false)]
+        [InlineData(":l", true)]
+        public void FormatProviderWithDestructuredProperties(string format, bool shouldUseCustomFormatter)
+        {
+            var frenchFormatProvider = new CultureInfo("fr-FR");
+            var defaultFormatProvider = CultureInfo.InvariantCulture;
+
+            var date = new DateTime(2018, 01, 01);
+            var number = 12.345;
+
+            var expectedFormattedDate = shouldUseCustomFormatter
+                ? date.ToString(frenchFormatProvider)
+                : date.ToString("O", defaultFormatProvider);
+            var expectedFormattedNumber = shouldUseCustomFormatter
+                ? number.ToString(frenchFormatProvider)
+                : number.ToString(defaultFormatProvider);
+
+            var formatter = new MessageTemplateTextFormatter("{Message" + format + "}", frenchFormatProvider);
+            var evt = DelegatingSink.GetLogEvent(l =>
+            {
+                l.Information("{@Item}", new
+                {
+                    MyDate = date,
+                    MyNumber = number
+                });
+            });
+            var sw = new StringWriter();
+            formatter.Format(evt, sw);
+
+            Assert.Contains(expectedFormattedDate, sw.ToString());
+            Assert.Contains(expectedFormattedNumber, sw.ToString());
         }
     }
 }


### PR DESCRIPTION
This PR adds tests about the current behavior of message templates when passing a custom `IFormatProvider`. 

There are no changes to the tested code.

Those tests are ported and adapted from https://github.com/serilog/serilog/pull/1183 and are related to https://github.com/serilog/serilog-sinks-file/issues/57#issuecomment-424154262 and https://github.com/serilog/serilog/issues/1115