### PR TITLE
Add extension methods for lazy evaluated property values

### DIFF
--- a/src/Serilog/LoggerExtensions.cs
+++ b/src/Serilog/LoggerExtensions.cs
@@ -145,6 +145,7 @@ namespace Serilog
         /// Write a log event with the specified level and message.
         /// </summary>
         /// <param name="logger">The logger.</param>
+        /// <param name="level">The level of the event.</param>
         /// <param name="messageTemplate">Message template describing the event.</param>
         /// <param name="propertyValueAccessors">Objects positionally formatted into the message template.</param>
         public static void Write(this ILogger logger, LogEventLevel level, string messageTemplate, params Func<object>[] propertyValueAccessors)

--- a/src/Serilog/LoggerExtensions.cs
+++ b/src/Serilog/LoggerExtensions.cs
@@ -1,5 +1,6 @@
-﻿using System;
+using System;
 using Serilog.Events;
+using System.Linq;
 
 namespace Serilog
 {
@@ -8,6 +9,78 @@ namespace Serilog
     /// </summary>
     public static class LoggerExtensions
     {
+        #region Nested Types
+
+        private class LazyPropertyValue
+        {
+            #region Constructors
+
+            public LazyPropertyValue(Func<object> valueAccessor)
+            {
+                _valueAccessor = valueAccessor;
+            }
+
+            #endregion Constructors
+
+            #region Fields
+
+            private readonly Func<object> _valueAccessor;
+
+            #endregion Fields
+
+            #region Methods
+
+            #region Public Methods
+
+            public override string ToString()
+            {
+                return _valueAccessor?.Invoke()?.ToString();
+            }
+
+            #endregion Public Methods
+
+            #endregion Methods
+        }
+
+        #endregion Nested Types
+
+        #region Methods
+
+        #region Public Static Methods
+
+        /// <summary>
+        /// Write a log event with the <see cref="LogEventLevel.Debug"/> level and message.
+        /// </summary>
+        /// <param name="logger">The logger.</param>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <param name="propertyValueAccessors">Objects positionally formatted into the message template.</param>
+        public static void Debug(this ILogger logger, string messageTemplate, params Func<object>[] propertyValueAccessors)
+        {
+            logger.Debug(messageTemplate, propertyValueAccessors.Select(x => new LazyPropertyValue(x)));
+        }
+
+        /// <summary>
+        /// Write a log event with the <see cref="LogEventLevel.Error"/> level and message.
+        /// </summary>
+        /// <param name="logger">The logger.</param>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <param name="propertyValueAccessors">Objects positionally formatted into the message template.</param>
+        public static void Error(this ILogger logger, string messageTemplate, params Func<object>[] propertyValueAccessors)
+        {
+            logger.Error(messageTemplate, propertyValueAccessors.Select(x => new LazyPropertyValue(x)));
+        }
+
+        /// <summary>
+        /// Write a log event with the <see cref="LogEventLevel.Fatal"/> level and message.
+        /// </summary>
+        /// <param name="logger">The logger.</param>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <param name="propertyValueAccessors">Objects positionally formatted into the message template.</param>
+        public static void Fatal(this ILogger logger, string messageTemplate, params Func<object>[] propertyValueAccessors)
+        {
+            logger.Fatal(messageTemplate, propertyValueAccessors.Select(x => new LazyPropertyValue(x)));
+        }
+
         /// <summary>
         /// Create a logger that enriches log events when the specified level is enabled.
         /// </summary>
@@ -34,5 +107,53 @@ namespace Serilog
                 ? logger.ForContext(propertyName, value, destructureObjects)
                 : logger;
         }
+
+        /// <summary>
+        /// Write a log event with the <see cref="LogEventLevel.Information"/> level and message.
+        /// </summary>
+        /// <param name="logger">The logger.</param>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <param name="propertyValueAccessors">Objects positionally formatted into the message template.</param>
+        public static void Information(this ILogger logger, string messageTemplate, params Func<object>[] propertyValueAccessors)
+        {
+            logger.Information(messageTemplate, propertyValueAccessors.Select(x => new LazyPropertyValue(x)));
+        }
+
+        /// <summary>
+        /// Write a log event with the <see cref="LogEventLevel.Verbose"/> level and message.
+        /// </summary>
+        /// <param name="logger">The logger.</param>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <param name="propertyValueAccessors">Objects positionally formatted into the message template.</param>
+        public static void Verbose(this ILogger logger, string messageTemplate, params Func<object>[] propertyValueAccessors)
+        {
+            logger.Verbose(messageTemplate, propertyValueAccessors.Select(x => new LazyPropertyValue(x)));
+        }
+
+        /// <summary>
+        /// Write a log event with the <see cref="LogEventLevel.Warning"/> level and message.
+        /// </summary>
+        /// <param name="logger">The logger.</param>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <param name="propertyValueAccessors">Objects positionally formatted into the message template.</param>
+        public static void Warning(this ILogger logger, string messageTemplate, params Func<object>[] propertyValueAccessors)
+        {
+            logger.Warning(messageTemplate, propertyValueAccessors.Select(x => new LazyPropertyValue(x)));
+        }
+
+        /// <summary>
+        /// Write a log event with the specified level and message.
+        /// </summary>
+        /// <param name="logger">The logger.</param>
+        /// <param name="messageTemplate">Message template describing the event.</param>
+        /// <param name="propertyValueAccessors">Objects positionally formatted into the message template.</param>
+        public static void Write(this ILogger logger, LogEventLevel level, string messageTemplate, params Func<object>[] propertyValueAccessors)
+        {
+            logger.Write(level, messageTemplate, propertyValueAccessors.Select(x => new LazyPropertyValue(x)));
+        }
+
+        #endregion Public Static Methods
+
+        #endregion Methods
     }
 }

