### PR TITLE
Use snupkg symbol packages.

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,4 @@
 <Project>
-  <ItemGroup>
-      <PackageReference Include="SourceLink.Create.CommandLine" Version="2.8.1" PrivateAssets="All" />
-  </ItemGroup>
   <!-- Workaround for https://github.com/dotnet/sdk/pull/908 -->
   <Target Name="GetPackagingOutputs" />
   <PropertyGroup>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,7 +20,7 @@ for:
   build_script:
   - sh build.sh
 artifacts:
-  - path: artifacts/Serilog.*.nupkg
+- path: artifacts/Serilog.*.?nupkg
 deploy:
 - provider: NuGet
   api_key:
@@ -31,7 +31,7 @@ deploy:
 - provider: GitHub
   auth_token:
     secure: p4LpVhBKxGS5WqucHxFQ5c7C8cP74kbNB0Z8k9Oxx/PMaDQ1+ibmoexNqVU5ZlmX
-  artifact: /Serilog.*\.nupkg/
+  artifact: /Serilog.*\.?nupkg/
   tag: v$(appveyor_build_version)
   on:
     branch: master

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,7 +20,8 @@ for:
   build_script:
   - sh build.sh
 artifacts:
-- path: artifacts/Serilog.*.?nupkg
+- path: artifacts/Serilog.*.nupkg
+- path: artifacts/Serilog.*.snupkg
 deploy:
 - provider: NuGet
   api_key:
@@ -31,7 +32,9 @@ deploy:
 - provider: GitHub
   auth_token:
     secure: p4LpVhBKxGS5WqucHxFQ5c7C8cP74kbNB0Z8k9Oxx/PMaDQ1+ibmoexNqVU5ZlmX
-  artifact: /Serilog.*\.?nupkg/
+  artifacts:
+    /Serilog.*\.nupkg/
+    /Serilog.*\.snupkg/
   tag: v$(appveyor_build_version)
   on:
     branch: master

--- a/src/Serilog/Serilog.csproj
+++ b/src/Serilog/Serilog.csproj
@@ -14,8 +14,6 @@
     <PackageIconUrl>https://serilog.net/images/serilog-nuget.png</PackageIconUrl>
     <PackageProjectUrl>https://github.com/serilog/serilog</PackageProjectUrl>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
-    <RepositoryUrl>https://github.com/serilog/serilog</RepositoryUrl>
-    <RepositoryType>git</RepositoryType>
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
     <TreatSpecificWarningsAsErrors />
@@ -58,4 +56,16 @@
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
     <PackageReference Include="System.Collections.NonGeneric" Version="4.3.0" />
   </ItemGroup>
+
+  <PropertyGroup>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19270-01" PrivateAssets="All"/>
+  </ItemGroup>
+
 </Project>

--- a/src/Serilog/Serilog.csproj
+++ b/src/Serilog/Serilog.csproj
@@ -12,7 +12,7 @@
     <PackageId>Serilog</PackageId>
     <PackageTags>serilog;logging;semantic;structured</PackageTags>
     <PackageIconUrl>https://serilog.net/images/serilog-nuget.png</PackageIconUrl>
-    <PackageProjectUrl>https://github.com/serilog/serilog</PackageProjectUrl>
+    <PackageProjectUrl>https://serilog.net/</PackageProjectUrl>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>

--- a/test/Serilog.Tests/Serilog.Tests.csproj
+++ b/test/Serilog.Tests/Serilog.Tests.csproj
@@ -38,7 +38,4 @@
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
-  <ItemGroup>
-    <DotNetCliToolReference Include="dotnet-sourcelink" Version="2.8.1" />
-  </ItemGroup>
 </Project>


### PR DESCRIPTION
**What issue does this PR address?**

The new recommended way to release debug symbols is separately, via `.snupkg` packages. This reduces package size, and conforms with NuGet's best practices.

**Does this PR introduce a breaking change?**

The `.snupkg` files must be published in NuGet as well.

**Please check if the PR fulfills these requirements**
- [X] The commit follows our [guidelines](https://github.com/serilog/serilog/blob/dev/CONTRIBUTING.md)
- [X] Unit Tests for the changes have been added (for bug fixes / features)

**Other information**:
