### PR TITLE
Write to SelfLog to warn about settings with missing assembly references

### DIFF
--- a/src/Serilog/Settings/KeyValuePairs/KeyValuePairSettings.cs
+++ b/src/Serilog/Settings/KeyValuePairs/KeyValuePairSettings.cs
@@ -19,6 +19,7 @@ using System.Reflection;
 using System.Text.RegularExpressions;
 using Serilog.Configuration;
 using Serilog.Core;
+using Serilog.Debugging;
 using Serilog.Events;
 
 namespace Serilog.Settings.KeyValuePairs
@@ -230,7 +231,12 @@ namespace Serilog.Settings.KeyValuePairs
             {
                 var target = SelectConfigurationMethod(configurationMethods, directiveInfo.Key, directiveInfo);
 
-                if (target != null)
+                if (target == null)
+                {
+                    SelfLog.WriteLine("Setting \"{0}\" could not be matched to an implementation in any of the loaded assemblies. " +
+                        "To use settings from additional assemblies, specify them with the \"serilog:using\" key.", directiveInfo.Key);
+                }
+                else
                 {
                     var call = (from p in target.GetParameters().Skip(1)
                                 let directive = directiveInfo.FirstOrDefault(s => s.ArgumentName == p.Name)

--- a/test/Serilog.Tests/Debugging/SelfLogTests.cs
+++ b/test/Serilog.Tests/Debugging/SelfLogTests.cs
@@ -1,6 +1,8 @@
+using Serilog.Debugging;
+using Serilog.Tests.Support;
 using System;
 using System.Collections.Generic;
-using Serilog.Debugging;
+using TestDummies;
 using Xunit;
 
 namespace Serilog.Tests.Debugging
@@ -29,6 +31,35 @@ namespace Serilog.Tests.Debugging
             SelfLog.Disable();
             SelfLog.WriteLine("Unwritten");
             Assert.Equal(Messages.Count, count);
+        }
+
+        [Fact]
+        public void WritingToUndeclaredSinkWritesToSelfLog()
+        {
+            Messages = new();
+            SelfLog.Enable(m =>
+            {
+                Messages = Messages ?? new();
+                Messages.Add(m);
+            });
+
+            var settings = new Dictionary<string, string>
+            {
+                ["write-to:DummyRollingFile.pathFormat"] = "C:\\"
+            };
+
+            var log = new LoggerConfiguration()
+                .ReadFrom.KeyValuePairs(settings)
+                .CreateLogger();
+
+            DummyRollingFileSink.Reset();
+            DummyRollingFileAuditSink.Reset();
+
+            log.Write(Some.InformationEvent());
+
+            Assert.Single(Messages);
+            Assert.Contains(Messages, m => m.EndsWith("Setting \"DummyRollingFile\" could not be matched to an implementation in any of the loaded assemblies. " +
+                "To use settings from additional assemblies, specify them with the \"serilog:using\" key."));
         }
     }
 }


### PR DESCRIPTION
## Summary

- Writes a warning message in `SelfLog` when a setting is found to have no implementation in any of the loaded assemblies
- Helpful when a user misses a `using` reference

## Context
Fixes #1539