### PR TITLE
Feature/optionally write final depth as scalar

### DIFF
--- a/src/Serilog/Capturing/DepthLimiter.cs
+++ b/src/Serilog/Capturing/DepthLimiter.cs
@@ -75,7 +75,7 @@ namespace Serilog.Capturing
                     SelfLog.WriteLine("Maximum destructuring depth reached.");
                     if (_writeFinalDepthAsScalar)
                     {
-                        return _propertyValueConverter.CreatePropertyValue(value, Destructuring.Default, depth);
+                        return _propertyValueConverter.CreatePropertyValue(value, Destructuring.Scalars, depth);
                     }
                     else
                     {

--- a/src/Serilog/Capturing/PropertyValueConverter.cs
+++ b/src/Serilog/Capturing/PropertyValueConverter.cs
@@ -134,14 +134,19 @@ namespace Serilog.Capturing
                 return Stringify(value);
             }
 
-            if (destructuring.HasFlag(Destructuring.Scalars))
+            if (destructuring.HasFlag(Destructuring.Destructure))
             {
                 if (value is string stringValue)
                 {
                     value = TruncateIfNecessary(stringValue);
-                    return new ScalarValue(value);
                 }
+            }
 
+            if (value is string)
+                return new ScalarValue(value);
+
+            if (destructuring.HasFlag(Destructuring.Scalars))
+            {
                 foreach (var scalarConversionPolicy in _scalarConversionPolicies)
                 {
                     if (scalarConversionPolicy.TryConvertToScalar(value, out var converted))
@@ -151,7 +156,7 @@ namespace Serilog.Capturing
 
             DepthLimiter.SetCurrentDepth(depth);
 
-            if (destructuring == Destructuring.Destructure)
+            if (destructuring.HasFlag(Destructuring.Destructure))
             {
                 foreach (var destructuringPolicy in _destructuringPolicies)
                 {

--- a/src/Serilog/Capturing/PropertyValueConverter.cs
+++ b/src/Serilog/Capturing/PropertyValueConverter.cs
@@ -52,6 +52,7 @@ namespace Serilog.Capturing
 
         public PropertyValueConverter(
             int maximumDestructuringDepth,
+            bool writeFinalDepthAsScalar,
             int maximumStringLength,
             int maximumCollectionCount,
             IEnumerable<Type> additionalScalarTypes,
@@ -83,7 +84,7 @@ namespace Serilog.Capturing
                 })
                 .ToArray();
 
-            _depthLimiter = new DepthLimiter(maximumDestructuringDepth, this);
+            _depthLimiter = new DepthLimiter(maximumDestructuringDepth, writeFinalDepthAsScalar, this);
         }
 
         public LogEventProperty CreateProperty(string name, object value, bool destructureObjects = false)

--- a/src/Serilog/Configuration/LoggerDestructuringConfiguration.cs
+++ b/src/Serilog/Configuration/LoggerDestructuringConfiguration.cs
@@ -154,9 +154,9 @@ namespace Serilog.Configuration
         }
 
         /// <summary>
-        /// When destructuring objects, depth will be limited to 5 property traversals deep to
+        /// When destructuring objects, depth will be limited to 10 property traversals deep to
         /// guard against ballooning space when recursive/cyclic structures are accidentally passed. To
-        /// increase this limit pass a higher value.
+        /// change this limit pass a new maximum depth.
         /// </summary>
         /// <param name="maximumDestructuringDepth">The maximum depth to use.</param>
         /// <param name="writeFinalDepthAsScalar">When set to true write the final depth as scalar instead of null.</param>

--- a/src/Serilog/Configuration/LoggerDestructuringConfiguration.cs
+++ b/src/Serilog/Configuration/LoggerDestructuringConfiguration.cs
@@ -27,15 +27,17 @@ namespace Serilog.Configuration
         readonly LoggerConfiguration _loggerConfiguration;
         readonly Action<Type> _addScalar;
         readonly Action<IDestructuringPolicy> _addPolicy;
-        readonly Action<int> _setMaximumDepth;
+        readonly SetMaximumDepthDeletegate _setMaximumDepth;
         readonly Action<int> _setMaximumStringLength;
         readonly Action<int> _setMaximumCollectionCount;
+
+        internal delegate void SetMaximumDepthDeletegate(int depth, bool writeFinalDepthAsScalar);
 
         internal LoggerDestructuringConfiguration(
             LoggerConfiguration loggerConfiguration,
             Action<Type> addScalar,
             Action<IDestructuringPolicy> addPolicy,
-            Action<int> setMaximumDepth,
+            SetMaximumDepthDeletegate setMaximumDepth,
             Action<int> setMaximumStringLength,
             Action<int> setMaximumCollectionCount)
         {
@@ -147,7 +149,23 @@ namespace Serilog.Configuration
         public LoggerConfiguration ToMaximumDepth(int maximumDestructuringDepth)
         {
             if (maximumDestructuringDepth < 0) throw new ArgumentOutOfRangeException(nameof(maximumDestructuringDepth));
-            _setMaximumDepth(maximumDestructuringDepth);
+            _setMaximumDepth(maximumDestructuringDepth, false);
+            return _loggerConfiguration;
+        }
+
+        /// <summary>
+        /// When destructuring objects, depth will be limited to 5 property traversals deep to
+        /// guard against ballooning space when recursive/cyclic structures are accidentally passed. To
+        /// increase this limit pass a higher value.
+        /// </summary>
+        /// <param name="maximumDestructuringDepth">The maximum depth to use.</param>
+        /// <param name="writeFinalDepthAsScalar">When set to true write the final depth as scalar instead of null.</param>
+        /// <returns>Configuration object allowing method chaining.</returns>
+        /// <exception cref="ArgumentOutOfRangeException"></exception>
+        public LoggerConfiguration ToMaximumDepth(int maximumDestructuringDepth, bool writeFinalDepthAsScalar)
+        {
+            if (maximumDestructuringDepth < 0) throw new ArgumentOutOfRangeException(nameof(maximumDestructuringDepth));
+            _setMaximumDepth(maximumDestructuringDepth, writeFinalDepthAsScalar);
             return _loggerConfiguration;
         }
 

--- a/src/Serilog/LoggerConfiguration.cs
+++ b/src/Serilog/LoggerConfiguration.cs
@@ -39,6 +39,7 @@ namespace Serilog
         LogEventLevel _minimumLevel = LogEventLevel.Information;
         LoggingLevelSwitch _levelSwitch;
         int _maximumDestructuringDepth = 10;
+        bool _writeFinalDepthAsScalar = false;
         int _maximumStringLength = int.MaxValue;
         int _maximumCollectionCount = int.MaxValue;
         bool _loggerCreated;
@@ -121,7 +122,11 @@ namespace Serilog
                     this,
                     _additionalScalarTypes.Add,
                     _additionalDestructuringPolicies.Add,
-                    depth => _maximumDestructuringDepth = depth,
+                    (depth, writeFinalDepthAsScalar) =>
+                    {
+                        _maximumDestructuringDepth = depth;
+                        _writeFinalDepthAsScalar = writeFinalDepthAsScalar;
+                    },
                     length => _maximumStringLength = length,
                     count => _maximumCollectionCount = count);
             }
