### PR TITLE
Reduce LogEventLevel boxing

### DIFF
--- a/src/Serilog/Formatting/Display/LevelOutputFormat.cs
+++ b/src/Serilog/Formatting/Display/LevelOutputFormat.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System;
 using Serilog.Events;
 using Serilog.Rendering;
 
@@ -26,36 +27,40 @@ namespace Serilog.Formatting.Display
     static class LevelOutputFormat
     {
         static readonly string[][] _titleCaseLevelMap = {
-            new []{ "V", "Vb", "Vrb", "Verb" },
-            new []{ "D", "De", "Dbg", "Dbug" },
-            new []{ "I", "In", "Inf", "Info" },
-            new []{ "W", "Wn", "Wrn", "Warn" },
-            new []{ "E", "Er", "Err", "Eror" },
-            new []{ "F", "Fa", "Ftl", "Fatl" }
+            new []{ "V", "Vb", "Vrb", "Verb", "Verbo", "Verbos", "Verbose" },
+            new []{ "D", "De", "Dbg", "Dbug", "Debug" },
+            new []{ "I", "In", "Inf", "Info", "Infor", "Inform", "Informa", "Informat", "Informati", "Informatio", "Information" },
+            new []{ "W", "Wn", "Wrn", "Warn", "Warni", "Warnin", "Warning" },
+            new []{ "E", "Er", "Err", "Eror", "Error" },
+            new []{ "F", "Fa", "Ftl", "Fatl", "Fatal" }
         };
 
-        static readonly string[][] _lowercaseLevelMap = {
-            new []{ "v", "vb", "vrb", "verb" },
-            new []{ "d", "de", "dbg", "dbug" },
-            new []{ "i", "in", "inf", "info" },
-            new []{ "w", "wn", "wrn", "warn" },
-            new []{ "e", "er", "err", "eror" },
-            new []{ "f", "fa", "ftl", "fatl" }
+        static readonly string[][] _lowerCaseLevelMap = {
+            new []{ "v", "vb", "vrb", "verb", "verbo", "verbos", "verbose" },
+            new []{ "d", "de", "dbg", "dbug", "debug" },
+            new []{ "i", "in", "inf", "info", "infor", "inform", "informa", "informat", "informati", "informatio", "information" },
+            new []{ "w", "wn", "wrn", "warn", "warni", "warnin", "warning"  },
+            new []{ "e", "er", "err", "eror", "error" },
+            new []{ "f", "fa", "ftl", "fatl", "fatal" }
         };
 
-        static readonly string[][] _uppercaseLevelMap = {
-            new []{ "V", "VB", "VRB", "VERB" },
-            new []{ "D", "DE", "DBG", "DBUG" },
-            new []{ "I", "IN", "INF", "INFO" },
-            new []{ "W", "WN", "WRN", "WARN" },
-            new []{ "E", "ER", "ERR", "EROR" },
-            new []{ "F", "FA", "FTL", "FATL" }
+        static readonly string[][] _upperCaseLevelMap = {
+            new []{ "V", "VB", "VRB", "VERB", "VERBO", "VERBOS", "VERBOSE" },
+            new []{ "D", "DE", "DBG", "DBUG", "DEBUG" },
+            new []{ "I", "IN", "INF", "INFO", "INFOR", "INFORM", "INFORMA", "INFORMAT", "INFORMATI", "INFORMATIO", "INFORMATION"  },
+            new []{ "W", "WN", "WRN", "WARN", "WARNI", "WARNIN", "WARNING" },
+            new []{ "E", "ER", "ERR", "EROR", "ERROR" },
+            new []{ "F", "FA", "FTL", "FATL", "FATAL" }
         };
 
         public static string GetLevelMoniker(LogEventLevel value, string format = null)
         {
-            if (format == null || format.Length != 2 && format.Length != 3)
+            var index = (int)value;
+            if(index < 0 || index > (int) LogEventLevel.Fatal)
                 return Casing.Format(value.ToString(), format);
+
+            if (format == null || format.Length != 2 && format.Length != 3)
+                return Casing.Format(GetLevelMoniker(_titleCaseLevelMap, index), format);
 
             // Using int.Parse() here requires allocating a string to exclude the first character prefix.
             // Junk like "wxy" will be accepted but produce benign results.
@@ -69,29 +74,29 @@ namespace Serilog.Formatting.Display
             if (width < 1)
                 return string.Empty;
 
-            if (width > 4)
+            switch (format[0])
             {
-                var stringValue = value.ToString();
-                if (stringValue.Length > width)
-                    stringValue = stringValue.Substring(0, width);
-                return Casing.Format(stringValue);
+                case 'w':
+                    return GetLevelMoniker(_lowerCaseLevelMap, index, width);
+                case 'u':
+                    return GetLevelMoniker(_upperCaseLevelMap, index, width);
+                case 't':
+                    return GetLevelMoniker(_titleCaseLevelMap, index, width);
             }
 
-            var index = (int)value;
-            if (index >= 0 && index <= (int) LogEventLevel.Fatal)
-            {
-                switch (format[0])
-                {
-                    case 'w':
-                        return _lowercaseLevelMap[index][width - 1];
-                    case 'u':
-                        return _uppercaseLevelMap[index][width - 1];
-                    case 't':
-                        return _titleCaseLevelMap[index][width - 1];
-                }
-            }
+            return Casing.Format(GetLevelMoniker(_titleCaseLevelMap, index), format);
+        }
 
-            return Casing.Format(value.ToString(), format);
+        static string GetLevelMoniker(string[][] caseLevelMap, int index, int width)
+        {
+            var caseLevel = caseLevelMap[index];
+            return caseLevel[Math.Min(width, caseLevel.Length) - 1];
+        }
+
+        static string GetLevelMoniker(string[][] caseLevelMap, int index)
+        {
+            var caseLevel = caseLevelMap[index];
+            return caseLevel[caseLevel.Length - 1];
         }
     }
 }

--- a/src/Serilog/Formatting/Display/LevelOutputFormat.cs
+++ b/src/Serilog/Formatting/Display/LevelOutputFormat.cs
@@ -56,7 +56,7 @@ namespace Serilog.Formatting.Display
         public static string GetLevelMoniker(LogEventLevel value, string format = null)
         {
             var index = (int)value;
-            if(index < 0 || index > (int) LogEventLevel.Fatal)
+            if (index < 0 || index > (int) LogEventLevel.Fatal)
                 return Casing.Format(value.ToString(), format);
 
             if (format == null || format.Length != 2 && format.Length != 3)


### PR DESCRIPTION
Hi!

**What issue does this PR address?**

During the profiling I found that `LogEventLevel` was boxed during [formatting](https://github.com/serilog/serilog/blob/dev/src/Serilog/Formatting/Display/LevelOutputFormat.cs#L55). You can see the evidence of the boxing in the screenshot :

<img width="1211" alt="logeventlevel boxing" src="https://user-images.githubusercontent.com/664889/49733899-8e7a0e80-fca4-11e8-835d-905411971210.png">

**Does this PR introduce a breaking change?**
Nope

**Please check if the PR fulfills these requirements**
- [X] The commit follows our [guidelines](https://github.com/serilog/serilog/blob/dev/CONTRIBUTING.md)
- [ ] Unit Tests for the changes have been added (for bug fixes / features)

**Other information**: