### PR TITLE
more precise logevent timestamp

### DIFF
--- a/src/Serilog/Core/Logger.cs
+++ b/src/Serilog/Core/Logger.cs
@@ -368,9 +368,10 @@ namespace Serilog.Core
                 propertyValues.GetType() != typeof(object[]))
                 propertyValues = new object[] { propertyValues };
 
+            var logTimestamp = DateTimeOffset.Now;
             _messageTemplateProcessor.Process(messageTemplate, propertyValues, out var parsedTemplate, out var boundProperties);
 
-            var logEvent = new LogEvent(DateTimeOffset.Now, level, exception, parsedTemplate, boundProperties);
+            var logEvent = new LogEvent(logTimestamp, level, exception, parsedTemplate, boundProperties);
             Dispatch(logEvent);
         }
 


### PR DESCRIPTION
Processing of message template can take a bit of time and it offsets the real timestamp of log event.
I catch max additional offset about 12 milliseconds with small testing