### PR TITLE
Adds the ability to filter object properties recorded in StructureValue

### DIFF
--- a/src/Serilog/Capturing/PropertyValueConverter.cs
+++ b/src/Serilog/Capturing/PropertyValueConverter.cs
@@ -362,7 +362,7 @@ namespace Serilog.Capturing
                     propValue = "The property accessor threw an exception: " + ex.InnerException?.GetType().Name;
                 }
 
-                if (_destructuringPropertyFilter?.Invoke(prop, propValue) == true)
+                if (_destructuringPropertyFilter == null || _destructuringPropertyFilter(prop, propValue))
                     yield return new LogEventProperty(prop.Name, _depthLimiter.CreatePropertyValue(propValue, Destructuring.Destructure));
             }
         }

--- a/src/Serilog/LoggerConfiguration.cs
+++ b/src/Serilog/LoggerConfiguration.cs
@@ -15,6 +15,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using Serilog.Capturing;
 using Serilog.Configuration;
 using Serilog.Core;
@@ -41,6 +42,7 @@ namespace Serilog
         int _maximumDestructuringDepth = 10;
         int _maximumStringLength = int.MaxValue;
         int _maximumCollectionCount = int.MaxValue;
+        Func<PropertyInfo, object, bool> _destructuringPropertyFilter;
         bool _loggerCreated;
 
         /// <summary>
@@ -123,7 +125,8 @@ namespace Serilog
                     _additionalDestructuringPolicies.Add,
                     depth => _maximumDestructuringDepth = depth,
                     length => _maximumStringLength = length,
-                    count => _maximumCollectionCount = count);
+                    count => _maximumCollectionCount = count,
+                    filter => _destructuringPropertyFilter = filter);
             }
         }
 
@@ -164,6 +167,7 @@ namespace Serilog
                 _maximumCollectionCount,
                 _additionalScalarTypes,
                 _additionalDestructuringPolicies,
+                _destructuringPropertyFilter,
                 auditing);
             var processor = new MessageTemplateProcessor(converter);
 

--- a/test/Serilog.Tests/Core/LogEventPropertyCapturingTests.cs
+++ b/test/Serilog.Tests/Core/LogEventPropertyCapturingTests.cs
@@ -178,7 +178,7 @@ namespace Serilog.Tests.Core
         {
             var mt = new MessageTemplateParser().Parse(messageTemplate);
             var binder = new PropertyBinder(
-                new PropertyValueConverter(10, 1000, 1000, Enumerable.Empty<Type>(), Enumerable.Empty<IDestructuringPolicy>(), false));
+                new PropertyValueConverter(10, 1000, 1000, Enumerable.Empty<Type>(), Enumerable.Empty<IDestructuringPolicy>(), null, false));
             return binder.ConstructProperties(mt, properties).Select(p => new LogEventProperty(p.Name, p.Value));
         }
     }

--- a/test/Serilog.Tests/Core/MessageTemplateTests.cs
+++ b/test/Serilog.Tests/Core/MessageTemplateTests.cs
@@ -120,7 +120,7 @@ namespace Serilog.Tests.Core
         static string Render(IFormatProvider formatProvider, string messageTemplate, params object[] properties)
         {
             var mt = new MessageTemplateParser().Parse(messageTemplate);
-            var binder = new PropertyBinder(new PropertyValueConverter(10, 1000, 1000, Enumerable.Empty<Type>(), Enumerable.Empty<IDestructuringPolicy>(), false));
+            var binder = new PropertyBinder(new PropertyValueConverter(10, 1000, 1000, Enumerable.Empty<Type>(), Enumerable.Empty<IDestructuringPolicy>(), null, false));
             var props = binder.ConstructProperties(mt, properties);
             var output = new StringBuilder();
             var writer = new StringWriter(output);

--- a/test/Serilog.Tests/Events/LogEventPropertyValueTests.cs
+++ b/test/Serilog.Tests/Events/LogEventPropertyValueTests.cs
@@ -27,7 +27,7 @@ namespace Serilog.Tests.Events
     public class LogEventPropertyValueTests
     {
         readonly PropertyValueConverter _converter =
-            new PropertyValueConverter(10, 1000, 1000, Enumerable.Empty<Type>(), Enumerable.Empty<IDestructuringPolicy>(), false);
+            new PropertyValueConverter(10, 1000, 1000, Enumerable.Empty<Type>(), Enumerable.Empty<IDestructuringPolicy>(), null, false);
 
         [Fact]
         public void AnEnumIsConvertedToANonStringScalarValue()


### PR DESCRIPTION
**What issue does this PR address?**

New feature for filtering properties.

**Does this PR introduce a breaking change?**

No.

**Please check if the PR fulfills these requirements**
- [x] The commit follows our [guidelines](https://github.com/serilog/serilog/blob/dev/CONTRIBUTING.md)
- [x] Unit Tests for the changes have been added (for bug fixes / features)
