### PR TITLE
Update summary for default destructuring depth

### DIFF
--- a/src/Serilog/Configuration/LoggerDestructuringConfiguration.cs
+++ b/src/Serilog/Configuration/LoggerDestructuringConfiguration.cs
@@ -137,9 +137,9 @@ namespace Serilog.Configuration
         }
 
         /// <summary>
-        /// When destructuring objects, depth will be limited to 5 property traversals deep to
+        /// When destructuring objects, depth will be limited to 10 property traversals deep to
         /// guard against ballooning space when recursive/cyclic structures are accidentally passed. To
-        /// increase this limit pass a higher value.
+        /// change this limit pass a new maximum depth.
         /// </summary>
         /// <param name="maximumDestructuringDepth">The maximum depth to use.</param>
         /// <returns>Configuration object allowing method chaining.</returns>

--- a/test/Serilog.Tests/LoggerConfigurationTests.cs
+++ b/test/Serilog.Tests/LoggerConfigurationTests.cs
@@ -263,6 +263,35 @@ namespace Serilog.Tests
         }
 
         [Fact]
+        public void MaximumDestructuringDepthDefaultIsEffective()
+        {
+            var x = new
+            {
+                Lvl01 = new
+                {
+                    Lvl02 = new
+                    {
+                        Lvl03 = new
+                        {
+                            Lvl04 = new
+                            {
+                                Lvl05 = new
+                                {
+                                    Lvl06 = new { Lvl07 = new { Lvl08 = new { Lvl09 = new { Lvl10 = "Lvl11" } } } }
+                                }
+                            }
+                        }
+                    }
+                }
+            };
+
+            var xs = LogAndGetAsString(x, conf => conf, "@");
+
+            Assert.Contains("Lvl10", xs);
+            Assert.DoesNotContain("Lvl11", xs);
+        }
+
+        [Fact]
         public void MaximumDestructuringDepthIsEffective()
         {
             var x = new


### PR DESCRIPTION
**What issue does this PR address?**
The summary for the [`LoggerDestructuringConfiguration.ToMaximumDepth`](https://github.com/serilog/serilog/blob/dev/src/Serilog/Configuration/LoggerDestructuringConfiguration.cs#L140) method incorrectly states that the default maximum destructuring depth is 5, when in fact the [default is 10](https://github.com/serilog/serilog/blob/dev/src/Serilog/LoggerConfiguration.cs#L41).

There is no Issue raised for this. Since it does not change any implementation and is such a minor change I assumed it would not be necessary. Let me know if this is not the case and I'll happily add one!

**Does this PR introduce a breaking change?**
No. This is a documentation change only.

**Please check if the PR fulfills these requirements**
- [x] The commit follows our [guidelines](https://github.com/serilog/serilog/blob/dev/CONTRIBUTING.md)
- [x] Unit Tests for the changes have been added (for bug fixes / features)

**Other information**:
As well as updating the summary, I've also added a test to confirm that the default destructuring depth of 10 is honoured.