@@ -160,6 +165,7 @@ namespace Serilog
 
             var converter = new PropertyValueConverter(
                 _maximumDestructuringDepth,
+                _writeFinalDepthAsScalar,
                 _maximumStringLength,
                 _maximumCollectionCount,
                 _additionalScalarTypes,

--- a/src/Serilog/Parsing/Destructuring.cs
+++ b/src/Serilog/Parsing/Destructuring.cs
@@ -12,28 +12,45 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System;
+
 namespace Serilog.Parsing
 {
     /// <summary>
     /// Instructs the logger on how to store information about provided
     /// parameters.
     /// </summary>
+    [Flags]
     public enum Destructuring
     {
         /// <summary>
-        /// Convert known types and objects to scalars, arrays to sequences.
-        /// </summary>
-        Default,
-
-        /// <summary>
         /// Convert all types to scalar strings. Prefix name with '$'.
         /// </summary>
-        Stringify,
+        Stringify = 0,
+
+        /// <summary>
+        /// Convert known types and objects to scalars.
+        /// </summary>
+        Scalars = 1 << 1,
+        /// <summary>
+        /// Convert arrays to sequences.
+        /// </summary>
+        Sequences = 1 << 2,
+
+        /// <summary>
+        /// Convert known types to scalars, destructure objects into structures.
+        /// </summary>
+        Structures = 1 << 3,
+
+        /// <summary>
+        /// Convert known types and objects to scalars, arrays to sequences.
+        /// </summary>
+        Default = Scalars | Sequences,
 
         /// <summary>
         /// Convert known types to scalars, destructure objects and collections
         /// into sequences and structures. Prefix name with '@'.
         /// </summary>
-        Destructure
+        Destructure = Scalars | Sequences | Structures
     }
 }

--- a/src/Serilog/Parsing/Destructuring.cs
+++ b/src/Serilog/Parsing/Destructuring.cs
@@ -31,16 +31,16 @@ namespace Serilog.Parsing
         /// <summary>
         /// Convert known types and objects to scalars.
         /// </summary>
-        Scalars = 1 << 1,
+        Scalars = 1 << 0,
         /// <summary>
         /// Convert arrays to sequences.
         /// </summary>
-        Sequences = 1 << 2,
+        Sequences = 1 << 1,
 
         /// <summary>
         /// Convert known types to scalars, destructure objects into structures.
         /// </summary>
-        Structures = 1 << 3,
+        Structures = 1 << 2,
 
         /// <summary>
         /// Convert known types and objects to scalars, arrays to sequences.

--- a/test/Serilog.Tests/Capturing/PropertyValueConverterTests.cs
+++ b/test/Serilog.Tests/Capturing/PropertyValueConverterTests.cs
@@ -77,7 +77,7 @@ namespace Serilog.Tests.Capturing
         {
             var converter = new PropertyValueConverter(3, true, 1000, 1000, Enumerable.Empty<Type>(), Enumerable.Empty<IDestructuringPolicy>(), false);
 
-            var barrier = new Barrier(participantCount: 1);
+            var barrier = new Barrier(participantCount: 4);
 
             var testObject1 = new { Root = new { B = new { C = new { D = new { E = "F" } } } } };
             var t1 =
@@ -105,7 +105,7 @@ namespace Serilog.Tests.Capturing
                     {
                         Assert.Contains("M", result);
                         Assert.Contains("N", result);
-                        Assert.Contains(testObject3.Root.M.N.ToString(), result);
+                        Assert.Contains("\"{ V = 8 }\"", result);
                     }));
 
             var testObject4 = new { Root = new { I = new { Arr = new[] { 1, 2, 3, 4, 5, 6 } } } };
