### PR TITLE
Structured types with associated format are not destructured but forw…

### DIFF
--- a/src/Serilog/Capturing/PropertyBinder.cs
+++ b/src/Serilog/Capturing/PropertyBinder.cs
@@ -123,7 +123,7 @@ namespace Serilog.Capturing
         {
             return new EventProperty(
                         propertyToken.PropertyName,
-                        _valueConverter.CreatePropertyValue(value, propertyToken.Destructuring));
+                        _valueConverter.CreatePropertyValue(value, propertyToken.Destructuring, propertyToken.Format));
         }
     }
 }

--- a/src/Serilog/Capturing/PropertyValueConverter.cs
+++ b/src/Serilog/Capturing/PropertyValueConverter.cs
@@ -96,7 +96,7 @@ namespace Serilog.Capturing
             return CreatePropertyValue(value, destructureObjects, 1);
         }
 
-        public LogEventPropertyValue CreatePropertyValue(object value, Destructuring destructuring, string format = "")
+        public LogEventPropertyValue CreatePropertyValue(object value, Destructuring destructuring, string format = null)
         {
             try
             {
@@ -123,7 +123,7 @@ namespace Serilog.Capturing
                 depth);
         }
 
-        LogEventPropertyValue CreatePropertyValue(object value, Destructuring destructuring, int depth, string format = "")
+        LogEventPropertyValue CreatePropertyValue(object value, Destructuring destructuring, int depth, string format = null)
         {
             if (value == null)
                 return new ScalarValue(null);
@@ -163,7 +163,7 @@ namespace Serilog.Capturing
 
             // if a non builtin scalar has a format associated, pass it to the sink -
             // considering it a scalar even if it is a structured type.
-            if (format != "")
+            if (!string.IsNullOrEmpty(format))
             {
                 return new ScalarValue(value);
             }

--- a/src/Serilog/Capturing/PropertyValueConverter.cs
+++ b/src/Serilog/Capturing/PropertyValueConverter.cs
@@ -96,7 +96,7 @@ namespace Serilog.Capturing
             return CreatePropertyValue(value, destructureObjects, 1);
         }
 
-        public LogEventPropertyValue CreatePropertyValue(object value, Destructuring destructuring, string format)
+        public LogEventPropertyValue CreatePropertyValue(object value, Destructuring destructuring, string format = "")
         {
             try
             {

--- a/src/Serilog/Capturing/PropertyValueConverter.cs
+++ b/src/Serilog/Capturing/PropertyValueConverter.cs
@@ -96,11 +96,11 @@ namespace Serilog.Capturing
             return CreatePropertyValue(value, destructureObjects, 1);
         }
 
-        public LogEventPropertyValue CreatePropertyValue(object value, Destructuring destructuring)
+        public LogEventPropertyValue CreatePropertyValue(object value, Destructuring destructuring, string format)
         {
             try
             {
-                return CreatePropertyValue(value, destructuring, 1);
+                return CreatePropertyValue(value, destructuring, 1, format);
             }
             catch (Exception ex)
             {
@@ -123,7 +123,7 @@ namespace Serilog.Capturing
                 depth);
         }
 
-        LogEventPropertyValue CreatePropertyValue(object value, Destructuring destructuring, int depth)
+        LogEventPropertyValue CreatePropertyValue(object value, Destructuring destructuring, int depth, string format = "")
         {
             if (value == null)
                 return new ScalarValue(null);
@@ -159,6 +159,13 @@ namespace Serilog.Capturing
                     if (destructuringPolicy.TryDestructure(value, _depthLimiter, out var result))
                         return result;
                 }
+            }
+
+            // if a non builtin scalar has a format associated, pass it to the sink -
+            // considering it a scalar even if it is a structured type.
+            if (format != "")
+            {
+                return new ScalarValue(value);
             }
 
             var valueType = value.GetType();

