### PR TITLE
Fix custom format string parsing

### DIFF
--- a/src/Serilog/Parsing/MessageTemplateParser.cs
+++ b/src/Serilog/Parsing/MessageTemplateParser.cs
@@ -253,7 +253,8 @@ namespace Serilog.Parsing
             return c != '}' &&
                 (char.IsLetterOrDigit(c) ||
                  char.IsPunctuation(c) ||
-                 c == ' ');
+                 c == ' ' ||
+                 c == '+');
         }
 
         static TextToken ParseTextToken(int startAt, string messageTemplate, out int next)

--- a/test/Serilog.Tests/Parsing/MessageTemplateParserTests.cs
+++ b/test/Serilog.Tests/Parsing/MessageTemplateParserTests.cs
@@ -171,5 +171,23 @@ namespace Serilog.Tests.Parsing
             var parser = new MessageTemplateParser();
             parser.Parse("{,,}");
         }
+
+        [Fact]
+        public void Bug1353FormatStringIsParsedCorrectly()
+        {
+            AssertParsedAs("{0,-25} {1,10:#,##0} {2,10:#,##0} {3,10:+#,##0;-#,##0;0} {4,10:0.00}",
+                new PropertyToken("0","{0,-25}", startIndex:0),
+                new TextToken(" ", startIndex:7),
+                new PropertyToken("1","{1,10:#,##0}", "#,##0", startIndex:8),
+                new TextToken(" ", startIndex:20),
+                new PropertyToken("2","{2,10:#,##0}", "#,##0", startIndex:21),
+                new TextToken(" ", startIndex:33),
+                new PropertyToken("3","{3,10:+#,##0;-#,##0;0}", "+#,##0;-#,##0;0", startIndex:34),
+                new TextToken(" ", startIndex:56),
+                new PropertyToken("4","{4,10:0.00}", "0.00", startIndex:57)
+            );
+        }
+        
+        
     }
 }

--- a/test/Serilog.Tests/Parsing/MessageTemplateParserTests.cs
+++ b/test/Serilog.Tests/Parsing/MessageTemplateParserTests.cs
@@ -173,21 +173,17 @@ namespace Serilog.Tests.Parsing
         }
 
         [Fact]
-        public void Bug1353FormatStringIsParsedCorrectly()
+        public void FormatCanContainMultipleSections()
         {
-            AssertParsedAs("{0,-25} {1,10:#,##0} {2,10:#,##0} {3,10:+#,##0;-#,##0;0} {4,10:0.00}",
-                new PropertyToken("0","{0,-25}", startIndex:0),
-                new TextToken(" ", startIndex:7),
-                new PropertyToken("1","{1,10:#,##0}", "#,##0", startIndex:8),
-                new TextToken(" ", startIndex:20),
-                new PropertyToken("2","{2,10:#,##0}", "#,##0", startIndex:21),
-                new TextToken(" ", startIndex:33),
-                new PropertyToken("3","{3,10:+#,##0;-#,##0;0}", "+#,##0;-#,##0;0", startIndex:34),
-                new TextToken(" ", startIndex:56),
-                new PropertyToken("4","{4,10:0.00}", "0.00", startIndex:57)
-            );
+            var parsed = (PropertyToken)Parse("{Number:##.0;-##.0;zero}").Single();
+            Assert.Equal("##.0;-##.0;zero", parsed.Format);
         }
-        
-        
+
+        [Fact]
+        public void FormatCanContainPlusSign()
+        {
+            var parsed = (PropertyToken)Parse("{Number:+##.0}").Single();
+            Assert.Equal("+##.0", parsed.Format);
+        }
     }
 }


### PR DESCRIPTION
**What issue does this PR address?**
fixes  #1353 


**Does this PR introduce a breaking change?**
No

**Please check if the PR fulfills these requirements**
- [x] The commit follows our [guidelines](https://github.com/serilog/serilog/blob/dev/CONTRIBUTING.md)
- [x] Unit Tests for the changes have been added (for bug fixes / features)

**Other information**:
The custom numeric format string mentioned in the bug was not parsed correctly because it contained a plus sign. The IsValidInFormat() function in the MessageTemplateParser did not consider '+' a valid character in format strings.