@@ -114,7 +114,7 @@ namespace Serilog.Tests.Capturing
                     result =>
                     {
                         Assert.Contains("I", result);
-                        Assert.Contains("Arr: null", result);
+                        Assert.Contains("\"System.Int32[]\"", result);
                     }));
 
             await Task.WhenAll(t1, t2, t3, t4);
@@ -378,7 +378,7 @@ namespace Serilog.Tests.Capturing
         public void ValueTuplesAreRecognizedWhenDestructuring()
         {
             var o = (1, "A", new[] { "B" });
-            var result = _converter.CreatePropertyValue(o);
+            var result = _converter.CreatePropertyValue(o, true);
 
             var sequenceValue = Assert.IsType<SequenceValue>(result);
 
@@ -405,7 +405,7 @@ namespace Serilog.Tests.Capturing
             };
 
             foreach (var t in tuples)
-                Assert.IsType<SequenceValue>(_converter.CreatePropertyValue(t));
+                Assert.IsType<SequenceValue>(_converter.CreatePropertyValue(t, true));
         }
 
         [Fact]

--- a/test/Serilog.Tests/Core/LogEventPropertyCapturingTests.cs
+++ b/test/Serilog.Tests/Core/LogEventPropertyCapturingTests.cs
@@ -178,7 +178,7 @@ namespace Serilog.Tests.Core
         {
             var mt = new MessageTemplateParser().Parse(messageTemplate);
             var binder = new PropertyBinder(
-                new PropertyValueConverter(10, 1000, 1000, Enumerable.Empty<Type>(), Enumerable.Empty<IDestructuringPolicy>(), false));
+                new PropertyValueConverter(10, false, 1000, 1000, Enumerable.Empty<Type>(), Enumerable.Empty<IDestructuringPolicy>(), false));
             return binder.ConstructProperties(mt, properties).Select(p => new LogEventProperty(p.Name, p.Value));
         }
     }

