### PR TITLE
Enrich.ByRemovingProperty(name)

### DIFF
--- a/src/Serilog/Configuration/LoggerEnrichmentConfiguration.cs
+++ b/src/Serilog/Configuration/LoggerEnrichmentConfiguration.cs
@@ -84,6 +84,18 @@ namespace Serilog.Configuration
         }
 
         /// <summary>
+        /// Remove the specified property from events.
+        /// </summary>
+        /// <param name="name">The name of the property to remove.</param>
+        /// <param name="retainWhenInMessage">If <c>true</c>, the property will be removed only when
+        /// it doesn't appear in the event's message template; otherwise, the property will be removed regardless.</param>
+        /// <returns></returns>
+        public LoggerConfiguration ByRemovingProperty(string name, bool retainWhenInMessage = false)
+        {
+            return With(new RemovePropertyEnricher(name, retainWhenInMessage));
+        }
+
+        /// <summary>
         /// Enrich log events with properties from <see cref="Context.LogContext"/>.
         /// </summary>
         /// <returns>Configuration object allowing method chaining.</returns>

--- a/src/Serilog/Core/Enrichers/FixedPropertyEnricher.cs
+++ b/src/Serilog/Core/Enrichers/FixedPropertyEnricher.cs
@@ -17,6 +17,10 @@ using Serilog.Events;
 
 namespace Serilog.Core.Enrichers
 {
+    /// <summary>
+    /// A lower-cost alternative to <see cref="PropertyEnricher"/> that can be used in cases where
+    /// the logger's destructuring/scalar conversion policies won't apply.
+    /// </summary>
     class FixedPropertyEnricher : ILogEventEnricher
     {
         readonly EventProperty _eventProperty;

--- a/src/Serilog/Core/Enrichers/RemovePropertyEnricher.cs
+++ b/src/Serilog/Core/Enrichers/RemovePropertyEnricher.cs
@@ -1,0 +1,52 @@
+﻿// Copyright 2019 Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using Serilog.Events;
+
+namespace Serilog.Core.Enrichers
+{
+    class RemovePropertyEnricher : ILogEventEnricher
+    {
+        readonly string _propertyName;
+        readonly bool _retainWhenInMessage;
+
+        public RemovePropertyEnricher(string propertyName, bool retainWhenInMessage)
+        {
+            if (string.IsNullOrWhiteSpace(propertyName)) throw new ArgumentException("Property name must not be null or empty.", nameof(propertyName));
+            _propertyName = propertyName;
+            _retainWhenInMessage = retainWhenInMessage;
+        }
+
+        public void Enrich(LogEvent logEvent, ILogEventPropertyFactory propertyFactory)
+        {
+            if (!_retainWhenInMessage)
+            {
+                logEvent.RemovePropertyIfPresent(_propertyName);
+                return;
+            }
+
+            if (logEvent.Properties.ContainsKey(_propertyName))
+            {
+                for (var i = 0; i < logEvent.MessageTemplate.NamedProperties.Length; ++i)
+                {
+                    if (logEvent.MessageTemplate.NamedProperties[i].PropertyName == _propertyName)
+                        return;
+                }
+
+                logEvent.RemovePropertyIfPresent(_propertyName);
+            }
+        }
+    }
+}

--- a/test/Serilog.Tests/Core/RemovePropertyEnricherTests.cs
+++ b/test/Serilog.Tests/Core/RemovePropertyEnricherTests.cs
@@ -1,0 +1,54 @@
+﻿using Serilog.Core.Enrichers;
+using Serilog.Tests.Support;
+using Xunit;
+
+namespace Serilog.Tests.Core
+{
+    public class RemovePropertyEnricherTests
+    {
+        [Fact]
+        public void TheEnricherHasNoEffectIfThePropertyIsMissing()
+        {
+            var logEvent = Some.LogEvent(l => l.ForContext("A", 1).Information("Hello"));
+            var enricher = new RemovePropertyEnricher("B", false);
+
+            enricher.Enrich(logEvent, Some.LogEventPropertyFactory());
+
+            Assert.True(logEvent.Properties.ContainsKey("A"));
+            Assert.False(logEvent.Properties.ContainsKey("B"));
+        }
+
+        [Fact]
+        public void TheEnricherRemovesThePropertyIfPresent()
+        {
+            var logEvent = Some.LogEvent(l => l.ForContext("A", 1).Information("Hello"));
+            var enricher = new RemovePropertyEnricher("A", false);
+
+            enricher.Enrich(logEvent, Some.LogEventPropertyFactory());
+
+            Assert.False(logEvent.Properties.ContainsKey("A"));
+        }
+
+        [Fact]
+        public void TheEnricherRemovesThePropertyEvenIfIncludedInTheMessage()
+        {
+            var logEvent = Some.LogEvent(l => l.Information("Hello, {A}", 1));
+            var enricher = new RemovePropertyEnricher("A", false);
+
+            enricher.Enrich(logEvent, Some.LogEventPropertyFactory());
+
+            Assert.False(logEvent.Properties.ContainsKey("A"));
+        }
+
+        [Fact]
+        public void TheEnricherPreservesThePropertyIfIncludedInTheMessageAndInstructedToRetain()
+        {
+            var logEvent = Some.LogEvent(l => l.Information("Hello, {A}", 1));
+            var enricher = new RemovePropertyEnricher("A", true);
+
+            enricher.Enrich(logEvent, Some.LogEventPropertyFactory());
+
+            Assert.True(logEvent.Properties.ContainsKey("A"));
+        }
+    }
+}

--- a/test/Serilog.Tests/Support/Some.cs
+++ b/test/Serilog.Tests/Support/Some.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading;
+using Serilog.Capturing;
 using Serilog.Core;
 using Serilog.Events;
 using Serilog.Parsing;
@@ -75,6 +76,24 @@ namespace Serilog.Tests.Support
         public static MessageTemplate MessageTemplate()
         {
             return new MessageTemplateParser().Parse(String());
+        }
+
+        public static LogEvent LogEvent(Action<ILogger> emit)
+        {
+            var cs = new CollectingSink();
+            using var logger = new LoggerConfiguration()
+                .MinimumLevel.Is(LevelAlias.Minimum)
+                .WriteTo.Sink(cs)
+                .CreateLogger();
+
+            emit(logger);
+
+            return cs.SingleEvent;
+        }
+
+        public static ILogEventPropertyFactory LogEventPropertyFactory()
+        {
+            return new PropertyValueConverter(10, 1000, 1000, Enumerable.Empty<Type>(), Enumerable.Empty<IDestructuringPolicy>(), true);
         }
     }
 }


