### PR TITLE
Potentially faster PropertyBinder

### DIFF
--- a/src/Serilog/Capturing/MessageTemplateProcessor.cs
+++ b/src/Serilog/Capturing/MessageTemplateProcessor.cs
@@ -31,10 +31,13 @@ namespace Serilog.Capturing
             _propertyBinder = new PropertyBinder(_propertyValueConverter);
         }
 
-        public void Process(string messageTemplate, object[] messageTemplateParameters, out MessageTemplate parsedTemplate, out EventProperty[] properties)
+        public void Process<TPropertyVisitor>(string messageTemplate, object[] messageTemplateParameters, ref TPropertyVisitor visitor)
+            where TPropertyVisitor : struct, EventProperty.IBoundedPropertyVisitor
         {
-            parsedTemplate = _parser.Parse(messageTemplate);
-            properties = _propertyBinder.ConstructProperties(parsedTemplate, messageTemplateParameters);
+            var parsedTemplate = _parser.Parse(messageTemplate);
+            visitor.On(parsedTemplate);
+
+            _propertyBinder.ConstructProperties(parsedTemplate, messageTemplateParameters, ref visitor);
         }
 
         public LogEventProperty CreateProperty(string name, object value, bool destructureObjects = false)

--- a/src/Serilog/Capturing/MessageTemplateProcessor.cs
+++ b/src/Serilog/Capturing/MessageTemplateProcessor.cs
@@ -31,12 +31,10 @@ namespace Serilog.Capturing
             _propertyBinder = new PropertyBinder(_propertyValueConverter);
         }
 
-        public void Process<TPropertyVisitor>(string messageTemplate, object[] messageTemplateParameters, ref TPropertyVisitor visitor)
+        public void Process<TPropertyVisitor>(string messageTemplate, object[] messageTemplateParameters, out MessageTemplate parsedTemplate, ref TPropertyVisitor visitor)
             where TPropertyVisitor : struct, EventProperty.IBoundedPropertyVisitor
         {
-            var parsedTemplate = _parser.Parse(messageTemplate);
-            visitor.On(parsedTemplate);
-
+            parsedTemplate = _parser.Parse(messageTemplate);
             _propertyBinder.ConstructProperties(parsedTemplate, messageTemplateParameters, ref visitor);
         }
 

--- a/src/Serilog/Capturing/MessageTemplateProcessor.cs
+++ b/src/Serilog/Capturing/MessageTemplateProcessor.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System.Collections.Generic;
 using Serilog.Core;
 using Serilog.Core.Pipeline;
 using Serilog.Events;
@@ -31,11 +32,10 @@ namespace Serilog.Capturing
             _propertyBinder = new PropertyBinder(_propertyValueConverter);
         }
 
-        public void Process<TPropertyVisitor>(string messageTemplate, object[] messageTemplateParameters, out MessageTemplate parsedTemplate, ref TPropertyVisitor visitor)
-            where TPropertyVisitor : struct, EventProperty.IBoundedPropertyVisitor
+        public void Process(string messageTemplate, object[] messageTemplateParameters, out MessageTemplate parsedTemplate, IDictionary<string, LogEventPropertyValue> properties)
         {
             parsedTemplate = _parser.Parse(messageTemplate);
-            _propertyBinder.ConstructProperties(parsedTemplate, messageTemplateParameters, ref visitor);
+            _propertyBinder.ConstructProperties(parsedTemplate, messageTemplateParameters, properties);
         }
 
         public LogEventProperty CreateProperty(string name, object value, bool destructureObjects = false)

--- a/src/Serilog/Capturing/PropertyBinder.cs
+++ b/src/Serilog/Capturing/PropertyBinder.cs
@@ -45,14 +45,12 @@ namespace Serilog.Capturing
         /// this will be empty.</returns>
         public void ConstructProperties<TPropertyVisitor>(MessageTemplate messageTemplate, object[] messageTemplateParameters, ref TPropertyVisitor visitor)
             where TPropertyVisitor : struct, EventProperty.IBoundedPropertyVisitor