--- a/test/Serilog.Tests/Core/MessageTemplateTests.cs
+++ b/test/Serilog.Tests/Core/MessageTemplateTests.cs
@@ -120,7 +120,7 @@ namespace Serilog.Tests.Core
         static string Render(IFormatProvider formatProvider, string messageTemplate, params object[] properties)
         {
             var mt = new MessageTemplateParser().Parse(messageTemplate);
-            var binder = new PropertyBinder(new PropertyValueConverter(10, 1000, 1000, Enumerable.Empty<Type>(), Enumerable.Empty<IDestructuringPolicy>(), false));
+            var binder = new PropertyBinder(new PropertyValueConverter(10, false, 1000, 1000, Enumerable.Empty<Type>(), Enumerable.Empty<IDestructuringPolicy>(), false));
             var props = binder.ConstructProperties(mt, properties);
             var output = new StringBuilder();
             var writer = new StringWriter(output);

--- a/test/Serilog.Tests/Events/LogEventPropertyValueTests.cs
+++ b/test/Serilog.Tests/Events/LogEventPropertyValueTests.cs
@@ -27,7 +27,7 @@ namespace Serilog.Tests.Events
     public class LogEventPropertyValueTests
     {
         readonly PropertyValueConverter _converter =
-            new PropertyValueConverter(10, 1000, 1000, Enumerable.Empty<Type>(), Enumerable.Empty<IDestructuringPolicy>(), false);
+            new PropertyValueConverter(10, false, 1000, 1000, Enumerable.Empty<Type>(), Enumerable.Empty<IDestructuringPolicy>(), false);
 
         [Fact]
         public void AnEnumIsConvertedToANonStringScalarValue()

--- a/test/Serilog.Tests/LoggerConfigurationTests.cs
+++ b/test/Serilog.Tests/LoggerConfigurationTests.cs
@@ -297,7 +297,7 @@ namespace Serilog.Tests
         public void MaximumStringLengthNOTEffectiveForString()
         {
             var x = "ABCD";
-            var limitedText = LogAndGetAsString(x, conf => conf.Destructure.ToMaximumStringLength(4));
+            var limitedText = LogAndGetAsString(x, conf => conf.Destructure.ToMaximumStringLength(3));
 
             Assert.Equal("\"ABCD\"", limitedText);
         }

--- a/test/Serilog.Tests/LoggerConfigurationTests.cs
+++ b/test/Serilog.Tests/LoggerConfigurationTests.cs
@@ -297,7 +297,7 @@ namespace Serilog.Tests
         public void MaximumStringLengthNOTEffectiveForString()
         {
             var x = "ABCD";
-            var limitedText = LogAndGetAsString(x, conf => conf.Destructure.ToMaximumStringLength(3));
+            var limitedText = LogAndGetAsString(x, conf => conf.Destructure.ToMaximumStringLength(4));
 
             Assert.Equal("\"ABCD\"", limitedText);
         }
@@ -706,7 +706,7 @@ namespace Serilog.Tests
             Assert.Empty(DummyWrappingSink.Emitted);
             Assert.Empty(sink.Events);
         }
-        
+
         [Fact]
         public void WrappingSinkReceivesEventsWhenLevelIsAppropriate()
         {
@@ -778,7 +778,7 @@ namespace Serilog.Tests
             var evt = Assert.Single(enricher.Events);
             Assert.Equal(LogEventLevel.Warning, evt.Level);
         }
-        
+
         [Fact]
         public void LeveledEnrichersCheckLevels()
         {


### PR DESCRIPTION
**What issue does this PR address?**
#1351

**Does this PR introduce a breaking change?**
Probably not. Some unit tests were passing when they possibly shouldn't be.

**Please check if the PR fulfills these requirements**
- [x] The commit follows our [guidelines](https://github.com/serilog/serilog/blob/dev/CONTRIBUTING.md)
- [x] Unit Tests for the changes have been added (for bug fixes / features)

**Other information**:
Unsure about the Destructuring enum being changed to a flag, but found what seems like bugs because of it specifically:
- `ValueTuplesAreRecognizedWhenDestructuring` was acting despite destrucuturing set implicitly to false
- `AllTupleLengthsUpToSevenAreSupportedForCapturing` also acting despite destrucuturing being implicitly false
- `MaximumStringLengthNOTEffectiveForString` ~~passing despite being give a 4 length string and a 3 length limit~~ According to method description this should only apply during destructuring 
