### PR TITLE
Update `LoggerSinkConfiguration.Wrap()` to use `AggregateSink` ...

### DIFF
--- a/src/Serilog/Configuration/LoggerSinkConfiguration.cs
+++ b/src/Serilog/Configuration/LoggerSinkConfiguration.cs
@@ -252,7 +252,7 @@ namespace Serilog.Configuration
 
             var enclosed = sinksToWrap.Count == 1 ?
                 sinksToWrap.Single() :
-                new SafeAggregateSink(sinksToWrap);
+                new AggregateSink(sinksToWrap);
 
             var wrappedSink = wrapSink(enclosed);
 


### PR DESCRIPTION
... to let exceptions bubble up the stack to be consistent with the behavior of wrapping a single sink

Relates to #1441