### PR TITLE
Refactor wrapper sinks

### DIFF
--- a/Serilog.sln.DotSettings
+++ b/Serilog.sln.DotSettings
@@ -560,7 +560,13 @@ II.2.12 &lt;HandlesEvent /&gt;&#xD;
 	<s:String x:Key="/Default/FilterSettingsManager/CoverageFilterXml/@EntryValue">&lt;data&gt;&lt;IncludeFilters /&gt;&lt;ExcludeFilters /&gt;&lt;/data&gt;</s:String>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=auditable/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=cacheable/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=callvirt/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=destructure/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Enricher/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Enrichers/@EntryIndexedValue">True</s:Boolean>
-	<s:Boolean x:Key="/Default/UserDictionary/Words/=Serilog/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=iface/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=imap/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Mesg/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Nops/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Serilog/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=xunit/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/src/Serilog/Core/CustomDefaultMethodImplementationAttribute.cs
+++ b/src/Serilog/Core/CustomDefaultMethodImplementationAttribute.cs
@@ -1,11 +1,13 @@
+#if FEATURE_DEFAULT_INTERFACE
+
+using System;
+
 namespace Serilog.Core
 {
-#if FEATURE_DEFAULT_INTERFACE
-    using System;
-
     [AttributeUsage(AttributeTargets.Method | AttributeTargets.Interface)]
-    internal sealed class CustomDefaultMethodImplementationAttribute : Attribute
+    sealed class CustomDefaultMethodImplementationAttribute : Attribute
     {
     }
-#endif
 }
+
+#endif

--- a/src/Serilog/Core/Sinks/AggregateSink.cs
+++ b/src/Serilog/Core/Sinks/AggregateSink.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2016 Serilog Contributors
+﻿// Copyright 2016-2020 Serilog Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -43,7 +43,7 @@ namespace Serilog.Core.Sinks
                 catch (Exception ex)
                 {
                     SelfLog.WriteLine("Caught exception while emitting to sink {0}: {1}", sink, ex);
-                    exceptions = exceptions ?? new List<Exception>();
+                    exceptions ??= new List<Exception>();
                     exceptions.Add(ex);
                 }
             }

--- a/src/Serilog/Core/Sinks/ConditionalSink.cs
+++ b/src/Serilog/Core/Sinks/ConditionalSink.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2019 Serilog Contributors
+﻿// Copyright 2019-2020 Serilog Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
 using System;
 using Serilog.Events;
 
