### PR TITLE
Respect explicit format specifiers even when JSON defaults are selected

### DIFF
--- a/src/Serilog/Rendering/MessageTemplateRenderer.cs
+++ b/src/Serilog/Rendering/MessageTemplateRenderer.cs
@@ -95,7 +95,7 @@ namespace Serilog.Rendering
             {
                 output.Write(str);
             }
-            else if (json)
+            else if (json && format == null)
             {
                 JsonValueFormatter.Format(propertyValue, output);
             }

--- a/test/Serilog.Tests/Rendering/MessageTemplateRendererTests.cs
+++ b/test/Serilog.Tests/Rendering/MessageTemplateRendererTests.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using Serilog.Events;
+using Serilog.Parsing;
+using Serilog.Rendering;
+using Xunit;
+
+namespace Serilog.Tests.Rendering
+{
+    public class MessageTemplateRendererTests
+    {
+        readonly MessageTemplateParser _messageTemplateParser = new MessageTemplateParser();
+
+        [Theory]
+        [InlineData("{Number}", null, "16")]
+        [InlineData("{Number:X8}", null, "00000010")]
+        [InlineData("{Number}", "j", "16")]
+        [InlineData("{Number:X8}", "j", "00000010")]
+        public void PropertyTokenFormatsAreApplied(string template, string appliedFormat, string expected)
+        {
+            var eventTemplate = _messageTemplateParser.Parse(template);
+            var properties = new Dictionary<string, LogEventPropertyValue>{["Number"] = new ScalarValue(16)};
+
+            var output = new StringWriter();
+            MessageTemplateRenderer.Render(eventTemplate, properties, output, appliedFormat, CultureInfo.InvariantCulture);
+
+            Assert.Equal(expected, output.ToString());
+        }
+    }
+}


### PR DESCRIPTION
Fixes #1323 

We should check this against the behavior of https://github.com/serilog/serilog-sinks-console/blob/dev/src/Serilog.Sinks.Console/Sinks/SystemConsole/Rendering/ThemedMessageTemplateRenderer.cs before merging.