### PR TITLE
made formatProvider optional in the constructor of MessageTemplateTextFormatter

### DIFF
--- a/src/Serilog/Formatting/Display/MessageTemplateTextFormatter.cs
+++ b/src/Serilog/Formatting/Display/MessageTemplateTextFormatter.cs
@@ -41,7 +41,7 @@ namespace Serilog.Formatting.Display
         /// <param name="outputTemplate">A message template describing the
         /// output messages.</param>
         /// <param name="formatProvider">Supplies culture-specific formatting information, or null.</param>
-        public MessageTemplateTextFormatter(string outputTemplate, IFormatProvider formatProvider)
+        public MessageTemplateTextFormatter(string outputTemplate, IFormatProvider formatProvider = null)
         {
             if (outputTemplate == null) throw new ArgumentNullException(nameof(outputTemplate));
             _outputTemplate = new MessageTemplateParser().Parse(outputTemplate);


### PR DESCRIPTION
**What issue does this PR address?**
Resolves issue #1328

**Does this PR introduce a breaking change?**
It makes the last argument of a constructor optional.  I don't think that is breaking change.

**Please check if the PR fulfills these requirements**
- [X] The commit follows our [guidelines](https://github.com/serilog/serilog/blob/dev/CONTRIBUTING.md)
- [NA] Unit Tests for the changes have been added (for bug fixes / features)