-namespace Serilog.Core.Enrichers
+namespace Serilog.Core.Sinks
 {
     class ConditionalSink : ILogEventSink, IDisposable
     {

--- a/src/Serilog/Core/Sinks/DisposeDelegatingSink.cs
+++ b/src/Serilog/Core/Sinks/DisposeDelegatingSink.cs
@@ -17,20 +17,20 @@ using System;
 
 namespace Serilog.Core.Sinks
 {
-    class DisposeWrappingSink : ILogEventSink, IDisposable
+    class DisposeDelegatingSink : ILogEventSink, IDisposable
     {
         readonly ILogEventSink _sink;
-        readonly Action _dispose;
+        readonly IDisposable _disposable;
 
-        public DisposeWrappingSink(ILogEventSink sink, Action dispose)
+        public DisposeDelegatingSink(ILogEventSink sink, IDisposable disposable)
         {
-            _sink = sink;
-            _dispose = dispose;
+            _sink = sink ?? throw new ArgumentNullException(nameof(sink));
+            _disposable = disposable ?? throw new ArgumentNullException(nameof(disposable));
         }
 
         public void Dispose()
         {
-            _dispose();
+            _disposable.Dispose();
         }
 
         public void Emit(LogEvent logEvent)

--- a/src/Serilog/Core/Sinks/DisposeWrappingSink.cs
+++ b/src/Serilog/Core/Sinks/DisposeWrappingSink.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2019 Serilog Contributors
+﻿// Copyright 2020 Serilog Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -19,8 +19,8 @@ namespace Serilog.Core.Sinks
 {
     class DisposeWrappingSink : ILogEventSink, IDisposable
     {
-        private readonly ILogEventSink _sink;
-        private readonly Action _dispose;
+        readonly ILogEventSink _sink;
+        readonly Action _dispose;
 
         public DisposeWrappingSink(ILogEventSink sink, Action dispose)
         {

--- a/src/Serilog/Core/Sinks/DisposingSafeAggregateSink.cs
+++ b/src/Serilog/Core/Sinks/DisposingSafeAggregateSink.cs
@@ -1,4 +1,4 @@
-// Copyright 2019 Serilog Contributors
+// Copyright 2020 Serilog Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -27,21 +27,19 @@ namespace Serilog.Core.Sinks
 
         public void Dispose()
         {
-            var sinks = _sinks;
-            if (sinks != null)
+            if (_sinks == null) return;
+
+            foreach (var sink in _sinks)
             {
-                foreach (var sink in sinks)
+                if (sink is IDisposable disposable)
                 {
-                    if (sink is IDisposable disposable)
+                    try
                     {
-                        try
-                        {
-                            disposable.Dispose();
-                        }
-                        catch (Exception ex)
-                        {
-                            SelfLog.WriteLine("Caught exception while disposing sink {0}: {1}", sink, ex);
-                        }
+                        disposable.Dispose();
+                    }
+                    catch (Exception ex)
+                    {
+                        SelfLog.WriteLine("Caught exception while disposing sink {0}: {1}", sink, ex);
                     }
                 }
             }

--- a/src/Serilog/Core/Sinks/FilteringSink.cs
+++ b/src/Serilog/Core/Sinks/FilteringSink.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2013-2015 Serilog Contributors
+﻿// Copyright 2013-2020 Serilog Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -28,8 +28,10 @@ namespace Serilog.Core.Sinks
 
         public FilteringSink(ILogEventSink sink, IEnumerable<ILogEventFilter> filters, bool propagateExceptions)
         {
+            if (filters == null) throw new ArgumentNullException(nameof(filters));
             _sink = sink ?? throw new ArgumentNullException(nameof(sink));
-            _filters = filters?.ToArray() ?? throw new ArgumentNullException(nameof(filters));
+
+            _filters = filters.ToArray();
             _propagateExceptions = propagateExceptions;
         }
 

--- a/src/Serilog/Core/Sinks/RestrictedSink.cs
+++ b/src/Serilog/Core/Sinks/RestrictedSink.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2013-2015 Serilog Contributors
+﻿// Copyright 2013-2020 Serilog Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Serilog/Core/Sinks/SafeAggregateSink.cs
+++ b/src/Serilog/Core/Sinks/SafeAggregateSink.cs
@@ -1,4 +1,4 @@
-// Copyright 2013-2015 Serilog Contributors
+// Copyright 2013-2020 Serilog Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Serilog/Core/Sinks/SafeAggregateSink.cs
+++ b/src/Serilog/Core/Sinks/SafeAggregateSink.cs
@@ -22,7 +22,7 @@ namespace Serilog.Core.Sinks
 {
     class SafeAggregateSink : ILogEventSink
     {
-        protected readonly ILogEventSink[] _sinks;
+        readonly ILogEventSink[] _sinks;
 
         public SafeAggregateSink(IEnumerable<ILogEventSink> sinks)
         {

--- a/src/Serilog/Core/Sinks/SecondaryLoggerSink.cs
+++ b/src/Serilog/Core/Sinks/SecondaryLoggerSink.cs
@@ -24,7 +24,7 @@ namespace Serilog.Core.Sinks
     /// <remarks>The properties dictionary is copied, however the values within
     /// the dictionary (of type <see cref="LogEventProperty"/> are expected to
     /// be immutable.</remarks>
-    sealed class SecondaryLoggerSink : ILogEventSink, IDisposable
+    class SecondaryLoggerSink : ILogEventSink, IDisposable
     {
         readonly ILogger _logger;
         readonly bool _attemptDispose;

--- a/src/Serilog/Events/EventProperty.cs
+++ b/src/Serilog/Events/EventProperty.cs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 using System;
-using System.Runtime.CompilerServices;
 
 namespace Serilog.Events
 {
@@ -28,7 +27,7 @@ namespace Serilog.Events
         /// No property.
         /// </summary>
         public static EventProperty None = default;
-        
+
         /// <summary>
         /// The name of the property.
         /// </summary>

--- a/test/Serilog.Tests/Core/LoggerTests.cs
+++ b/test/Serilog.Tests/Core/LoggerTests.cs
@@ -1,4 +1,3 @@
-using Serilog.Configuration;
 using Serilog.Core;
 using Serilog.Core.Enrichers;
 using Serilog.Core.Pipeline;
@@ -80,7 +79,7 @@ namespace Serilog.Tests.Core
             var events = new List<LogEvent>();
             var sink = new DelegatingSink(events.Add);
 
-            var levelSwitch = new LoggingLevelSwitch(LogEventLevel.Information);
+            var levelSwitch = new LoggingLevelSwitch();
 
             var log = CreateLogger(loggerType, lc => lc
                 .MinimumLevel.ControlledBy(levelSwitch)
@@ -156,7 +155,7 @@ namespace Serilog.Tests.Core
             }
         }
 
-        ILogger CreateLogger(Type loggerType, Func<LoggerConfiguration, LoggerConfiguration> configureLogger)
+        static ILogger CreateLogger(Type loggerType, Func<LoggerConfiguration, LoggerConfiguration> configureLogger)
         {
             var lc = new LoggerConfiguration();
 
@@ -166,7 +165,7 @@ namespace Serilog.Tests.Core
 #if FEATURE_DEFAULT_INTERFACE
                 _ when loggerType == typeof(DelegatingLogger) => new DelegatingLogger(configureLogger(lc).CreateLogger()),
 #endif
-                _ => throw new NotImplementedException()
+                _ => throw new NotSupportedException()
             };
         }
 
@@ -231,17 +230,17 @@ namespace Serilog.Tests.Core
         [Fact]
         public void AggregatedSinksAreDisposedWhenLoggerIsDisposed()
         {
-            var sinka = new DisposeTrackingSink();
-            var sinkb = new DisposeTrackingSink();
+            var sinkA = new DisposeTrackingSink();
+            var sinkB = new DisposeTrackingSink();
             var log = new LoggerConfiguration()
-                .WriteTo.Sink(sinka)
-                .WriteTo.Sink(sinkb)
+                .WriteTo.Sink(sinkA)
+                .WriteTo.Sink(sinkB)
                 .CreateLogger();
 
             log.Dispose();
 
-            Assert.True(sinka.IsDisposed);
-            Assert.True(sinkb.IsDisposed);
+            Assert.True(sinkA.IsDisposed);
+            Assert.True(sinkB.IsDisposed);
         }
 
         [Fact]
@@ -260,16 +259,16 @@ namespace Serilog.Tests.Core
         [Fact]
         public void WrappedAggregatedSinksAreDisposedWhenLoggerIsDisposed()
         {
-            var sinka = new DisposeTrackingSink();
-            var sinkb = new DisposeTrackingSink();
+            var sinkA = new DisposeTrackingSink();
+            var sinkB = new DisposeTrackingSink();
             var log = new LoggerConfiguration()
-                .WriteTo.Dummy(wrapped => wrapped.Sink(sinka).WriteTo.Sink(sinkb))
+                .WriteTo.Dummy(wrapped => wrapped.Sink(sinkA).WriteTo.Sink(sinkB))
                 .CreateLogger();
 
             log.Dispose();
 
-            Assert.True(sinka.IsDisposed);
-            Assert.True(sinkb.IsDisposed);
+            Assert.True(sinkA.IsDisposed);
+            Assert.True(sinkB.IsDisposed);
         }
     }
 }

--- a/test/Serilog.Tests/LoggerConfigurationTests.cs
+++ b/test/Serilog.Tests/LoggerConfigurationTests.cs
@@ -1,6 +1,5 @@
 using Serilog.Core;
 using Serilog.Core.Filters;
-using Serilog.Debugging;
 using Serilog.Events;
 using Serilog.Tests.Support;
 using System;
@@ -11,6 +10,7 @@ using Serilog.Configuration;
 using Serilog.Core.Enrichers;
 using TestDummies;
 using Xunit;
+
 // ReSharper disable PossibleNullReferenceException
 
 namespace Serilog.Tests
@@ -725,7 +725,7 @@ namespace Serilog.Tests
             Assert.Empty(DummyWrappingSink.Emitted);
             Assert.Empty(sink.Events);
         }
-        
+
         [Fact]
         public void WrappingSinkReceivesEventsWhenLevelIsAppropriate()
         {
@@ -797,7 +797,7 @@ namespace Serilog.Tests
             var evt = Assert.Single(enricher.Events);
             Assert.Equal(LogEventLevel.Warning, evt.Level);
         }
-        
+
         [Fact]
         public void LeveledEnrichersCheckLevels()
         {

--- a/test/Serilog.Tests/MethodOverloadConventionTests.cs
+++ b/test/Serilog.Tests/MethodOverloadConventionTests.cs
@@ -13,6 +13,7 @@ using Xunit.Sdk;
 
 #if FEATURE_DEFAULT_INTERFACE
 using System.Reflection.Emit;
+// ReSharper disable PossibleNullReferenceException
 #endif
 
 // ReSharper disable PossibleMultipleEnumeration
@@ -59,6 +60,7 @@ namespace Serilog.Tests
             // calls with the same type arguments, name and parameters are considered equal
             static bool MethodBodyEqual(MethodBase ifaceMethod, MethodBase classMethod)
             {
+                // ReSharper disable once VariableHidesOuterVariable
                 var imap = typeof(Logger).GetInterfaceMap(typeof(ILogger));
 
                 var opCodesMap = new[]
@@ -141,7 +143,7 @@ namespace Serilog.Tests
                         }
                         else
                         {
-                            if (!object.Equals(ifaceField, classField))
+                            if (!Equals(ifaceField, classField))
                             {
                                 return false;
                             }
@@ -342,7 +344,7 @@ namespace Serilog.Tests
 
             Assert.IsType<bool>(result);
 
-            //silentlogger is always false
+            //SilentLogger is always false
             if (loggerType == typeof(SilentLogger))
                 return;
 
@@ -398,7 +400,7 @@ namespace Serilog.Tests
 
             Assert.IsType<bool>(result);
 
-            //silentlogger will always be false
+            //SilentLogger will always be false
             if (loggerType == typeof(SilentLogger))
                 return;
 
@@ -444,7 +446,7 @@ namespace Serilog.Tests
 
             Assert.IsType<bool>(trueResult);
 
-            //return as silentlogger will always be false
+            //return as SilentLogger will always be false
             if (loggerType == typeof(SilentLogger))
                 return;
 
@@ -553,7 +555,7 @@ namespace Serilog.Tests
             Assert.NotNull(enrichedLogger);
             Assert.True(enrichedLogger is ILogger);
 
-            //silentlogger will always return itself
+            //SilentLogger will always return itself
             if (method.DeclaringType == typeof(SilentLogger))
                 return;
 

--- a/test/Serilog.Tests/Rendering/MessageTemplateRendererTests.cs
+++ b/test/Serilog.Tests/Rendering/MessageTemplateRendererTests.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using Serilog.Events;

--- a/test/Serilog.Tests/Support/DelegatingLogger.cs
+++ b/test/Serilog.Tests/Support/DelegatingLogger.cs
@@ -1,9 +1,10 @@
-﻿namespace Serilog.Tests.Support
-{
-#if FEATURE_DEFAULT_INTERFACE
-    using System;
-    using Serilog.Events;
+﻿#if FEATURE_DEFAULT_INTERFACE
 
+using System;
+using Serilog.Events;
+
+namespace Serilog.Tests.Support
+{
     public class DelegatingLogger : ILogger, IDisposable
     {
         readonly ILogger _inner;
@@ -19,5 +20,6 @@
 
         public void Write(LogEvent logEvent) => _inner.Write(logEvent);
     }
-#endif
 }
+
+#endif


### PR DESCRIPTION
 * Breaks the inheritance relationship between `SafeAggregateSink` and `DisposingSafeAggregateSink` - generally we're aiming to avoid inheritance wherever we can
 * Merges #1449 from @augustoproiete - `DisposingSafeAggregateSink` should be `DisposingAggregateSink`, so that wrapper sinks can observe exceptions in more cases
 * Renames `DisposeWrappingSink` to `DisposeDelegatingSink` and removes a level of indirection, since the introduction of the disposing aggregate sink means that the enclosed/wrapped sink will always be `IDisposable` in the case that disposal is required
 * Some tidy-up based on Rider's latest suggestions...