### PR TITLE
DepthLimiter stops using ThreadStatic and uses a list instead

### DIFF
--- a/src/Serilog/Capturing/DepthLimiter.cs
+++ b/src/Serilog/Capturing/DepthLimiter.cs
@@ -33,7 +33,7 @@ namespace Serilog.Capturing
         {
             class NullLimiter : IDepthLimiter
             {
-                public static NullLimiter Instance = new NullLimiter();
+                public static IDepthLimiter Instance = new NullLimiter();
 
                 NullLimiter() { }
 
@@ -54,11 +54,16 @@ namespace Serilog.Capturing
 
             readonly PropertyValueConverter _propertyValueConverter;
 
-            public DepthLimiter(int maximumDepth, PropertyValueConverter propertyValueConverter)
+            DepthLimiter(int maximumDepth, PropertyValueConverter propertyValueConverter)
             {
                 _propertyValueConverter = propertyValueConverter;
 
-                NextLevel = maximumDepth > 1 ? (IDepthLimiter)new DepthLimiter(maximumDepth - 1, propertyValueConverter) : NullLimiter.Instance;
+                NextLevel = Create(maximumDepth, propertyValueConverter);
+            }
+
+            public static IDepthLimiter Create(int maximumDepth, PropertyValueConverter propertyValueConverter)
+            {
+                return maximumDepth > 1 ? new DepthLimiter(maximumDepth - 1, propertyValueConverter) : NullLimiter.Instance;
             }
 
             public LogEventPropertyValue CreatePropertyValue(object value, Destructuring destructuring)

--- a/src/Serilog/Capturing/PropertyValueConverter.cs
+++ b/src/Serilog/Capturing/PropertyValueConverter.cs
@@ -201,7 +201,7 @@ namespace Serilog.Capturing
                             }
 
                             var pair = new KeyValuePair<ScalarValue, LogEventPropertyValue>(
-                                (ScalarValue)limiter.CreatePropertyValue(entry.Key, destructure),
+                                (ScalarValue)depthLimiter.CreatePropertyValue(entry.Key, destructure),
                                 depthLimiter.CreatePropertyValue(entry.Value, destructure));
 
                             if (pair.Key.Value != null)

--- a/src/Serilog/Capturing/PropertyValueConverter.cs
+++ b/src/Serilog/Capturing/PropertyValueConverter.cs
@@ -187,10 +187,10 @@ namespace Serilog.Capturing
                 // multiple different interpretations.
                 if (TryGetDictionary(value, valueType, out var dictionary))
                 {
-                    result = new DictionaryValue(MapToDictionaryElements(dictionary, destructuring));
+                    result = new DictionaryValue(MapToDictionaryElements(dictionary, destructuring, limiter));
                     return true;
 
-                    IEnumerable<KeyValuePair<ScalarValue, LogEventPropertyValue>> MapToDictionaryElements(IDictionary dictionaryEntries, Destructuring destructure)
+                    IEnumerable<KeyValuePair<ScalarValue, LogEventPropertyValue>> MapToDictionaryElements(IDictionary dictionaryEntries, Destructuring destructure, DepthLimiter depthLimiter)
                     {
                         var count = 0;
                         foreach (DictionaryEntry entry in dictionaryEntries)
@@ -202,7 +202,7 @@ namespace Serilog.Capturing
 
                             var pair = new KeyValuePair<ScalarValue, LogEventPropertyValue>(
                                 (ScalarValue)limiter.CreatePropertyValue(entry.Key, destructure),
-                                limiter.CreatePropertyValue(entry.Value, destructure));
+                                depthLimiter.CreatePropertyValue(entry.Value, destructure));
 
                             if (pair.Key.Value != null)
                                 yield return pair;
@@ -210,10 +210,10 @@ namespace Serilog.Capturing
                     }
                 }
 
-                result = new SequenceValue(MapToSequenceElements(enumerable, destructuring));
+                result = new SequenceValue(MapToSequenceElements(enumerable, destructuring, limiter));
                 return true;
 
