### PR TITLE
Source context matching optimize

### DIFF
--- a/results/netcoreapp3.1/SourceContextMatchBenchmark-report-github.md
+++ b/results/netcoreapp3.1/SourceContextMatchBenchmark-report-github.md
@@ -1,0 +1,50 @@
+# Benchmark results
+
+## Linux
+
+``` ini
+
+BenchmarkDotNet=v0.12.0, OS=debian 11
+Intel Core i7-3840QM CPU 2.80GHz (Ivy Bridge), 1 CPU, 4 logical and 2 physical cores
+.NET Core SDK=3.1.201
+  [Host]     : .NET Core 3.1.3 (CoreCLR 4.700.20.11803, CoreFX 4.700.20.12001), X64 RyuJIT
+  Job-CSERBI : .NET Core 2.1.16 (CoreCLR 4.6.28516.03, CoreFX 4.6.28516.10), X64 RyuJIT
+  Job-GDNCBZ : .NET Core 3.1.3 (CoreCLR 4.700.20.11803, CoreFX 4.700.20.12001), X64 RyuJIT
+
+
+```
+|                             Method |       Runtime |       Mean |    Error |   StdDev | Ratio |
+|----------------------------------- |-------------- |-----------:|---------:|---------:|------:|
+|          Filter_MatchingFromSource | .NET Core 2.1 | 5,799.5 ns | 51.17 ns | 45.36 ns |  1.00 |
+|          Filter_MatchingFromSource | .NET Core 3.1 | 3,564.5 ns | 37.43 ns | 35.01 ns |  0.61 |
+|                                    |               |            |          |          |       |
+|                  Logger_ForContext | .NET Core 2.1 | 2,519.0 ns | 15.37 ns | 13.62 ns |  1.00 |
+|                  Logger_ForContext | .NET Core 3.1 |   961.8 ns |  4.67 ns |  4.36 ns |  0.38 |
+|                                    |               |            |          |          |       |
+| LevelOverrideMap_GetEffectiveLevel | .NET Core 2.1 | 1,745.7 ns | 11.95 ns | 10.60 ns |  1.00 |
+| LevelOverrideMap_GetEffectiveLevel | .NET Core 3.1 |   193.8 ns |  2.35 ns |  2.20 ns |  0.11 |
+
+## Windows
+
+``` ini
+
+BenchmarkDotNet=v0.12.0, OS=Windows 10.0.19041
+Intel Core i7-3840QM CPU 2.80GHz (Ivy Bridge), 1 CPU, 8 logical and 4 physical cores
+.NET Core SDK=3.1.300
+  [Host]     : .NET Core 3.1.4 (CoreCLR 4.700.20.20201, CoreFX 4.700.20.22101), X64 RyuJIT
+  Job-KEWXME : .NET Core 2.1.16 (CoreCLR 4.6.28516.03, CoreFX 4.6.28516.10), X64 RyuJIT
+  Job-KKEVOV : .NET Core 3.1.4 (CoreCLR 4.700.20.20201, CoreFX 4.700.20.22101), X64 RyuJIT
+
+
+```
+|                             Method |       Runtime |       Mean |     Error |    StdDev | Ratio |
+|----------------------------------- |-------------- |-----------:|----------:|----------:|------:|
+|          Filter_MatchingFromSource | .NET Core 2.1 | 8,088.7 ns | 120.48 ns | 112.70 ns |  1.00 |
+|          Filter_MatchingFromSource | .NET Core 3.1 | 3,369.0 ns |  71.49 ns |  73.42 ns |  0.42 |
+|                                    |               |            |           |           |       |
+|                  Logger_ForContext | .NET Core 2.1 | 6,322.1 ns |  98.18 ns |  91.84 ns |  1.00 |
+|                  Logger_ForContext | .NET Core 3.1 |   785.6 ns |   9.05 ns |   8.47 ns |  0.12 |
+|                                    |               |            |           |           |       |
+| LevelOverrideMap_GetEffectiveLevel | .NET Core 2.1 | 5,619.1 ns |  20.98 ns |  18.60 ns |  1.00 |
+| LevelOverrideMap_GetEffectiveLevel | .NET Core 3.1 |   185.4 ns |   1.63 ns |   1.44 ns |  0.03 |
+