-
         {
             if (messageTemplateParameters == null || messageTemplateParameters.Length == 0)
             {
                 if (messageTemplate.NamedProperties != null || messageTemplate.PositionalProperties != null)
                     SelfLog.WriteLine("Required properties not provided for: {0}", messageTemplate);
 
-                visitor.Dispatch();
                 return;
             }
 

--- a/src/Serilog/Events/EventProperty.cs
+++ b/src/Serilog/Events/EventProperty.cs
@@ -94,5 +94,11 @@ namespace Serilog.Events
                 return ((Name != null ? Name.GetHashCode() : 0) * 397) ^ (Value != null ? Value.GetHashCode() : 0);
             }
         }
+
+        public interface IBoundedPropertyVisitor
+        {
+            void On(MessageTemplate parsedTemplate);
+            void On(EventProperty property);
+        }
     }
 }

--- a/src/Serilog/Events/EventProperty.cs
+++ b/src/Serilog/Events/EventProperty.cs
@@ -94,10 +94,5 @@ namespace Serilog.Events
                 return ((Name != null ? Name.GetHashCode() : 0) * 397) ^ (Value != null ? Value.GetHashCode() : 0);
             }
         }
-
-        public interface IBoundedPropertyVisitor
-        {
-            void On(EventProperty property);
-        }
     }
 }

--- a/src/Serilog/Events/EventProperty.cs
+++ b/src/Serilog/Events/EventProperty.cs
@@ -97,7 +97,6 @@ namespace Serilog.Events
 
         public interface IBoundedPropertyVisitor
         {
-            void On(MessageTemplate parsedTemplate);
             void On(EventProperty property);
         }
     }

--- a/src/Serilog/Events/LogEvent.cs
+++ b/src/Serilog/Events/LogEvent.cs
@@ -25,7 +25,7 @@ namespace Serilog.Events
     {
         readonly Dictionary<string, LogEventPropertyValue> _properties;
 
-        LogEvent(DateTimeOffset timestamp, LogEventLevel level, Exception exception, MessageTemplate messageTemplate, Dictionary<string, LogEventPropertyValue> properties)
+        internal LogEvent(DateTimeOffset timestamp, LogEventLevel level, Exception exception, MessageTemplate messageTemplate, Dictionary<string, LogEventPropertyValue> properties)
         {
             Timestamp = timestamp;
             Level = level;
@@ -48,21 +48,6 @@ namespace Serilog.Events
             if (properties == null) throw new ArgumentNullException(nameof(properties));
             foreach (var property in properties)
                 AddOrUpdateProperty(property);
-        }
-
-        /// <summary>
-        /// Construct a new <seealso cref="LogEvent"/>.
-        /// </summary>
-        /// <param name="timestamp">The time at which the event occurred.</param>
-        /// <param name="level">The level of the event.</param>
-        /// <param name="exception">An exception associated with the event, or null.</param>
-        /// <param name="messageTemplate">The message template describing the event.</param>
-        /// <param name="properties">Properties associated with the event, including those presented in <paramref name="messageTemplate"/>.</param>
-        internal LogEvent(DateTimeOffset timestamp, LogEventLevel level, Exception exception, MessageTemplate messageTemplate, EventProperty[] properties)
-            : this(timestamp, level, exception, messageTemplate, new Dictionary<string, LogEventPropertyValue>(properties?.Length ?? throw new ArgumentNullException(nameof(properties))))
-        {
-            for (var i = 0; i < properties.Length; ++i)
-                _properties[properties[i].Name] = properties[i].Value;
         }
 
         /// <summary>

--- a/test/Serilog.Tests/Core/MessageTemplateTests.cs
+++ b/test/Serilog.Tests/Core/MessageTemplateTests.cs
@@ -1,5 +1,6 @@
 ﻿using Serilog.Capturing;
 using Serilog.Core;
+using Serilog.Tests.Support;
 using System;
 using System.Globalization;
 using System.IO;

--- a/test/Serilog.Tests/Support/Extensions.cs
+++ b/test/Serilog.Tests/Support/Extensions.cs
@@ -1,4 +1,7 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
 using Serilog.Capturing;
 using Serilog.Events;
 
@@ -13,22 +16,52 @@ namespace Serilog.Tests.Support
 
         internal static EventProperty[] ConstructProperties(this PropertyBinder binder, MessageTemplate messageTemplate, object[] messageTemplateParameters)
         {
-            var properties = new List<EventProperty>();
-            var visitor = new PropertyBinderVisitor(properties);
-            binder.ConstructProperties(messageTemplate, messageTemplateParameters, ref visitor);
-            return properties.ToArray();
+            var properties = new PropertiesCollector();
+            binder.ConstructProperties(messageTemplate, messageTemplateParameters, properties);
+            return properties.Properties.ToArray();
         }
 
-        struct PropertyBinderVisitor : EventProperty.IBoundedPropertyVisitor
+        class PropertiesCollector : IDictionary<string, LogEventPropertyValue>
         {
-            readonly List<EventProperty> _properties;
+            public List<EventProperty> Properties = new List<EventProperty>();
 
-            public PropertyBinderVisitor(List<EventProperty> properties)
+            IEnumerator<KeyValuePair<string, LogEventPropertyValue>> IEnumerable<KeyValuePair<string, LogEventPropertyValue>>.GetEnumerator() => throw new NotImplementedException();
+
+            IEnumerator IEnumerable.GetEnumerator() => throw new NotImplementedException();
+
+            void ICollection<KeyValuePair<string, LogEventPropertyValue>>.Add(KeyValuePair<string, LogEventPropertyValue> item) => throw new NotImplementedException();
+
+            void ICollection<KeyValuePair<string, LogEventPropertyValue>>.Clear() => throw new NotImplementedException();
+
+            bool ICollection<KeyValuePair<string, LogEventPropertyValue>>.Contains(KeyValuePair<string, LogEventPropertyValue> item) => throw new NotImplementedException();
+
+            void ICollection<KeyValuePair<string, LogEventPropertyValue>>.CopyTo(KeyValuePair<string, LogEventPropertyValue>[] array, int arrayIndex) => throw new NotImplementedException();
+
+            bool ICollection<KeyValuePair<string, LogEventPropertyValue>>.Remove(KeyValuePair<string, LogEventPropertyValue> item) => throw new NotImplementedException();
+
+            int ICollection<KeyValuePair<string, LogEventPropertyValue>>.Count => throw new NotImplementedException();
+
+            bool ICollection<KeyValuePair<string, LogEventPropertyValue>>.IsReadOnly => false;
+
+            void IDictionary<string, LogEventPropertyValue>.Add(string key, LogEventPropertyValue value)
             {
-                _properties = properties;
+                Properties.Add(new EventProperty(key, value));
             }
 
-            public void On(EventProperty property) => _properties.Add(property);
+            bool IDictionary<string, LogEventPropertyValue>.ContainsKey(string key) => throw new NotImplementedException();
+
+            bool IDictionary<string, LogEventPropertyValue>.Remove(string key) => throw new NotImplementedException();
+
+            bool IDictionary<string, LogEventPropertyValue>.TryGetValue(string key, out LogEventPropertyValue value) => throw new NotImplementedException();
+
+            LogEventPropertyValue IDictionary<string, LogEventPropertyValue>.this[string key]
+            {
+                get => throw new NotImplementedException();
+                set => throw new NotImplementedException();
+            }
+
+            ICollection<string> IDictionary<string, LogEventPropertyValue>.Keys => throw new NotImplementedException();
+            ICollection<LogEventPropertyValue> IDictionary<string, LogEventPropertyValue>.Values => throw new NotImplementedException();
         }
     }
 }

