### PR TITLE
Improve Serilog.Parsing Unit Tests and Code Coverage - Take 2

### DIFF
--- a/test/Serilog.Tests/Parsing/MessageTemplateParserTests.cs
+++ b/test/Serilog.Tests/Parsing/MessageTemplateParserTests.cs
@@ -228,6 +228,13 @@ namespace Serilog.Tests.Parsing
         }
 
         [Fact]
+        public void APropertyWithValidNameAndInvalidFormatIsParsedAsText()
+        {
+            AssertParsedAs("{Hello:HH$MM}",
+                new TextToken("{Hello:HH$MM}"));
+        }
+
+        [Fact]
         public void PropertiesCanHaveLeftAlignment()
         {
             var prop1 = (PropertyToken)Parse("{Hello,-5}").Single();

--- a/test/Serilog.Tests/Parsing/MessageTemplateParserTests.cs
+++ b/test/Serilog.Tests/Parsing/MessageTemplateParserTests.cs
@@ -77,6 +77,9 @@ namespace Serilog.Tests.Parsing
         {
             AssertParsedAs("Well, {{ Hi!",
                 new TextToken("Well, { Hi!"));
+
+            AssertParsedAs("Hello, {{worl@d}!",
+                new TextToken("Hello, {worl@d}!"));
         }
 
         [Fact]
@@ -85,12 +88,25 @@ namespace Serilog.Tests.Parsing
             AssertParsedAs("Nice }}-: mo",
                 new TextToken("Nice }-: mo"));
         }
+        
+        [Fact]
+        public void DoubledRightBracketsAfterOneLeftIsParsedAPropertyTokenAndATextToken()
+        {
+            AssertParsedAs("{World}}!",
+                new PropertyToken("World", "{World}"), new TextToken("}!"));
+
+            AssertParsedAs("Hello, {World}}!",
+                new TextToken("Hello, "), new PropertyToken("World", "{World}"), new TextToken("}!"));
+        }
 
         [Fact]
         public void DoubledBracketsAreParsedAsASingleBracket()
         {
             AssertParsedAs("{{Hi}}",
                 new TextToken("{Hi}"));
+            
+            AssertParsedAs("Hello, {{worl@d}}!",
+                new TextToken("Hello, {worl@d}!"));
         }
 
         [Fact]
@@ -113,6 +129,22 @@ namespace Serilog.Tests.Parsing
             AssertParsedAs("{0_}}space}",
                 new PropertyToken("0_", "{0_}"),
                 new TextToken("}space}"));
+        }
+        
+        [Fact]
+        public void AMessageWithAMalformedPropertyTagIsParsedAsManyTextTokens()
+        {
+            AssertParsedAs("Hello, {w@rld}",
+                new TextToken("Hello, "), new TextToken("{w@rld}"));
+
+            AssertParsedAs("Hello, {w@rld}, HI!",
+                new TextToken("Hello, "), new TextToken("{w@rld}"), new TextToken(", HI!"));
+
+            AssertParsedAs("{w@rld} Hi!",
+                new TextToken("{w@rld}"), new TextToken(" Hi!"));
+
+            AssertParsedAs("{H&llo}, {w@rld}",
+                new TextToken("{H&llo}"), new TextToken(", "), new TextToken("{w@rld}"));
         }
 
         [Fact]

--- a/test/Serilog.Tests/Parsing/MessageTemplateParserTests.cs
+++ b/test/Serilog.Tests/Parsing/MessageTemplateParserTests.cs
@@ -114,6 +114,12 @@ namespace Serilog.Tests.Parsing
         {
             AssertParsedAs("{0 space}",
                 new TextToken("{0 space}"));
+
+            AssertParsedAs("{0 space",
+                new TextToken("{0 space"));
+            
+            AssertParsedAs("{0_space",
+                new TextToken("{0_space"));
         }
 
         [Fact]
@@ -121,6 +127,9 @@ namespace Serilog.Tests.Parsing
         {
             AssertParsedAs("{0_{{space}",
                 new TextToken("{0_{{space}"));
+
+            AssertParsedAs("{0_{{space",
+                new TextToken("{0_{{space"));
         }
 
         [Fact]
@@ -136,6 +145,15 @@ namespace Serilog.Tests.Parsing
         {
             AssertParsedAs("Hello, {w@rld}",
                 new TextToken("Hello, "), new TextToken("{w@rld}"));
+
+            AssertParsedAs("Hello, {w@rld",
+                new TextToken("Hello, "), new TextToken("{w@rld"));
+
+            AssertParsedAs("Hello, {w{{rld",
+                new TextToken("Hello, "), new TextToken("{w{{rld"));
+
+            AssertParsedAs("Hello{{, {w{{rld",
+                new TextToken("Hello{, "), new TextToken("{w{{rld"));
 
             AssertParsedAs("Hello, {w@rld}, HI!",
                 new TextToken("Hello, "), new TextToken("{w@rld}"), new TextToken(", HI!"));
@@ -401,6 +419,9 @@ namespace Serilog.Tests.Parsing
         {
             AssertParsedAs("{@}",
                 new TextToken("{@}"));
+
+            AssertParsedAs("{$}",
+                new TextToken("{$}"));
         }
 
         [Fact]


### PR DESCRIPTION
**What issue does this PR address?**
This PR is to Improve the *Code Coverage* for _Serilog.Parsing.*_

**Does this PR introduce a breaking change?**
No

**Please check if the PR fulfills these requirements**
- [ ] The commit follows our [guidelines](https://github.com/serilog/serilog/blob/dev/CONTRIBUTING.md)
- [x] Unit Tests for the changes have been added (for bug fixes / features)

I didn't create a PR for this PR. This PR don't fix or add any functionality.

**Other information**:

-  _Serilog.Parsing.MessageTemplateParser_ code coverage is now **100%**