### PR TITLE
Improvements/time provider

### DIFF
--- a/src/Serilog/Configuration/LoggerTimeProviderConfiguration.cs
+++ b/src/Serilog/Configuration/LoggerTimeProviderConfiguration.cs
@@ -1,0 +1,31 @@
+﻿using System;
+
+namespace Serilog.Configuration
+{
+    /// <summary>
+    /// Controls sink configuration.
+    /// </summary>
+    public class LoggerTimeProviderConfiguration
+    {
+        readonly LoggerConfiguration _loggerConfiguration;
+        readonly Action<Func<DateTimeOffset>> _setTimeProvider;
+
+        internal LoggerTimeProviderConfiguration(LoggerConfiguration loggerConfiguration, Action<Func<DateTimeOffset>> setLevelSwitch)
+        {
+            _loggerConfiguration = loggerConfiguration ?? throw new ArgumentNullException(nameof(loggerConfiguration));
+            _setTimeProvider = setLevelSwitch;
+        }
+
+        /// <summary>
+        /// Sets the time provider.
+        /// </summary>
+        /// <param name="timeProvider">The time provider.</param>
+        /// <returns>Configuration object allowing method chaining.</returns>
+        public LoggerConfiguration SetTo(Func<DateTimeOffset> timeProvider)
+        {
+            if (timeProvider == null) throw new ArgumentNullException(nameof(timeProvider));
+            _setTimeProvider(timeProvider);
+            return _loggerConfiguration;
+        }
+    }
+}

--- a/src/Serilog/Configuration/LoggerTimeProviderConfiguration.cs
+++ b/src/Serilog/Configuration/LoggerTimeProviderConfiguration.cs
@@ -3,7 +3,7 @@
 namespace Serilog.Configuration
 {
     /// <summary>
-    /// Controls sink configuration.
+    /// Controls time provider configuration.
     /// </summary>
     public class LoggerTimeProviderConfiguration
     {
@@ -17,7 +17,7 @@ namespace Serilog.Configuration
         }
 
         /// <summary>
-        /// Sets the time provider.
+        /// Sets the time provider, which will be used for creating the time stamps of the log events.
         /// </summary>
         /// <param name="timeProvider">The time provider.</param>
         /// <returns>Configuration object allowing method chaining.</returns>

--- a/src/Serilog/LoggerConfiguration.cs
+++ b/src/Serilog/LoggerConfiguration.cs
@@ -42,6 +42,7 @@ namespace Serilog
         int _maximumStringLength = int.MaxValue;
         int _maximumCollectionCount = int.MaxValue;
         bool _loggerCreated;
+        Func<DateTimeOffset> _timeProvider;
 
         /// <summary>
         /// Construct a <see cref="LoggerConfiguration"/>.
@@ -96,6 +97,20 @@ namespace Serilog
                     },
                     sw => _levelSwitch = sw,
                     (s, lls) => _overrides[s] = lls);
+            }
+        }
+
+        /// <summary>
+        /// Configures the time provider for the log events.
+        /// If not specified, a default time provider is used.
+        /// </summary>
+        /// <returns>Configuration object allowing method chaining.</returns>
+        public LoggerTimeProviderConfiguration TimeProvider
+        {
+            get
+            {
+                return new LoggerTimeProviderConfiguration(this,
+                    timeProvider => _timeProvider = timeProvider);
             }
         }
 
@@ -200,8 +215,8 @@ namespace Serilog
             }
 
             return _levelSwitch == null ?
-                new Logger(processor, _minimumLevel, sink, enricher, Dispose, overrideMap) :
-                new Logger(processor, _levelSwitch, sink, enricher, Dispose, overrideMap);
+                new Logger(processor, _minimumLevel, sink, enricher, _timeProvider, Dispose, overrideMap) :
+                new Logger(processor, _levelSwitch, sink, enricher, _timeProvider, Dispose, overrideMap);
         }
     }
 }

--- a/test/Serilog.Tests/Core/LoggerTests.cs
+++ b/test/Serilog.Tests/Core/LoggerTests.cs
@@ -237,7 +237,7 @@ namespace Serilog.Tests.Core
             Assert.Equal(now.Date, eventTimestamp.Date);
             Assert.Equal(now.Hour, eventTimestamp.Hour);
             Assert.Equal(now.Minute, eventTimestamp.Minute);
-            // seconds are not checked intenionally to avoid instability.
+            // seconds are not checked intentionally to avoid instability.
         }
 
         [Fact]


### PR DESCRIPTION
**What issue does this PR address?**
This PR implements https://github.com/serilog/serilog/issues/1398. Therefor I added a feature for optionally providing a time provider via the fluent api. This allows the user to specify e.g. a high precision time provider of his/hers choice. Example:
```
new LoggerConfiguration()
    .TimeProvider.SetTo(() =>
    {
        return // DateTimeOffset
    })....
```

**Does this PR introduce a breaking change?**
No

**Please check if the PR fulfills these requirements**
- [x] The commit follows our [guidelines](https://github.com/serilog/serilog/blob/dev/CONTRIBUTING.md)
- [x] Unit Tests for the changes have been added (for bug fixes / features)

**Other information**
* The test `IfNoTimeProviderIsSpecifiedTheDefaultIsUsed()` checks, that the existing behavior (without specifying an explicit time provider) still works as expected.
* The test `ASpecifiedTimeProviderMustBeUsed` checks, that a specified time provider actually replaces the default time provider.