### PR TITLE
Use formatting string for custom formattable

### DIFF
--- a/src/Serilog/Capturing/PropertyValueConverter.cs
+++ b/src/Serilog/Capturing/PropertyValueConverter.cs
@@ -172,6 +172,9 @@ namespace Serilog.Capturing
             if (TryConvertCompilerGeneratedType(value, destructuring, valueType, out var compilerGeneratedResult))
                 return compilerGeneratedResult;
 
+            if (value is IFormattable)
+                return new ScalarValue(value);
+
             return new ScalarValue(value.ToString());
         }
 

--- a/test/Serilog.Tests/Core/MessageTemplateTests.cs
+++ b/test/Serilog.Tests/Core/MessageTemplateTests.cs
@@ -114,6 +114,22 @@ namespace Serilog.Tests.Core
             Assert.Equal("Welcome, customer 0012", m);
         }
 
+        class CustomFormattable : IFormattable
+        {
+            public override string ToString() => "No format used";
+
+            public string ToString(string format) => ToString(format, null);
+
+            public string ToString(string format, IFormatProvider provider) => $"Format string {format} used";
+        }
+
+        [Fact]
+        public void FormatStringsArePropagatedForCustomIFormattable()
+        {
+            var m = Render("{Formatted:F}", new CustomFormattable());
+            Assert.Equal("Format string F used", m);
+        }
+
         [Theory]
         [InlineData("Welcome, customer #{CustomerId,-10}, pleasure to see you", "Welcome, customer #1234      , pleasure to see you")]
         [InlineData("Welcome, customer #{CustomerId,-10:000000}, pleasure to see you", "Welcome, customer #001234    , pleasure to see you")]


### PR DESCRIPTION
**What issue does this PR address?**
#1396

**Does this PR introduce a breaking change?**
No.

**Please check if the PR fulfills these requirements**
- [x] The commit follows our [guidelines](https://github.com/serilog/serilog/blob/dev/CONTRIBUTING.md)
- [x] Unit Tests for the changes have been added (for bug fixes / features)

**Other information:**
This is my first PR to Serilog and I don't have much experience with the more complex parts of the library, so I hope this doesn't break anything.

It looked like the issue appeared in the last line of `PropertyValueConverter.CreatePropertyValue` where `new ScalarValue(value.ToString())` was used as a fallback. By calling `ToString()` and thus converting to a string the custom formatting capabilities are lost. Therefore I added a special case for `IFormattable` just before the `ToString()` call. The reason for putting it last was to not interfere with any destructuring.

It is arguable whether a custom implementation of `IFormattable` could be considered "scalar" as the type can potentially be very complex. The current behavior of `ScalarValue` worked as requested though, so I decided to use it. An alternative approach could be to do something like `FormattableValue` to make the naming a bit more fitting for complex custom `IFormattable` implementations.

**Changes:**
- The `PropertyValueConverter` now returns a `ScalarValue` without modification for `IFormattable` objects