### PR TITLE
added link to search of ps courses on readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ Serilog has an active and helpful community who are happy to help point you in t
  * Our [issue tracker](https://github.com/serilog/serilog/issues) here on GitHub
  * [Gitter chat](https://gitter.im/serilog/serilog)
  * The [#serilog tag on Twitter](https://twitter.com/search?q=%23serilog)
+ * [Serilog-related courses on Pluralsight](https://app.pluralsight.com/search/?q=serilog)
 
 ### Contributing
 

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Serilog has an active and helpful community who are happy to help point you in t
  * Our [issue tracker](https://github.com/serilog/serilog/issues) here on GitHub
  * [Gitter chat](https://gitter.im/serilog/serilog)
  * The [#serilog tag on Twitter](https://twitter.com/search?q=%23serilog)
- * [Serilog-related courses on Pluralsight](https://app.pluralsight.com/search/?q=serilog)
+ * [Serilog-related courses on Pluralsight](https://www.pluralsight.com/search/?q=serilog)
 
 ### Contributing
 


### PR DESCRIPTION
**What issue does this PR address?**
None - it adds a link to a list of Pluralsight courses (just uses search tag of "serilog") to the readme file.

**Does this PR introduce a breaking change?**
No

**Please check if the PR fulfills these requirements**
- [X] The commit follows our [guidelines](https://github.com/serilog/serilog/blob/dev/CONTRIBUTING.md)
- [X] Unit Tests for the changes have been added (for bug fixes / features)
(no unit tests added but not applicable)

**Other information**:
Only a readme update.