### PR TITLE
Follow redirect to download dotnet-install.sh

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -4,4 +4,4 @@ sudo apt-get update && sudo apt-get install -y --no-install-recommends jq
 
 RequiredDotnetVersion=$(jq -r '.sdk.version' global.json)
 
-curl https://dot.net/v1/dotnet-install.sh -sSf | bash -s -- --install-dir $HOME/.dotnetcli --no-path --version $RequiredDotnetVersion
+curl https://dot.net/v1/dotnet-install.sh -sSfL | bash -s -- --install-dir $HOME/.dotnetcli --no-path --version $RequiredDotnetVersion


### PR DESCRIPTION
Current Ubuntu1804 build failure; appears to be due to `dotnet-install.sh` moving.