--- a/test/Serilog.Tests/Core/LoggerExtensionsTests.cs
+++ b/test/Serilog.Tests/Core/LoggerExtensionsTests.cs
@@ -1,4 +1,5 @@
-﻿using System;
+using System;
+using Serilog;
 using Serilog.Events;
 using Serilog.Tests.Support;
 using Xunit;
@@ -7,6 +8,10 @@ namespace Serilog.Tests.Core
 {
     public class LoggerExtensionsTests
     {
+        #region Methods
+
+        #region Public Methods
+
         [Theory]
         [InlineData(LogEventLevel.Debug, LogEventLevel.Debug)]
         [InlineData(LogEventLevel.Debug, LogEventLevel.Information)]
@@ -51,5 +56,177 @@ namespace Serilog.Tests.Core
 
             Assert.True(!sink.SingleEvent.Properties.ContainsKey(propKey));
         }
+
+        [Theory]
+        [InlineData(LogEventLevel.Verbose, true)]
+        [InlineData(LogEventLevel.Debug, true)]
+        [InlineData(LogEventLevel.Information, false)]
+        [InlineData(LogEventLevel.Warning, false)]
+        [InlineData(LogEventLevel.Error, false)]
+        [InlineData(LogEventLevel.Fatal, false)]
+        public void ShouldNotWriteLogEventsWhenMinLevelIsHigherThanDebug(LogEventLevel logMinLevel, bool shouldBeWritten)
+        {
+            var sink = new CollectingSink();
+            var logger = new LoggerConfiguration()
+                .MinimumLevel.Is(logMinLevel)
+                .WriteTo.Sink(sink)
+                .CreateLogger();
+
+            logger.Debug("This is a {test}", () => "xxx");
+
+            if (shouldBeWritten)
+                Assert.True(sink.SingleEvent.Properties.ContainsKey("test"));
+            else
+                Assert.Empty(sink.Events);
+        }
+
+        [Theory]
+        [InlineData(LogEventLevel.Verbose, true)]
+        [InlineData(LogEventLevel.Debug, true)]
+        [InlineData(LogEventLevel.Information, true)]
+        [InlineData(LogEventLevel.Warning, true)]
+        [InlineData(LogEventLevel.Error, true)]
+        [InlineData(LogEventLevel.Fatal, false)]
+        public void ShouldNotWriteLogEventsWhenMinLevelIsHigherThanError(LogEventLevel logMinLevel, bool shouldBeWritten)
+        {
+            var sink = new CollectingSink();
+            var logger = new LoggerConfiguration()
+                .MinimumLevel.Is(logMinLevel)
+                .WriteTo.Sink(sink)
+                .CreateLogger();
+
+            logger.Error("This is a {test}", () => "xxx");
+
+            if (shouldBeWritten)
+                Assert.True(sink.SingleEvent.Properties.ContainsKey("test"));
+            else
+                Assert.Empty(sink.Events);
+        }
+
+        [Theory]
+        [InlineData(LogEventLevel.Verbose, true)]
+        [InlineData(LogEventLevel.Debug, true)]
+        [InlineData(LogEventLevel.Information, true)]
+        [InlineData(LogEventLevel.Warning, false)]
+        [InlineData(LogEventLevel.Error, false)]
+        [InlineData(LogEventLevel.Fatal, false)]
+        public void ShouldNotWriteLogEventsWhenMinLevelIsHigherThanInformation(LogEventLevel logMinLevel, bool shouldBeWritten)
+        {
+            var sink = new CollectingSink();
+            var logger = new LoggerConfiguration()
+                .MinimumLevel.Is(logMinLevel)
+                .WriteTo.Sink(sink)
+                .CreateLogger();
+
+            logger.Information("This is a {test}", () => "xxx");
+
+            if (shouldBeWritten)
+                Assert.True(sink.SingleEvent.Properties.ContainsKey("test"));
+            else
+                Assert.Empty(sink.Events);
+        }
+
+        [Theory]
+        [InlineData(LogEventLevel.Verbose, LogEventLevel.Verbose, true)]
+        [InlineData(LogEventLevel.Verbose, LogEventLevel.Debug, true)]
+        [InlineData(LogEventLevel.Verbose, LogEventLevel.Information, true)]
+        [InlineData(LogEventLevel.Verbose, LogEventLevel.Warning, true)]
+        [InlineData(LogEventLevel.Verbose, LogEventLevel.Error, true)]
+        [InlineData(LogEventLevel.Verbose, LogEventLevel.Fatal, true)]
+        [InlineData(LogEventLevel.Debug, LogEventLevel.Verbose, false)]
+        [InlineData(LogEventLevel.Debug, LogEventLevel.Debug, true)]
+        [InlineData(LogEventLevel.Debug, LogEventLevel.Information, true)]
+        [InlineData(LogEventLevel.Debug, LogEventLevel.Warning, true)]
+        [InlineData(LogEventLevel.Debug, LogEventLevel.Error, true)]
+        [InlineData(LogEventLevel.Debug, LogEventLevel.Fatal, true)]
+        [InlineData(LogEventLevel.Information, LogEventLevel.Verbose, false)]
+        [InlineData(LogEventLevel.Information, LogEventLevel.Debug, false)]
+        [InlineData(LogEventLevel.Information, LogEventLevel.Information, true)]
+        [InlineData(LogEventLevel.Information, LogEventLevel.Warning, true)]
+        [InlineData(LogEventLevel.Information, LogEventLevel.Error, true)]
+        [InlineData(LogEventLevel.Information, LogEventLevel.Fatal, true)]
+        [InlineData(LogEventLevel.Warning, LogEventLevel.Verbose, false)]
+        [InlineData(LogEventLevel.Warning, LogEventLevel.Debug, false)]
+        [InlineData(LogEventLevel.Warning, LogEventLevel.Information, false)]
+        [InlineData(LogEventLevel.Warning, LogEventLevel.Warning, true)]
+        [InlineData(LogEventLevel.Warning, LogEventLevel.Error, true)]
+        [InlineData(LogEventLevel.Warning, LogEventLevel.Fatal, true)]
+        [InlineData(LogEventLevel.Error, LogEventLevel.Verbose, false)]
+        [InlineData(LogEventLevel.Error, LogEventLevel.Debug, false)]
+        [InlineData(LogEventLevel.Error, LogEventLevel.Information, false)]
+        [InlineData(LogEventLevel.Error, LogEventLevel.Warning, false)]
+        [InlineData(LogEventLevel.Error, LogEventLevel.Error, true)]
+        [InlineData(LogEventLevel.Error, LogEventLevel.Fatal, true)]
+        [InlineData(LogEventLevel.Fatal, LogEventLevel.Verbose, false)]
+        [InlineData(LogEventLevel.Fatal, LogEventLevel.Debug, false)]
+        [InlineData(LogEventLevel.Fatal, LogEventLevel.Information, false)]
+        [InlineData(LogEventLevel.Fatal, LogEventLevel.Warning, false)]
+        [InlineData(LogEventLevel.Fatal, LogEventLevel.Error, false)]
+        [InlineData(LogEventLevel.Fatal, LogEventLevel.Fatal, true)]
+        public void ShouldNotWriteLogEventsWhenMinLevelIsHigherThanProvidedLogLevel(LogEventLevel logMinLevel, LogEventLevel logLevelToWrite, bool shouldBeWritten)
+        {
+            var sink = new CollectingSink();
+            var logger = new LoggerConfiguration()
+                .MinimumLevel.Is(logMinLevel)
+                .WriteTo.Sink(sink)
+                .CreateLogger();
+
+            logger.Write(logLevelToWrite, "This is a {test}", () => "xxx");
+
+            if (shouldBeWritten)
+                Assert.True(sink.SingleEvent.Properties.ContainsKey("test"));
+            else
+                Assert.Empty(sink.Events);
+        }
+
+        [Theory]
+        [InlineData(LogEventLevel.Verbose, true)]
+        [InlineData(LogEventLevel.Debug, false)]
+        [InlineData(LogEventLevel.Information, false)]
+        [InlineData(LogEventLevel.Warning, false)]
+        [InlineData(LogEventLevel.Error, false)]
+        [InlineData(LogEventLevel.Fatal, false)]
+        public void ShouldNotWriteLogEventsWhenMinLevelIsHigherThanVerbose(LogEventLevel logMinLevel, bool shouldBeWritten)
+        {
+            var sink = new CollectingSink();
+            var logger = new LoggerConfiguration()
+                .MinimumLevel.Is(logMinLevel)
+                .WriteTo.Sink(sink)
+                .CreateLogger();
+
+            logger.Verbose("This is a {test}", () => "xxx");
+
+            if (shouldBeWritten)
+                Assert.True(sink.SingleEvent.Properties.ContainsKey("test"));
+            else
+                Assert.Empty(sink.Events);
+        }
+
+        [Theory]
+        [InlineData(LogEventLevel.Verbose, true)]
+        [InlineData(LogEventLevel.Debug, true)]
+        [InlineData(LogEventLevel.Information, true)]
+        [InlineData(LogEventLevel.Warning, true)]
+        [InlineData(LogEventLevel.Error, false)]
+        [InlineData(LogEventLevel.Fatal, false)]
+        public void ShouldNotWriteLogEventsWhenMinLevelIsHigherThanWarning(LogEventLevel logMinLevel, bool shouldBeWritten)
+        {
+            var sink = new CollectingSink();
+            var logger = new LoggerConfiguration()
+                .MinimumLevel.Is(logMinLevel)
+                .WriteTo.Sink(sink)
+                .CreateLogger();
+
+            logger.Warning("This is a {test}", () => "xxx");
+
+            if (shouldBeWritten)
+                Assert.True(sink.SingleEvent.Properties.ContainsKey("test"));
+            else
+                Assert.Empty(sink.Events);
+        }
+
+        #endregion Public Methods
+
+        #endregion Methods
     }
 }


### PR DESCRIPTION
Add extension methods to use delegates to generate property values only if the corresponding log level is active.