### PR TITLE
update Overrides during runtime fixes #1413

### DIFF
--- a/src/Serilog/Configuration/LoggerSinkConfiguration.cs
+++ b/src/Serilog/Configuration/LoggerSinkConfiguration.cs
@@ -131,7 +131,7 @@ namespace Serilog.Configuration
             configureLogger(lc);
 
             var subLogger = lc.CreateLogger();
-            if (subLogger.HasOverrideMap)
+            if (subLogger.HasAnyOverrides)
             {
                 SelfLog.WriteLine("Minimum level overrides are not supported on sub-loggers " +
                                   "and may be removed completely in a future version.");
@@ -158,7 +158,7 @@ namespace Serilog.Configuration
         {
             if (logger == null) throw new ArgumentNullException(nameof(logger));
 
-            if (logger is Logger concreteLogger && concreteLogger.HasOverrideMap)
+            if (logger is Logger concreteLogger && concreteLogger.HasAnyOverrides)
             {
                 SelfLog.WriteLine("Minimum level overrides are not supported on sub-loggers " +
                                   "and may be removed completely in a future version.");

--- a/src/Serilog/Core/Enrichers/SourceContextEnricher.cs
+++ b/src/Serilog/Core/Enrichers/SourceContextEnricher.cs
@@ -1,0 +1,38 @@
+﻿// Copyright 2013-2015 Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using Serilog.Events;
+
+namespace Serilog.Core.Enrichers
+{
+    class SourceContextEnricher : ILogEventEnricher
+    {
+        public string Context { get; }
+
+        readonly EventProperty _eventProperty;
+
+        public SourceContextEnricher(string context)
+        {
+            Context = context;
+            _eventProperty = new EventProperty(Constants.SourceContextPropertyName, new ScalarValue(context));
+        }
+
+        public void Enrich(LogEvent logEvent, ILogEventPropertyFactory propertyFactory)
+        {
+            if (logEvent == null) throw new ArgumentNullException(nameof(logEvent));
+            logEvent.AddPropertyIfAbsent(_eventProperty);
+        }
+    }
+}

--- a/test/Serilog.Tests/Core/LoggerTests.cs
+++ b/test/Serilog.Tests/Core/LoggerTests.cs
@@ -140,5 +140,30 @@ namespace Serilog.Tests.Core
                 Assert.Same(Log.Logger, Logger.None);
             }
         }
+
+
+
+        [Fact]
+        public void AddingAnOverridingUpdatesTheLogLevel()
+        {
+            var rootLogger = new LoggerConfiguration()
+                .MinimumLevel.Warning()
+                .CreateLogger();
+
+
+            var contextLogger = (Logger)rootLogger.ForContext<LoggerTests>();
+
+            Assert.False(rootLogger.IsEnabled(LogEventLevel.Verbose));
+            Assert.False(contextLogger.IsEnabled(LogEventLevel.Verbose));
+
+            var loggerSwitch = contextLogger.GetOrAddOverride(typeof(LoggerTests).FullName);
+            Assert.Equal(LogEventLevel.Warning, loggerSwitch.MinimumLevel);
+
+            loggerSwitch.MinimumLevel = LogEventLevel.Verbose;
+
+
+            Assert.False(rootLogger.IsEnabled(LogEventLevel.Verbose));
+            Assert.True(contextLogger.IsEnabled(LogEventLevel.Verbose));
+        }
     }
 }

--- a/test/Serilog.Tests/LoggerConfigurationTests.cs
+++ b/test/Serilog.Tests/LoggerConfigurationTests.cs
@@ -41,12 +41,12 @@ namespace Serilog.Tests
                 return (new WeakReference(loggerConfiguration), logger);
             }
 
-            var (wr, logger) = UseLoggerConfiguration();
+            var (wr, outerLogger) = UseLoggerConfiguration();
 
             GC.Collect();
 
             Assert.False(wr.IsAlive);
-            GC.KeepAlive(logger);
+            GC.KeepAlive(outerLogger);
         }
 
         [Fact]

--- a/test/Serilog.Tests/LoggerConfigurationTests.cs
+++ b/test/Serilog.Tests/LoggerConfigurationTests.cs
@@ -48,7 +48,7 @@ namespace Serilog.Tests
             Assert.False(wr.IsAlive);
             GC.KeepAlive(logger);
         }
-        
+
         [Fact]
         public void CreateLoggerThrowsIfCalledMoreThanOnce()
         {

--- a/test/Serilog.Tests/LoggerConfigurationTests.cs
+++ b/test/Serilog.Tests/LoggerConfigurationTests.cs
@@ -34,16 +34,21 @@ namespace Serilog.Tests
         [Fact]
         public void LoggerShouldNotReferenceToItsConfigurationAfterBeingCreated()
         {
-            var loggerConfiguration = new LoggerConfiguration();
-            var wr = new WeakReference(loggerConfiguration);
-            var logger = loggerConfiguration.CreateLogger();
+            (WeakReference, Logger) UseLoggerConfiguration()
+            {
+                var loggerConfiguration = new LoggerConfiguration();
+                var logger = loggerConfiguration.CreateLogger();
+                return (new WeakReference(loggerConfiguration), logger);
+            }
+
+            var (wr, logger) = UseLoggerConfiguration();
 
             GC.Collect();
 
             Assert.False(wr.IsAlive);
             GC.KeepAlive(logger);
         }
-
+        
         [Fact]
         public void CreateLoggerThrowsIfCalledMoreThanOnce()
         {


### PR DESCRIPTION
this pr is an attempt to fix #1413

**Does this PR introduce a breaking change?**
I hope not. I did not add the method to the ILogger Interface just to the default implementation.
this may be debateable?!


- [x] The commit follows our [guidelines]
- [x] Unit Tests for the changes have been added (for bug fixes / features)

**Other information**:

- I had to update one test that was failing. 
   LoggerShouldNotReferenceToItsConfigurationAfterBeingCreated

   I think I did not break it in the first place as it was just the local method that kept a reference to the configuration object.

- I created a new class to be able to retrieve the context for subloggers. I copied over the license header from another file. Im not sure if you should update the year in all the headers? 
