### PR TITLE
ProjectedDestructuringPolicy made public

### DIFF
--- a/src/Serilog/Policies/ProjectedDestructuringPolicy.cs
+++ b/src/Serilog/Policies/ProjectedDestructuringPolicy.cs
@@ -1,4 +1,5 @@
-﻿// Copyright 2013-2015 Serilog Contributors
+
+// Copyright 2013-2015 Serilog Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,17 +19,33 @@ using Serilog.Events;
 
 namespace Serilog.Policies
 {
-    class ProjectedDestructuringPolicy : IDestructuringPolicy
+    /// <summary>
+    /// When destructuring objects, projects instances of the specified type with
+    /// the provided function.
+    /// </summary>
+    public class ProjectedDestructuringPolicy : IDestructuringPolicy
     {
         readonly Func<Type, bool> _canApply;
         readonly Func<object, object> _projection;
 
+        /// <summary>
+        /// Construct policy
+        /// </summary>
+        /// <param name="canApply">
+        /// Predicate for object type to check if policy can be applied.
+        /// </param>
+        /// <param name="projection">
+        /// Projection function transforming incoming type into the projected one.
+        /// </param>
         public ProjectedDestructuringPolicy(Func<Type, bool> canApply, Func<object, object> projection)
         {
             _canApply = canApply ?? throw new ArgumentNullException(nameof(canApply));
             _projection = projection ?? throw new ArgumentNullException(nameof(projection));
         }
 
+        /// <summary>
+        /// Implements <see cref="IDestructuringPolicy.TryDestructure(object, ILogEventPropertyValueFactory, out LogEventPropertyValue)"/>.
+        /// </summary>
         public bool TryDestructure(object value, ILogEventPropertyValueFactory propertyValueFactory, out LogEventPropertyValue result)
         {
             if (value == null) throw new ArgumentNullException(nameof(value));


### PR DESCRIPTION
I think it would be better to have a public modifier for ProjectedDestructuringPolicy. Let me explain a reason.

Imagine that we're designing a complex system with a lot of layers/packages those are conditionally/dynamically bind. Some of them may have their own classes that can be destructured so simple calls like config.ByTransforming(...) is not a good option and violates DIP (high level modules should not depend on low level modules). Sometimes we even don't know which transformation will be provided by a third-party plugin. Good design is to have something like this registered in composition root (talking in terms of DIP principle, IoC design patterns, etc).

```csharp
public class SerilogConfigurator
{
    public SerilogConfigurator(
        ...
        // Serilog enrichers and destructures are collected and injected by IoC. 
        // We don't care here where they come from
        IEnumerable<ILogEventEnricher> enrichers,
        IEnumerable<IDestructuringPolicy> destructures
    )
    {
        ...
        // Very simple dispatching of all collected policies to Serilog LoggerConfiguration
        config.Enrich.With(enrichers.ToArray());
        config.Destructure.With(destructures.ToArray());
        ...
    }
}
```

So when we want to create some projection in some specific package it could be as simple as (with extension methods it can be even shorter):
```csharp
// Autofac syntax used in this example
var projection = new ProjectedDestructuringPolicy(...instantiation options...)
builder.RegisterInstance(projection).As<IDestructuringPolicy>();

builder.RegisterType<PostgresConnectionEnricher>().As<ILogEventEnricher>().SingleInstance();
```

But this is impossible because ProjectedDestructuringPolicy is private so to have a good SOLID design this ~~wheel should be reinvented~~ class should be created again. I think you see a good implementation of OCP/DIP principles here. High level modules do not rely on low level. Configuration can be extended without any changes in the module responsible for configuration, etc.

I'm not sure how big is my investment into the codebase, but may be you'd find some ideas useful for documentation.

I made this change only for ProjectedDestructuringPolicy just because it looks like to the the only policy explicitly called from LoggerDestructuringConfiguration.