--- a/test/Serilog.Tests/Support/Extensions.cs
+++ b/test/Serilog.Tests/Support/Extensions.cs
@@ -1,4 +1,6 @@
-﻿using Serilog.Events;
+﻿using System.Collections.Generic;
+using Serilog.Capturing;
+using Serilog.Events;
 
 namespace Serilog.Tests.Support
 {
@@ -7,6 +9,26 @@ namespace Serilog.Tests.Support
         public static object LiteralValue(this LogEventPropertyValue @this)
         {
             return ((ScalarValue)@this).Value;
+        }
+
+        internal static EventProperty[] ConstructProperties(this PropertyBinder binder, MessageTemplate messageTemplate, object[] messageTemplateParameters)
+        {
+            var properties = new List<EventProperty>();
+            var visitor = new PropertyBinderVisitor(properties);
+            binder.ConstructProperties(messageTemplate, messageTemplateParameters, ref visitor);
+            return properties.ToArray();
+        }
+
+        struct PropertyBinderVisitor : EventProperty.IBoundedPropertyVisitor
+        {
+            readonly List<EventProperty> _properties;
+
+            public PropertyBinderVisitor(List<EventProperty> properties)
+            {
+                _properties = properties;
+            }
+
+            public void On(EventProperty property) => _properties.Add(property);
         }
     }
 }


### PR DESCRIPTION
This PR augments `PropertyBinder` to do not allocate the `EventProperty[]` and to directly pass the values to the caller, that requested it. I found two paths that are calling it:

- Logger, when creating `LogEvent` and then calling `.Dispatch`
- Logger, when calling `.BindMessageTemplate`

This PR is just a proposal. It requires some insight and potentially running more benchmarks.

### Benchmarks

I run benchmarks from `AllocationBenchmark` but it might require running the rest of the suite. 

```ini
BenchmarkDotNet=v0.11.5, OS=Windows 10.0.17134.829 (1803/April2018Update/Redstone4)
Intel Core i7-6700HQ CPU 2.60GHz (Skylake), 1 CPU, 8 logical and 4 physical cores
Frequency=2531247 Hz, Resolution=395.0622 ns, Timer=TSC
.NET Core SDK=2.2.300
  [Host]     : .NET Core 2.2.5 (CoreCLR 4.6.27617.05, CoreFX 4.6.27618.01), 64bit RyuJIT
  DefaultJob : .NET Core 2.2.5 (CoreCLR 4.6.27617.05, CoreFX 4.6.27618.01), 64bit RyuJIT
```

#### Before

|               Method |         Mean |       Error |        StdDev |       Median | Gen 0 | Allocated |
|--------------------- |-------------:|------------:|--------------:|-------------:|------:|----------:|
|             LogEmpty |     11.85 ns |   0.3149 ns |     0.9085 ns |     11.82 ns |     - |         - |
| LogEmptyWithEnricher |     78.25 ns |   2.4580 ns |     3.8268 ns |     77.20 ns |0.0178 |      56 B |
|            LogScalar |    966.26 ns |  30.2759 ns |    82.8799 ns |    938.42 ns |0.1183 |     376 B |
|        LogDictionary |  5,912.98 ns | 406.5219 ns | 1,185.8435 ns |  5,570.99 ns |0.7095 |    2240 B |
|          LogSequence |  2,732.37 ns | 169.2209 ns |   482.7967 ns |  2,553.46 ns |0.2594 |     824 B |
|         LogAnonymous | 11,927.61 ns | 497.3753 ns | 1,450.8670 ns | 12,070.04 ns |1.0834 |    3440 B |

#### After

|               Method |        Mean |       Error |     StdDev |      Median | Gen 0 |Allocated |
|--------------------- |------------:|------------:|-----------:|------------:|------:|---------:|
|             LogEmpty |    12.23 ns |   0.3690 ns |   1.053 ns |    12.01 ns |     - |        - |
| LogEmptyWithEnricher |    87.15 ns |   3.4287 ns |  10.056 ns |    83.39 ns |0.0178 |     56 B |
|            LogScalar | 1,000.03 ns |  19.7406 ns |  27.674 ns |   993.39 ns |0.1049 |    336 B |
|        LogDictionary | 5,265.85 ns | 197.2796 ns | 562.850 ns | 5,133.75 ns |0.6943 |   2200 B |
|          LogSequence | 2,234.62 ns |  45.9707 ns |  68.807 ns | 2,210.84 ns |0.2480 |    784 B |
|         LogAnonymous | 9,715.81 ns | 118.8590 ns | 105.365 ns | 9,716.56 ns |1.0681 |   3400 B |