--- a/test/Serilog.Tests/Formatting/NonScalarFormatting/NonScalarFormatTest.cs
+++ b/test/Serilog.Tests/Formatting/NonScalarFormatting/NonScalarFormatTest.cs
@@ -1,0 +1,128 @@
+﻿using Serilog.Tests.Support;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace Serilog.Tests.Formatting.NonScalars
+{
+    class CustomFormatter : IFormatProvider, ICustomFormatter
+    {
+        public Dictionary<string, Func<Object, string>> Formatters { get; }
+
+        public CustomFormatter()
+        {
+            this.Formatters = new Dictionary<string, Func<object, string>>();
+        }
+
+        public object GetFormat(Type formatType)
+        {
+            return formatType == typeof(ICustomFormatter) ? this : null;
+        }
+
+        public string Format(string format, object arg, IFormatProvider formatProvider)
+        {
+            if (this.Formatters.TryGetValue(format, out var f))
+                return f(arg);
+            if (arg is IFormattable formattable)
+                return formattable.ToString(format, null);
+            return arg.ToString();
+        }
+    }
+
+    public class NonScalarFormattingTests
+    {
+        [Fact]
+        public void FormatOfScalarsScenario()
+        {
+            // example database values
+            var db = new Dictionary<int, string>
+            {
+                { 3, "kylie" },
+                { 4, "stereo mcs" },
+                { 5, "bilderbuch" }
+            };
+
+            // logger
+            var cf = new CustomFormatter();
+            cf.Formatters["id"] = id => db[(int)id];
+            var ss = new StringSink(outputTemplate: "{Message:lj}", formatProvider: cf);
+
+            ILogger l =
+                new LoggerConfiguration()
+                    .WriteTo.Sink(ss)
+                    .CreateLogger();
+
+            l.Information("artist: {value:id}", 4); // this works with Serilog 2.9
+
+            Assert.Equal("artist: stereo mcs", ss.ToString());
+        }
+
+        [Fact]
+        public void FormatOfNonScalarsScenario()
+        {
+            // example database values
+            var db = new Dictionary<int, string>
+            {
+                { 3, "kylie" },
+                { 4, "stereo mcs" },
+                { 5, "bilderbuch" }
+            };
+
+            // logger
+            var cf = new CustomFormatter();
+            cf.Formatters["id"] = id => db[(int)id];
+            cf.Formatters["ids"] = ids => string.Join(", ", ((int[])ids).Select(id => db[id]));
+            var ss = new StringSink(outputTemplate: "{Message:lj}", formatProvider: cf);
+
+            ILogger l =
+                new LoggerConfiguration()
+                    .WriteTo.Sink(ss)
+                    .CreateLogger();
+
+            l.Information("artists: {values:ids}", new[] { 3, 4, 5 }); // this requires that the format is passed for nonscalars
+
+            // logger writes resolved strings
+            Assert.Equal("artists: kylie, stereo mcs, bilderbuch", ss.ToString());
+        }
+
+        class FormatCollector : IFormatProvider, ICustomFormatter
+        {
+            public List<string> Formats { get; }
+
+            public FormatCollector()
+            {
+                this.Formats = new List<string>();
+            }
+
+            public object GetFormat(Type formatType)
+            {
+                return formatType == typeof(ICustomFormatter) ? this : null;
+            }
+
+            public string Format(string format, object arg, IFormatProvider formatProvider)
+            {
+                this.Formats.Add(format); // collect formats
+                return arg.ToString(); // value not evaluated here
+            }
+        }
+
+        [Fact]
+        public void FormatOfNonScalarsArePassed()
+        {
+            var fc = new FormatCollector();
+            var ss = new StringSink(outputTemplate: "{Message:lj}", formatProvider: fc);
+
+            ILogger l =
+                new LoggerConfiguration()
+                    .WriteTo.Sink(ss)
+                    .CreateLogger();
+
+            l.Information("artist: {value:id}", 4); // this works with Serilog 2.9
+            l.Information("artists: {values:ids}", new[] { 3, 4, 5 }); // this requires passing format for nonscalars
+
+            // logger writes resolved strings
+            Assert.Equal(fc.Formats.ToArray(), new[] { "id", "ids" });
+        }
+    }
+}

--- a/test/Serilog.Tests/Support/StringSink.cs
+++ b/test/Serilog.Tests/Support/StringSink.cs
@@ -1,4 +1,5 @@
-﻿using System.Globalization;
+﻿using System;
+using System.Globalization;
 using System.IO;
 using Serilog.Core;
 using Serilog.Events;
@@ -14,9 +15,9 @@ namespace Serilog.Tests.Support
 
         const string DefaultOutputTemplate = "{Timestamp:yyyy-MM-dd HH:mm:ss.fff zzz} [{Level}] {Message}{NewLine}{Exception}";
 
-        public StringSink(string outputTemplate = DefaultOutputTemplate)
+        public StringSink(string outputTemplate = DefaultOutputTemplate, IFormatProvider formatProvider = null)
         {
-            _formatter = new MessageTemplateTextFormatter(outputTemplate, CultureInfo.InvariantCulture);
+            _formatter = new MessageTemplateTextFormatter(outputTemplate, formatProvider ?? CultureInfo.InvariantCulture);
         }
 
         public void Emit(LogEvent logEvent)


### PR DESCRIPTION
…arded to the sink.

Structured logging in Serilog allows passing the properties of structured values as separate scalars to sinks, so that log-stores can provide searches for the values of those scalar property values.

### Using Serilog to resolve object-ids at the logging stage
I tried to use the logging pipeline for a different purpose. Many systems process objects by their id, person-ids and so on. Often, reading logs that hold those ids only is cumbersome. Replacing the ids with names can be done with passing down resolver functions like so:

    getuserprofile (int personid, diagnosticgetusername)
        ... log(  ... diagnosticgetusername(personid) ... )

passing around diagnostic resolver functions in that way clutters the apis, adding complexity to the code.

Serilog greatly helps here. First I tried to use custom Destructurers like so:

   ... log("   {@personid} ", new PersonId( 42) ...

but this requires wrapping the scalar value and adding the @ symbol. Finally I realised that a custom formatter is more appropriate. The design I cam up with is the register resolver functions for format-names, so I can do:

     ... log("   {person:id} ", 42 ...  // format "id" relates to a resolver function configured below

CustomFormatter.Formatters["id"] = id => getname(id) // register resolver in the logger configuration

### Respecting a format specifier for non scalars - preventing destructuring
So far that works with the current Serilog version. I also have collections of ids and would like to format them in a similar way:

    ... log("   {persons:ids}  ", persons ) // where persons: int[]

At this point, the current destructure logic of Serilog interferes: The property is destructured and the format is ignored. To get around this I propose this pull request. A unit test describes the scenario of such logger-stage resolver functions and how they work with collections and arbitrary objects. The code changes should speak for themselves.

I tried to make the least possible changes and in the sense of the current code base.

### No API or relevant behavior change
Structured objects without format specifier (which would be ignored in the current version, so its highly unlikely that anyone assigned such) are destructured as before. No API changes.

related issue: #1409 