### PR TITLE
Don't inherit parent Minimum Level for inline sublogger configuration

### DIFF
--- a/src/Serilog/Configuration/LoggerAuditSinkConfiguration.cs
+++ b/src/Serilog/Configuration/LoggerAuditSinkConfiguration.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2016 Serilog Contributors
+// Copyright 2016-2020 Serilog Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -25,9 +25,9 @@ namespace Serilog.Configuration
     {
         readonly LoggerSinkConfiguration _sinkConfiguration;
 
-        internal LoggerAuditSinkConfiguration(LoggerConfiguration loggerConfiguration, Action<ILogEventSink> addSink, Action<LoggerConfiguration> applyInheritedConfiguration)
+        internal LoggerAuditSinkConfiguration(LoggerConfiguration loggerConfiguration, Action<ILogEventSink> addSink)
         {
-            _sinkConfiguration = new LoggerSinkConfiguration(loggerConfiguration, addSink, applyInheritedConfiguration);
+            _sinkConfiguration = new LoggerSinkConfiguration(loggerConfiguration, addSink);
         }
 
         /// <summary>

--- a/src/Serilog/Configuration/LoggerSinkConfiguration.cs
+++ b/src/Serilog/Configuration/LoggerSinkConfiguration.cs
@@ -1,4 +1,4 @@
-// Copyright 2013-2015 Serilog Contributors
+// Copyright 2013-2020 Serilog Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -30,13 +30,11 @@ namespace Serilog.Configuration
     {
         readonly LoggerConfiguration _loggerConfiguration;
         readonly Action<ILogEventSink> _addSink;
-        readonly Action<LoggerConfiguration> _applyInheritedConfiguration;
 
-        internal LoggerSinkConfiguration(LoggerConfiguration loggerConfiguration, Action<ILogEventSink> addSink, Action<LoggerConfiguration> applyInheritedConfiguration)
+        internal LoggerSinkConfiguration(LoggerConfiguration loggerConfiguration, Action<ILogEventSink> addSink)
         {
             _loggerConfiguration = loggerConfiguration ?? throw new ArgumentNullException(nameof(loggerConfiguration));
             _addSink = addSink ?? throw new ArgumentNullException(nameof(addSink));
-            _applyInheritedConfiguration = applyInheritedConfiguration ?? throw new ArgumentNullException(nameof(applyInheritedConfiguration));
         }
 
         /// <summary>
@@ -126,13 +124,7 @@ namespace Serilog.Configuration
         {
             if (configureLogger == null) throw new ArgumentNullException(nameof(configureLogger));
 
-            var lc = new LoggerConfiguration();
-
-            // apply inherited configuration except minimum level
-            // since parent logger can have overrides
-            _applyInheritedConfiguration(lc);
-            lc.MinimumLevel.Is(LevelAlias.Minimum);
-
+            var lc = new LoggerConfiguration().MinimumLevel.Is(LevelAlias.Minimum);
             configureLogger(lc);
 
             var subLogger = lc.CreateLogger();
@@ -241,8 +233,7 @@ namespace Serilog.Configuration
             var capturingConfiguration = new LoggerConfiguration();
             var capturingLoggerSinkConfiguration = new LoggerSinkConfiguration(
                 capturingConfiguration,
-                sinksToWrap.Add,
-                loggerSinkConfiguration._applyInheritedConfiguration);
+                sinksToWrap.Add);
 
             // `WriteTo.Sink()` will return the capturing configuration; this ensures chained `WriteTo` gets back
             // to the capturing sink configuration, enabling `WriteTo.X().WriteTo.Y()`.

--- a/src/Serilog/Configuration/LoggerSinkConfiguration.cs
+++ b/src/Serilog/Configuration/LoggerSinkConfiguration.cs
@@ -128,7 +128,11 @@ namespace Serilog.Configuration
 
             var lc = new LoggerConfiguration();
 
+            // apply inherited configuration except minimum level
+            // since parent logger can have overrides
             _applyInheritedConfiguration(lc);
+            lc.MinimumLevel.Is(LevelAlias.Minimum);
+
             configureLogger(lc);
 
             var subLogger = lc.CreateLogger();

--- a/src/Serilog/LoggerConfiguration.cs
+++ b/src/Serilog/LoggerConfiguration.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2013-2016 Serilog Contributors
+// Copyright 2013-2020 Serilog Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -48,16 +48,8 @@ namespace Serilog
         /// </summary>
         public LoggerConfiguration()
         {
-            WriteTo = new LoggerSinkConfiguration(this, s => _logEventSinks.Add(s), ApplyInheritedConfiguration);
+            WriteTo = new LoggerSinkConfiguration(this, s => _logEventSinks.Add(s));
             Enrich = new LoggerEnrichmentConfiguration(this, e => _enrichers.Add(e));
-        }
-
-        void ApplyInheritedConfiguration(LoggerConfiguration child)
-        {
-            if (_levelSwitch != null)
-                child.MinimumLevel.ControlledBy(_levelSwitch);
-            else
-                child.MinimumLevel.Is(_minimumLevel);
         }
 
         /// <summary>
@@ -76,7 +68,7 @@ namespace Serilog
         /// extending <see cref="LoggerAuditSinkConfiguration"/>, though the generic <see cref="LoggerAuditSinkConfiguration.Sink"/>
         /// method allows any sink class to be adapted for auditing.
         /// </remarks>
-        public LoggerAuditSinkConfiguration AuditTo => new LoggerAuditSinkConfiguration(this, s => _auditSinks.Add(s), ApplyInheritedConfiguration);
+        public LoggerAuditSinkConfiguration AuditTo => new LoggerAuditSinkConfiguration(this, s => _auditSinks.Add(s));
 
         /// <summary>
         /// Configures the minimum level at which events will be passed to sinks. If

--- a/test/Serilog.Tests/Context/LogContextTests.cs
+++ b/test/Serilog.Tests/Context/LogContextTests.cs
@@ -188,13 +188,15 @@ namespace Serilog.Tests.Context
                 {
                     var pre = Thread.CurrentThread.ManagedThreadId;
 
-                    await Task.Delay(1000);
+                    await Task.Yield();
 
                     var post = Thread.CurrentThread.ManagedThreadId;
 
                     log.Write(Some.InformationEvent());
                     Assert.Equal(1, lastEvent.Properties["A"].LiteralValue());
 
+                    Assert.False(Thread.CurrentThread.IsThreadPoolThread);
+                    Assert.True(Thread.CurrentThread.IsBackground);
                     Assert.NotEqual(pre, post);
                 }
             },
@@ -404,6 +406,6 @@ namespace Serilog.Tests.Context
 
     class ForceNewThreadSyncContext : SynchronizationContext
     {
-        public override void Post(SendOrPostCallback d, object state) => new Thread(x => d(x)).Start(state);
+        public override void Post(SendOrPostCallback d, object state) => new Thread(x => d(x)) { IsBackground = true }.Start(state);
     }
 }

--- a/test/Serilog.Tests/Core/ChildLoggerTests.cs
+++ b/test/Serilog.Tests/Core/ChildLoggerTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using Serilog.Core;
 using Serilog.Events;
 using Serilog.Tests.Support;
@@ -149,9 +149,9 @@ namespace Serilog.Tests.Core
             //   Event  --> Root Logger --> Child Logger -> YES or
             //    lvl       override/lvl    override/levl     NO ?
             //
-            object[] T(string rs, int? rl, string cs, int? cl, bool r)
+            object[] T(string rs, int? rl, string cs, int? cl, bool r, LogEventLevel dl = LevelAlias.Minimum)
             {
-                return new object[] { rs, rl, cs, cl, r };
+                return new object[] { dl, rs, rl, cs, cl, r };
             }
             // numbers are relative to incoming event level
             // Information + 1 = Warning
@@ -166,10 +166,13 @@ namespace Serilog.Tests.Core
             // ... and child logger is out of the way
             yield return T("Root", +0, null, +0, true);
             yield return T("Root", -1, null, +0, true);
+            yield return T("Root", -1, null, +0, true, LevelAlias.Maximum);
             yield return T("Root.N1", +0, null, +0, true);
             yield return T("Root.N1", -1, null, +0, true);
+            yield return T("Root.N1", -1, null, +0, true, LevelAlias.Maximum);
             yield return T("Root.N1.N2", +0, null, +0, true);
             yield return T("Root.N1.N2", -1, null, +0, true);
+            yield return T("Root.N1.N2", -1, null, +0, true, LevelAlias.Maximum);
             // - root overrides on irrelevant namespaces
             yield return T("xx", +1, null, +0, true);
             yield return T("Root.xx", +1, null, +0, true);
@@ -191,6 +194,7 @@ namespace Serilog.Tests.Core
         [Theory]
         [MemberData(nameof(GetMinimumLevelOverrideInheritanceTestCases))]
         public void WriteToLoggerWithConfigCallbackMinimumLevelOverrideInheritanceScenarios(
+            LogEventLevel defaultRootLevel,
             string rootOverrideSource,
             int rootOverrideLevelIncrement,
             string childOverrideSource,
@@ -205,7 +209,7 @@ namespace Serilog.Tests.Core
             var sink = new DelegatingSink(e => evt = e);
 
             var rootLoggerConfig = new LoggerConfiguration()
-                .MinimumLevel.Is(LevelAlias.Minimum);
+                .MinimumLevel.Is(defaultRootLevel);
 
             if (rootOverrideSource != null)
             {
@@ -215,7 +219,6 @@ namespace Serilog.Tests.Core
             var logger = rootLoggerConfig
                 .WriteTo.Logger(lc =>
                 {
-                    lc.MinimumLevel.Is(LevelAlias.Minimum);
                     if (childOverrideSource != null)
                     {
                         lc.MinimumLevel.Override(childOverrideSource, childOverrideLevel);
@@ -241,6 +244,7 @@ namespace Serilog.Tests.Core
         [Theory]
         [MemberData(nameof(GetMinimumLevelOverrideInheritanceTestCases))]
         public void WriteToLoggerMinimumLevelOverrideInheritanceScenarios(
+            LogEventLevel defaultRootLevel,
             string rootOverrideSource,
             int rootOverrideLevelIncrement,
             string childOverrideSource,
@@ -264,7 +268,7 @@ namespace Serilog.Tests.Core
             var childLogger = childLoggerConfig.CreateLogger();
 
             var rootLoggerConfig = new LoggerConfiguration()
-                .MinimumLevel.Is(LevelAlias.Minimum);
+                .MinimumLevel.Is(defaultRootLevel);
 
             if (rootOverrideSource != null)
             {


### PR DESCRIPTION
**What issue does this PR address?**
Fixes #1346 , #1453 

**Does this PR introduce a breaking change?**
Behavior change for subloggers configured inline when no explicit default level specified for them.

**Please check if the PR fulfills these requirements**
- [x] The commit follows our [guidelines](https://github.com/serilog/serilog/blob/dev/CONTRIBUTING.md)
- [x] Unit Tests for the changes have been added (for bug fixes / features)

**Other information**
Inheriting minimum level was done before overrides where introduced, so it doesn't take them into account now for subloggers which results in counterintuitive behavior.