-                IEnumerable<LogEventPropertyValue> MapToSequenceElements(IEnumerable sequence, Destructuring destructure)
+                IEnumerable<LogEventPropertyValue> MapToSequenceElements(IEnumerable sequence, Destructuring destructure, DepthLimiter depthLimiter)
                 {
                     var count = 0;
                     foreach (var element in sequence)
@@ -223,7 +223,7 @@ namespace Serilog.Capturing
                             yield break;
                         }
 
-                        yield return limiter.CreatePropertyValue(element, destructure);
+                        yield return depthLimiter.CreatePropertyValue(element, destructure);
                     }
                 }
             }

--- a/src/Serilog/Capturing/PropertyValueConverter.cs
+++ b/src/Serilog/Capturing/PropertyValueConverter.cs
@@ -45,7 +45,7 @@ namespace Serilog.Capturing
 
         readonly IDestructuringPolicy[] _destructuringPolicies;
         readonly IScalarConversionPolicy[] _scalarConversionPolicies;
-        readonly IDepthLimiter _depthLimiter;
+        readonly DepthLimiter _depthLimiter;
         readonly int _maximumStringLength;
         readonly int _maximumCollectionCount;
         readonly bool _propagateExceptions;
@@ -113,7 +113,7 @@ namespace Serilog.Capturing
             }
         }
 
-        LogEventPropertyValue CreatePropertyValue(object value, bool destructureObjects, IDepthLimiter limiter)
+        LogEventPropertyValue CreatePropertyValue(object value, bool destructureObjects, DepthLimiter limiter)
         {
             return CreatePropertyValue(
                 value,
@@ -123,7 +123,7 @@ namespace Serilog.Capturing
                 limiter);
         }
 
-        LogEventPropertyValue CreatePropertyValue(object value, Destructuring destructuring, IDepthLimiter limiter)
+        LogEventPropertyValue CreatePropertyValue(object value, Destructuring destructuring, DepthLimiter limiter)
         {
             if (value == null)
                 return new ScalarValue(null);
@@ -173,7 +173,7 @@ namespace Serilog.Capturing
             return new ScalarValue(value.ToString());
         }
 
