### PR TITLE
Record stringified property as `null` when `ToString()` returns `null`

### DIFF
--- a/src/Serilog/Capturing/PropertyValueConverter.cs
+++ b/src/Serilog/Capturing/PropertyValueConverter.cs
@@ -299,7 +299,7 @@ namespace Serilog.Capturing
         LogEventPropertyValue Stringify(object value)
         {
             var stringified = value.ToString();
-            var truncated = TruncateIfNecessary(stringified);
+            var truncated = stringified == null ? null : TruncateIfNecessary(stringified);
             return new ScalarValue(truncated);
         }
 

--- a/test/Serilog.Tests/Core/MessageTemplateTests.cs
+++ b/test/Serilog.Tests/Core/MessageTemplateTests.cs
@@ -30,6 +30,15 @@ namespace Serilog.Tests.Core
             public override string ToString() => "a receipt";
         }
 
+        class ABadBehavior
+        {
+            public override string ToString() => null;
+        }
+        class ABug
+        {
+            public override string ToString() => throw new ArgumentNullException("","A possible a Bug in a class");
+        }
+
         [Fact]
         public void AnObjectIsRenderedInSimpleNotation()
         {
@@ -63,6 +72,12 @@ namespace Serilog.Tests.Core
         {
             var m = Render("I sat at {Chair}", new Chair());
             Assert.Equal("I sat at \"a chair\"", m);
+
+            var m2 = Render("I sat at {Obj}", new ABadBehavior());
+            Assert.Equal("I sat at null", m2);
+
+            var m3 = Render("I sat at {Obj}", new ABug());
+            Assert.Equal("I sat at \"Capturing the property value threw an exception: ArgumentNullException\"", m3);
         }
 
         [Fact]
@@ -70,6 +85,12 @@ namespace Serilog.Tests.Core
         {
             var m = Render("I sat at {$Chair}", new Chair());
             Assert.Equal("I sat at \"a chair\"", m);
+
+            var m2 = Render("I sat at {$Obj}", new ABadBehavior());
+            Assert.Equal("I sat at null", m2);
+
+            var m3 = Render("I sat at {$Obj}", new ABug());
+            Assert.Equal("I sat at \"Capturing the property value threw an exception: ArgumentNullException\"", m3);
         }
 
         [Fact]


### PR DESCRIPTION
**What issue does this PR address?**
This will fix the issue #1426 - A bad designed Class can cause an Exception when logging with stringification operator.

**Does this PR introduce a breaking change?**
No

**Please check if the PR fulfills these requirements**
- [ x ] The commit follows our [guidelines](https://github.com/serilog/serilog/blob/dev/CONTRIBUTING.md)
- [ x ] Unit Tests for the changes have been added (for bug fixes / features)