### PR DESCRIPTION
Frameworks set up for structured logging often include a range of contextual properties in log events, via `LogContext.PushProperty()`, or `ILogger.BeginScope()`. Not all applications need or want all of these.

`Enrich.ByRemovingProperty()` addresses this:

```csharp
Log.Logger = new LoggerConfiguration()
    .Enrich.ByRemovingProperty("Test")
    .CreateLogger();

Log.ForContext("Test", 1).Information("Hello");
// --> no `Test` property appears in the output
```

The enricher will remove `Test` even if it appears in the message template:

```csharp
Log.ForContext("Running {Test}", testName);
```

This is the default behavior because a) it's cheap, and b) it's safer when the property is (questionably) something like `CreditCardNumber` (do not do this 🤨).

To check the message template, and retain the property when it appears in it, an additional flag can be set:

```csharp
    .Enrich.ByRemovingProperty("Test", retainWhenInMessage: true)
```

(The name of this flag could leave room for improvement.)

**Does this PR introduce a breaking change?**

No

**Please check if the PR fulfills these requirements**
- [x] The commit follows our [guidelines](https://github.com/serilog/serilog/blob/dev/CONTRIBUTING.md)
- [x] Unit Tests for the changes have been added (for bug fixes / features)

**Other information**:

CC @rocklan