-        bool TryConvertEnumerable(object value, Destructuring destructuring, Type valueType, IDepthLimiter limiter, out LogEventPropertyValue result)
+        bool TryConvertEnumerable(object value, Destructuring destructuring, Type valueType, DepthLimiter limiter, out LogEventPropertyValue result)
         {
             if (value is IEnumerable enumerable)
             {
@@ -232,7 +232,7 @@ namespace Serilog.Capturing
             return false;
         }
 
-        static bool TryConvertValueTuple(object value, Destructuring destructuring, Type valueType, IDepthLimiter limiter, out LogEventPropertyValue result)
+        static bool TryConvertValueTuple(object value, Destructuring destructuring, Type valueType, DepthLimiter limiter, out LogEventPropertyValue result)
         {
             if (!(value is IStructuralEquatable && valueType.IsConstructedGenericType))
             {
@@ -276,7 +276,7 @@ namespace Serilog.Capturing
             return false;
         }
 
-        bool TryConvertCompilerGeneratedType(object value, Destructuring destructuring, Type valueType, IDepthLimiter limiter, out LogEventPropertyValue result)
+        bool TryConvertCompilerGeneratedType(object value, Destructuring destructuring, Type valueType, DepthLimiter limiter, out LogEventPropertyValue result)
         {
             if (destructuring == Destructuring.Destructure)
             {
@@ -331,7 +331,7 @@ namespace Serilog.Capturing
                    valueType.GetTypeInfo().IsEnum;
         }
 
-        IEnumerable<LogEventProperty> GetProperties(object value, IDepthLimiter limiter)
+        IEnumerable<LogEventProperty> GetProperties(object value, DepthLimiter limiter)
         {
             foreach (var prop in value.GetType().GetPropertiesRecursive())
             {

--- a/src/Serilog/Capturing/PropertyValueConverter.cs
+++ b/src/Serilog/Capturing/PropertyValueConverter.cs
@@ -45,7 +45,7 @@ namespace Serilog.Capturing
 
         readonly IDestructuringPolicy[] _destructuringPolicies;
         readonly IScalarConversionPolicy[] _scalarConversionPolicies;
-        readonly DepthLimiter _depthLimiter;
+        readonly IDepthLimiter _depthLimiter;
         readonly int _maximumStringLength;
         readonly int _maximumCollectionCount;
         readonly bool _propagateExceptions;
@@ -83,7 +83,7 @@ namespace Serilog.Capturing
                 })
                 .ToArray();
 
-            _depthLimiter = new DepthLimiter(maximumDestructuringDepth, this);
+            _depthLimiter = DepthLimiter.Create(maximumDestructuringDepth, this);
         }
 
         public LogEventProperty CreateProperty(string name, object value, bool destructureObjects = false)


### PR DESCRIPTION
This PR removes `[ThreadStatic]` in `DepthLimiter` and replaces it with a simple unidirectional list of limiters, ended by a null object (doing nothing). 

The original idea was to check whether it's worth it to replace it and I found some potential improvements. At the same time it looks like it leaks some allocations, but I cannot find it though 😕 . Anyway, I'm sharing `AllocationBenchmarks` below. Still, it requires an opinionated review and potentially running of some other benchmarks.

```ini
BenchmarkDotNet=v0.11.5, OS=Windows 10.0.17134.829 (1803/April2018Update/Redstone4)
Intel Core i7-6700HQ CPU 2.60GHz (Skylake), 1 CPU, 8 logical and 4 physical cores
Frequency=2531247 Hz, Resolution=395.0622 ns, Timer=TSC
.NET Core SDK=2.2.300
  [Host]     : .NET Core 2.2.5 (CoreCLR 4.6.27617.05, CoreFX 4.6.27618.01), 64bit RyuJIT
  DefaultJob : .NET Core 2.2.5 (CoreCLR 4.6.27617.05, CoreFX 4.6.27618.01), 64bit RyuJIT
```

#### Before

|               Method |        Mean |       Error |      StdDev |  Gen 0 | Allocated |
|--------------------- |------------:|------------:|------------:|-------:|----------:|
|             LogEmpty |    10.90 ns |   0.2576 ns |   0.3934 ns |      - |         - |
| LogEmptyWithEnricher |    73.15 ns |   1.3302 ns |   1.1792 ns | 0.0178 |      56 B |
|            LogScalar |   920.46 ns |  18.0878 ns |  20.8300 ns | 0.1192 |     376 B |
|        LogDictionary | 4,767.65 ns |  95.0796 ns | 180.8989 ns | 0.7095 |    2240 B |
|          LogSequence | 2,222.24 ns |  44.3338 ns | 121.3631 ns | 0.2594 |     824 B |
|         LogAnonymous | 9,579.28 ns | 188.7198 ns | 406.2393 ns | 1.0834 |    3440 B |

#### After

|               Method |         Mean |       Error |      StdDev |  Gen 0 | Allocated |
|--------------------- |-------------:|------------:|------------:|-------:|----------:|
|             LogEmpty |     9.626 ns |   0.2251 ns |   0.3699 ns |      - |         - |
| LogEmptyWithEnricher |    69.689 ns |   1.4173 ns |   1.4554 ns | 0.0178 |      56 B |
|            LogScalar |   827.965 ns |  29.0880 ns |  34.6273 ns | 0.1192 |     376 B |
|        LogDictionary | 4,332.959 ns |  70.4718 ns |  65.9194 ns | 0.7248 |    2288 B |
|          LogSequence | 1,952.709 ns |  41.2889 ns |  38.6217 ns | 0.2632 |     840 B |
|         LogAnonymous | 8,187.965 ns | 136.0692 ns | 127.2793 ns | 1.1139 |    3504 B |
