### PR TITLE
Fix scenario where LogContext throws a SecurityException when making cross-AppDomain calls inside an AppDomain with limited permissions

### DIFF
--- a/src/Serilog/Context/LogContext.cs
+++ b/src/Serilog/Context/LogContext.cs
@@ -244,26 +244,50 @@ namespace Serilog.Context
 
         sealed class DisposableObjectHandle : ObjectHandle, IDisposable
         {
-            static readonly ISponsor LifeTimeSponsor = new ClientSponsor();
+            private bool _disposed;
 
             public DisposableObjectHandle(object o)
                 : base(o)
             {
             }
 
-            public override object InitializeLifetimeService()
+            public override sealed object InitializeLifetimeService()
             {
-                var lease = base.InitializeLifetimeService() as ILease;
-                lease?.Register(LifeTimeSponsor);
-                return lease;
+                // For net45 where AsyncLocal is not a built-in Framework class, we must propgate the ambient context using LogicalCallContext.
+                // One consequence of this is that we invoke the System.Runtime.Remoting infrastructure, and if a remote method call or cross-AppDomain
+                // method call is made, objects stored inside the LogicalCallContext are transmitted to the other side (aka the "server").
+                //
+                // For distributed garbage collection, the "server" uses leases / sponsors to keep track of what objects are needed by "clients"
+                // (our original AppDomain) and should not be garbage collected. If we do not refresh the lease on objects stored inside the LogicalCallContext,
+                // the "server" will garbage collect them and disconnect them, meaning any accesses of the object inside the LogicalCallContext will throw a
+                // RemotingException.
+                //
+                // This solves the problem by returning null so that the lease on the object never expires. To make sure the object doesn't live forever
+                // on the "server", we'll use the Disposable pattern to disconnect the object when we no longer need it.
+                //
+                // This approach is preferred over previous implementations because this InitializeLifetimeService() method will be invoked on the "server"
+                // which may be an AppDomain with locked-down permissions, which means this object will not be able to call into SecurityCritical methods like
+                // the base.InitializeLifetimeService() method (which will throw a SecurityException) and keep itself alive.
+                //
+                // See this link for more info on remoting leases / sponsors: https://docs.microsoft.com/en-us/archive/msdn-magazine/2003/december/managing-remote-net-objects-with-leasing-and-sponsorship
+                return null;
             }
 
-            public void Dispose()
+            public void Dispose() => Dispose(true);
+
+            private void Dispose(bool disposing)
             {
-                if (GetLifetimeService() is ILease lease)
+                if (_disposed)
                 {
-                    lease.Unregister(LifeTimeSponsor);
+                    return;
                 }
+
+                if (disposing)
+                {
+                    RemotingServices.Disconnect(this);
+                }
+
+                _disposed = true;
             }
         }
 


### PR DESCRIPTION
Fixes #1486. See issue for full reproduction and analysis details.

Fix: In the DisposableObjectHandle class, no longer have the proxy object keep itself alive on the server by invoking base.InitializeLifetimeService(), which can cause .NET code access permission errors. Instead, return null to keep it alive indefinitely and forcefully remove the remote object when the local object is disposed.

This PR also adds the restricted AppDomain settings to the existing test scenarios in Serilog.Tests.Context.LogContextTests