--- a/run_perf_tests.sh
+++ b/run_perf_tests.sh
@@ -2,5 +2,6 @@
 dotnet restore
 
 for path in test/*.PerformanceTests/*.csproj; do
+    dotnet test -f netcoreapp2.1 -c Release ${path}
     dotnet test -f netcoreapp3.1 -c Release ${path}
 done

--- a/src/Serilog/Core/LevelOverrideMap.cs
+++ b/src/Serilog/Core/LevelOverrideMap.cs
@@ -1,4 +1,4 @@
-// Copyright 2016 Serilog Contributors
+// Copyright 2016-2020 Serilog Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Serilog/Core/LevelOverrideMap.cs
+++ b/src/Serilog/Core/LevelOverrideMap.cs
@@ -29,13 +29,10 @@ namespace Serilog.Core
             public LevelOverride(string context, LoggingLevelSwitch levelSwitch)
             {
                 Context = context;
-                ContextPrefix = context + ".";
                 LevelSwitch = levelSwitch;
             }
 
             public string Context { get; }
-
-            public string ContextPrefix { get; }
 
             public LoggingLevelSwitch LevelSwitch { get; }
         }
@@ -65,11 +62,19 @@ namespace Serilog.Core
                 .ToArray();
         }
 
-        public void GetEffectiveLevel(string context, out LogEventLevel minimumLevel, out LoggingLevelSwitch levelSwitch)
+        public void GetEffectiveLevel(
+#if FEATURE_SPAN
+            ReadOnlySpan<char> context,
+#else
+            string context,
+#endif
+            out LogEventLevel minimumLevel,
+            out LoggingLevelSwitch levelSwitch)
         {
             foreach (var levelOverride in _overrides)
             {
-                if (context.StartsWith(levelOverride.ContextPrefix) || context == levelOverride.Context)
+                if (context.StartsWith(levelOverride.Context) &&
+                   (context.Length == levelOverride.Context.Length || context[levelOverride.Context.Length] == '.'))
                 {
                     minimumLevel = LevelAlias.Minimum;
                     levelSwitch = levelOverride.LevelSwitch;

--- a/src/Serilog/Filters/Matching.cs
+++ b/src/Serilog/Filters/Matching.cs
@@ -1,4 +1,4 @@
-// Copyright 2013-2015 Serilog Contributors
+// Copyright 2013-2020 Serilog Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Serilog/Filters/Matching.cs
+++ b/src/Serilog/Filters/Matching.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2013-2015 Serilog Contributors
+// Copyright 2013-2015 Serilog Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -44,8 +44,13 @@ namespace Serilog.Filters
         {
             if (source == null) throw new ArgumentNullException(nameof(source));
 
-            var sourcePrefix = source + ".";
-            return WithProperty<string>(Constants.SourceContextPropertyName, s => s != null && (s == source || s.StartsWith(sourcePrefix)));
+            return WithProperty<string>(
+                Constants.SourceContextPropertyName,
+                s => s != null && s
+#if FEATURE_SPAN
+                  .AsSpan()
+#endif
+                  .StartsWith(source) && (s.Length == source.Length || s[source.Length] == '.'));
         }
 
         /// <summary>

--- a/src/Serilog/Serilog.csproj
+++ b/src/Serilog/Serilog.csproj
@@ -38,7 +38,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.1' ">
-    <DefineConstants>$(DefineConstants);ASYNCLOCAL;HASHTABLE;FEATURE_DEFAULT_INTERFACE</DefineConstants>
+    <DefineConstants>$(DefineConstants);ASYNCLOCAL;HASHTABLE;FEATURE_DEFAULT_INTERFACE;FEATURE_SPAN</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">

--- a/test/Serilog.PerformanceTests/Harness.cs
+++ b/test/Serilog.PerformanceTests/Harness.cs
@@ -1,4 +1,4 @@
-// Copyright 2013-2017 Serilog Contributors
+// Copyright 2013-2020 Serilog Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/test/Serilog.PerformanceTests/Harness.cs
+++ b/test/Serilog.PerformanceTests/Harness.cs
@@ -26,6 +26,12 @@ namespace Serilog.PerformanceTests
     public class Harness
     {
         [Fact]
+        public void SourceContextMatch()
+        {
+            BenchmarkRunner.Run<SourceContextMatchBenchmark>();
+        }
+
+        [Fact]
         public void Allocations()
         {
             BenchmarkRunner.Run<AllocationsBenchmark>();
@@ -79,7 +85,7 @@ namespace Serilog.PerformanceTests
         {
             BenchmarkRunner.Run<OutputTemplateRenderingBenchmark>();
         }
-        
+
         [Fact]
         public void MessageTemplateRendering()
         {

--- a/test/Serilog.PerformanceTests/Serilog.PerformanceTests.csproj
+++ b/test/Serilog.PerformanceTests/Serilog.PerformanceTests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net48</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;netcoreapp2.1;net48</TargetFrameworks>
     <AssemblyName>Serilog.PerformanceTests</AssemblyName>
     <AssemblyOriginatorKeyFile>../../assets/Serilog.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>

--- a/test/Serilog.PerformanceTests/SourceContextMatchBenchmark.cs
+++ b/test/Serilog.PerformanceTests/SourceContextMatchBenchmark.cs
@@ -1,0 +1,95 @@
+using System.Collections.Generic;
+
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Jobs;
+
+using Serilog.Core;
+using Serilog.Events;
+using Serilog.Filters;
+using Serilog.PerformanceTests.Support;
+
+namespace Serilog.PerformanceTests
+{
+    [SimpleJob(RuntimeMoniker.NetCoreApp21, baseline: true)]
+    [SimpleJob(RuntimeMoniker.NetCoreApp31)]
+    public class SourceContextMatchBenchmark
+    {
+        readonly LevelOverrideMap _levelOverrideMap;
+        readonly Logger _loggerWithOverrides;
+        readonly List<ILogger> _loggersWithFilters = new List<ILogger>();
+        readonly LogEvent _event = Some.InformationEvent();
+        readonly string[] _contexts;
+
+        public SourceContextMatchBenchmark()
+        {
+            _contexts = new[]
+            {
+                "Serilog",
+                "MyApp",
+                "MyAppSomething",
+                "MyOtherApp",
+                "MyApp.Something",
+                "MyApp.Api.Models.Person",
+                "MyApp.Api.Controllers.AboutController",
+                "MyApp.Api.Controllers.HomeController",
+                "Api.Controllers.HomeController"
+            };
+
+            var overrides = new Dictionary<string, LoggingLevelSwitch>
+            {
+                ["MyApp"] = new LoggingLevelSwitch(LogEventLevel.Debug),
+                ["MyApp.Api.Controllers"] = new LoggingLevelSwitch(LogEventLevel.Information),
+                ["MyApp.Api.Controllers.HomeController"] = new LoggingLevelSwitch(LogEventLevel.Warning),
+                ["MyApp.Api"] = new LoggingLevelSwitch(LogEventLevel.Error)
+            };
+
+            _levelOverrideMap = new LevelOverrideMap(overrides, LogEventLevel.Fatal, null);
+
+            var loggerConfiguration = new LoggerConfiguration().MinimumLevel.Fatal();
+
+            foreach (var @override in overrides)
+            {
+                loggerConfiguration = loggerConfiguration.MinimumLevel.Override(@override.Key, @override.Value);
+
+                foreach (var ctx in _contexts)
+                {
+                    _loggersWithFilters.Add(
+                        new LoggerConfiguration().MinimumLevel.Verbose()
+                            .Filter.ByIncludingOnly(Matching.FromSource(@override.Key))
+                            .WriteTo.Sink<NullSink>()
+                            .CreateLogger()
+                            .ForContext(Constants.SourceContextPropertyName, ctx));
+                }
+            }
+
+            _loggerWithOverrides = loggerConfiguration.WriteTo.Sink<NullSink>().CreateLogger();
+        }
+
+        [Benchmark]
+        public void Filter_MatchingFromSource()
+        {
+            for (var i = 0; i < _loggersWithFilters.Count; ++i)
+            {
+                _loggersWithFilters[i].Write(_event);
+            }
+        }
+
+        [Benchmark]
+        public void Logger_ForContext()
+        {
+            for (var i = 0; i < _contexts.Length; ++i)
+            {
+                _loggerWithOverrides.ForContext(Constants.SourceContextPropertyName, _contexts[i]);
+            }
+        }
+
+        [Benchmark]
+        public void LevelOverrideMap_GetEffectiveLevel()
+        {
+            for (var i = 0; i < _contexts.Length; ++i)
+            {
+                _levelOverrideMap.GetEffectiveLevel(_contexts[i], out _, out _);
+            }
+        }
+    }
+}

--- a/test/Serilog.Tests/Filters/MatchingTests.cs
+++ b/test/Serilog.Tests/Filters/MatchingTests.cs
@@ -1,4 +1,4 @@
-﻿using Serilog.Filters;
+using Serilog.Filters;
 using Serilog.Tests.Support;
 using Xunit;
 
@@ -52,6 +52,20 @@ namespace Serilog.Tests.Filters
 
             log.Write(Some.InformationEvent());
             Assert.False(written);
+        }
+
+        [Fact]
+        public void SourceFiltersSkipNonNamespaces()
+        {
+            var written = false;
+            var log = new LoggerConfiguration()
+                .Filter.ByExcluding(Matching.FromSource("Serilog.Tests"))
+                .WriteTo.Sink(new DelegatingSink(e => written = true))
+                .CreateLogger()
+                .ForContext(Serilog.Core.Constants.SourceContextPropertyName, "Serilog.TestsLong");
+
+            log.Write(Some.InformationEvent());
+            Assert.True(written);
         }
     }
 }


### PR DESCRIPTION
**What issue does this PR address?**
Optimization made on source context matching (`LevelOverrideMap`, `Match.FromSource()`) for `netstandard2.1`.

**Does this PR introduce a breaking change?**
No

**Please check if the PR fulfills these requirements**
- [x] The commit follows our [guidelines](https://github.com/serilog/serilog/blob/dev/CONTRIBUTING.md)
- [x] Unit Tests for the changes have been added (for bug fixes / features)

**Other information**
## Linux

``` ini
BenchmarkDotNet=v0.12.0, OS=debian 11
Intel Core i7-3840QM CPU 2.80GHz (Ivy Bridge), 1 CPU, 4 logical and 2 physical cores
.NET Core SDK=3.1.201
  [Host]     : .NET Core 3.1.3 (CoreCLR 4.700.20.11803, CoreFX 4.700.20.12001), X64 RyuJIT
  Job-CSERBI : .NET Core 2.1.16 (CoreCLR 4.6.28516.03, CoreFX 4.6.28516.10), X64 RyuJIT
  Job-GDNCBZ : .NET Core 3.1.3 (CoreCLR 4.700.20.11803, CoreFX 4.700.20.12001), X64 RyuJIT
```
|                             Method |       Runtime |       Mean |    Error |   StdDev | Ratio |
|----------------------------------- |-------------- |-----------:|---------:|---------:|------:|
|          Filter_MatchingFromSource | .NET Core 2.1 | 5,799.5 ns | 51.17 ns | 45.36 ns |  1.00 |
|          Filter_MatchingFromSource | .NET Core 3.1 | 3,564.5 ns | 37.43 ns | 35.01 ns |  0.61 |
|                                    |               |            |          |          |       |
|                  Logger_ForContext | .NET Core 2.1 | 2,519.0 ns | 15.37 ns | 13.62 ns |  1.00 |
|                  Logger_ForContext | .NET Core 3.1 |   961.8 ns |  4.67 ns |  4.36 ns |  0.38 |
|                                    |               |            |          |          |       |
| LevelOverrideMap_GetEffectiveLevel | .NET Core 2.1 | 1,745.7 ns | 11.95 ns | 10.60 ns |  1.00 |
| LevelOverrideMap_GetEffectiveLevel | .NET Core 3.1 |   193.8 ns |  2.35 ns |  2.20 ns |  0.11 |

## Windows

``` ini
BenchmarkDotNet=v0.12.0, OS=Windows 10.0.19041
Intel Core i7-3840QM CPU 2.80GHz (Ivy Bridge), 1 CPU, 8 logical and 4 physical cores
.NET Core SDK=3.1.300
  [Host]     : .NET Core 3.1.4 (CoreCLR 4.700.20.20201, CoreFX 4.700.20.22101), X64 RyuJIT
  Job-KEWXME : .NET Core 2.1.16 (CoreCLR 4.6.28516.03, CoreFX 4.6.28516.10), X64 RyuJIT
  Job-KKEVOV : .NET Core 3.1.4 (CoreCLR 4.700.20.20201, CoreFX 4.700.20.22101), X64 RyuJIT
```
|                             Method |       Runtime |       Mean |     Error |    StdDev | Ratio |
|----------------------------------- |-------------- |-----------:|----------:|----------:|------:|
|          Filter_MatchingFromSource | .NET Core 2.1 | 8,088.7 ns | 120.48 ns | 112.70 ns |  1.00 |
|          Filter_MatchingFromSource | .NET Core 3.1 | 3,369.0 ns |  71.49 ns |  73.42 ns |  0.42 |
|                                    |               |            |           |           |       |
|                  Logger_ForContext | .NET Core 2.1 | 6,322.1 ns |  98.18 ns |  91.84 ns |  1.00 |
|                  Logger_ForContext | .NET Core 3.1 |   785.6 ns |   9.05 ns |   8.47 ns |  0.12 |
|                                    |               |            |           |           |       |
| LevelOverrideMap_GetEffectiveLevel | .NET Core 2.1 | 5,619.1 ns |  20.98 ns |  18.60 ns |  1.00 |
| LevelOverrideMap_GetEffectiveLevel | .NET Core 3.1 |   185.4 ns |   1.63 ns |   1.44 ns |  0.03 |