### PR TITLE
Reenable NuGet symbol publishing

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,7 +26,6 @@ deploy:
 - provider: NuGet
   api_key:
     secure: N59tiJECUYpip6tEn0xvdmDAEiP9SIzyLEFLpwiigm/8WhJvBNs13QxzT1/3/JW/
-  skip_symbols: true
   on:
     branch: /^(master|dev)$/
 - provider: GitHub


### PR DESCRIPTION
**What issue does this PR address?**

Symbols not published to the NuGet.org symbol server. Publishing was disabled early on due to some flakiness in the tooling (IIRC).

**Does this PR introduce a breaking change?**

No

**Please check if the PR fulfills these requirements**
- [ ] The commit follows our [guidelines](https://github.com/serilog/serilog/blob/dev/CONTRIBUTING.md)
- [ ] Unit Tests for the changes have been added (for bug fixes / features)

**Other information**:
