### PR TITLE
Fix testing of net5.0 target; disallow warnings in test projects

### DIFF
--- a/src/Serilog/Core/Logger.cs
+++ b/src/Serilog/Core/Logger.cs
@@ -102,7 +102,7 @@ namespace Serilog.Core
         /// <returns>A logger that will enrich log events as specified.</returns>
         public ILogger ForContext(ILogEventEnricher enricher)
         {
-            if (enricher == null)
+            if (enricher == null!)
                 return this; // No context here, so little point writing to SelfLog.
 
             return new Logger(
@@ -122,7 +122,7 @@ namespace Serilog.Core
         /// <returns>A logger that will enrich log events as specified.</returns>
         public ILogger ForContext(IEnumerable<ILogEventEnricher> enrichers)
         {
-            if (enrichers == null)
+            if (enrichers == null!)
                 return this; // No context here, so little point writing to SelfLog.
 
             return ForContext(new SafeAggregateEnricher(enrichers));
@@ -175,7 +175,7 @@ namespace Serilog.Core
         /// <returns>A logger that will enrich log events as specified.</returns>
         public ILogger ForContext(Type source)
         {
-            if (source == null)
+            if (source == null!)
                 return this; // Little point in writing to SelfLog here because we don't have any contextual information
 
             return ForContext(Constants.SourceContextPropertyName, source.FullName);
@@ -363,7 +363,7 @@ namespace Serilog.Core
         public void Write(LogEventLevel level, Exception? exception, string messageTemplate, params object?[]? propertyValues)
         {
             if (!IsEnabled(level)) return;
-            if (messageTemplate == null) return;
+            if (messageTemplate == null!) return;
 
             // Catch a common pitfall when a single non-object array is cast to object[]
             if (propertyValues != null &&
@@ -383,7 +383,7 @@ namespace Serilog.Core
         /// <param name="logEvent">The event to write.</param>
         public void Write(LogEvent logEvent)
         {
-            if (logEvent == null) return;
+            if (logEvent == null!) return;
             if (!IsEnabled(logEvent.Level)) return;
             Dispatch(logEvent);
         }
@@ -1328,9 +1328,9 @@ namespace Serilog.Core
         /// }
         /// </example>
         [MessageTemplateFormatMethod("messageTemplate")]
-        public bool BindMessageTemplate(string messageTemplate, object?[]? propertyValues, [NotNullWhen(true)] out MessageTemplate? parsedTemplate, [NotNullWhen(true)] out IEnumerable<LogEventProperty>? boundProperties)
+        public bool BindMessageTemplate(string messageTemplate, object?[]? propertyValues, [MaybeNullWhen(false)] out MessageTemplate parsedTemplate, [MaybeNullWhen(false)] out IEnumerable<LogEventProperty> boundProperties)
         {
-            if (messageTemplate == null)
+            if (messageTemplate == null!)
             {
                 parsedTemplate = null;
                 boundProperties = null;

--- a/src/Serilog/ILogger.cs
+++ b/src/Serilog/ILogger.cs
@@ -69,7 +69,7 @@ namespace Serilog
         ILogger ForContext(IEnumerable<ILogEventEnricher> enrichers)
 #if FEATURE_DEFAULT_INTERFACE
         {
-            if (enrichers == null)
+            if (enrichers == null!)
                 return this; // No context here, so little point writing to SelfLog.
 
             return ForContext(new Core.Enrichers.SafeAggregateEnricher(enrichers));
@@ -120,7 +120,7 @@ namespace Serilog
         ILogger ForContext(Type source)
 #if FEATURE_DEFAULT_INTERFACE
         {
-            if (source == null)
+            if (source == null!)
                 return this; // Little point in writing to SelfLog here because we don't have any contextual information
 
             return ForContext(Constants.SourceContextPropertyName, source.FullName);
@@ -331,7 +331,7 @@ namespace Serilog
 #if FEATURE_DEFAULT_INTERFACE
         {
             if (!IsEnabled(level)) return;
-            if (messageTemplate == null) return;
+            if (messageTemplate == null!) return;
 
             // Catch a common pitfall when a single non-object array is cast to object[]
             if (propertyValues != null &&
@@ -1341,7 +1341,8 @@ namespace Serilog
         [CustomDefaultMethodImplementation]
 #endif
         bool BindMessageTemplate(string messageTemplate, object?[]? propertyValues,
-                                 [NotNullWhen(true)] out MessageTemplate? parsedTemplate, [NotNullWhen(true)] out IEnumerable<LogEventProperty>? boundProperties)
+            [MaybeNullWhen(false)] out MessageTemplate parsedTemplate,
+            [MaybeNullWhen(false)] out IEnumerable<LogEventProperty> boundProperties)
 #if FEATURE_DEFAULT_INTERFACE
             => DefaultLoggerImpl.BindMessageTemplate(messageTemplate, propertyValues, out parsedTemplate, out boundProperties)
 #endif

--- a/src/Serilog/Serilog.csproj
+++ b/src/Serilog/Serilog.csproj
@@ -41,6 +41,10 @@
     <DefineConstants>$(DefineConstants);ASYNCLOCAL;HASHTABLE;FEATURE_DEFAULT_INTERFACE;FEATURE_SPAN</DefineConstants>
   </PropertyGroup>
 
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net5.0' ">
+    <DefineConstants>$(DefineConstants);ASYNCLOCAL;HASHTABLE;FEATURE_DEFAULT_INTERFACE;FEATURE_SPAN</DefineConstants>
+  </PropertyGroup>
+
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
     <PackageReference Include="System.Collections.NonGeneric" Version="4.3.0" />
   </ItemGroup>

--- a/test/Serilog.PerformanceTests/BindingBenchmark.cs
+++ b/test/Serilog.PerformanceTests/BindingBenchmark.cs
@@ -52,21 +52,21 @@ namespace Serilog.PerformanceTests
         public (MessageTemplate, int) BindZero()
         {
             _log.BindMessageTemplate(MT0, _zero, out var mt, out var p);
-            return (mt, p.Count());
+            return (mt, p!.Count())!;
         }
 
         [Benchmark]
         public (MessageTemplate, int) BindOne()
         {
             _log.BindMessageTemplate(MT1, _one, out var mt, out var p);
-            return (mt, p.Count());
+            return (mt, p!.Count())!;
         }
 
         [Benchmark]
         public (MessageTemplate, int) BindFive()
         {
             _log.BindMessageTemplate(MT5, _five, out var mt, out var p);
-            return (mt, p.Count());
+            return (mt, p!.Count())!;
         }
     }
 }

--- a/test/Serilog.PerformanceTests/Serilog.PerformanceTests.csproj
+++ b/test/Serilog.PerformanceTests/Serilog.PerformanceTests.csproj
@@ -6,6 +6,7 @@
     <SignAssembly>true</SignAssembly>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
     <Nullable>enable</Nullable>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Serilog.Tests/Context/LogContextTests.cs
+++ b/test/Serilog.Tests/Context/LogContextTests.cs
@@ -51,7 +51,7 @@ namespace Serilog.Tests.Context
             {
                 log.Write(Some.InformationEvent());
                 Assert.NotNull(lastEvent);
-                Assert.Equal(1, lastEvent.Properties["A"].LiteralValue());
+                Assert.Equal(1, lastEvent!.Properties["A"].LiteralValue());
                 Assert.Equal(2, lastEvent.Properties["B"].LiteralValue());
                 Assert.Equal(3, lastEvent.Properties["C"].LiteralValue());
                 Assert.Equal(4, lastEvent.Properties["D"].LiteralValue());
@@ -78,7 +78,7 @@ namespace Serilog.Tests.Context
             {
                 log.Write(Some.InformationEvent());
                 Assert.NotNull(lastEvent);
-                Assert.Equal(1, lastEvent.Properties["A"].LiteralValue());
+                Assert.Equal(1, lastEvent!.Properties["A"].LiteralValue());
             }
         }
 
@@ -110,7 +110,7 @@ namespace Serilog.Tests.Context
             t.Join();
 
             Assert.NotNull(lastEvent);
-            Assert.Equal(1, lastEvent.Properties["A"].LiteralValue());
+            Assert.Equal(1, lastEvent!.Properties["A"].LiteralValue());
         }
 
         [Fact]
@@ -127,7 +127,7 @@ namespace Serilog.Tests.Context
             {
                 log.Write(Some.InformationEvent());
                 Assert.NotNull(lastEvent);
-                Assert.Equal(1, lastEvent.Properties["A"].LiteralValue());
+                Assert.Equal(1, lastEvent!.Properties["A"].LiteralValue());
 
                 using (LogContext.PushProperty("A", 2))
                 {
@@ -157,7 +157,7 @@ namespace Serilog.Tests.Context
             {
                 log.Write(Some.InformationEvent());
                 Assert.NotNull(lastEvent);
-                Assert.Equal(1, lastEvent.Properties["A1"].LiteralValue());
+                Assert.Equal(1, lastEvent!.Properties["A1"].LiteralValue());
                 Assert.Equal(2, lastEvent.Properties["A2"].LiteralValue());
 
                 using (LogContext.Push(new PropertyEnricher("A1", 10), new PropertyEnricher("A2", 20)))
@@ -199,7 +199,7 @@ namespace Serilog.Tests.Context
 
                     log.Write(Some.InformationEvent());
                     Assert.NotNull(lastEvent);
-                    Assert.Equal(1, lastEvent.Properties["A"].LiteralValue());
+                    Assert.Equal(1, lastEvent!.Properties["A"].LiteralValue());
 
                     Assert.False(Thread.CurrentThread.IsThreadPoolThread);
                     Assert.True(Thread.CurrentThread.IsBackground);
@@ -228,7 +228,7 @@ namespace Serilog.Tests.Context
                 });
 
                 Assert.NotNull(lastEvent);
-                Assert.Empty(lastEvent.Properties);
+                Assert.Empty(lastEvent!.Properties);
 
                 // Reset should only work for current async scope, outside of it previous Context
                 // instance should be available again.
@@ -257,7 +257,7 @@ namespace Serilog.Tests.Context
                     });
 
                     Assert.NotNull(lastEvent);
-                    Assert.Empty(lastEvent.Properties);
+                    Assert.Empty(lastEvent!.Properties);
                 }
 
                 // Suspend should only work for scope of using. After calling Dispose all enrichers
@@ -408,7 +408,7 @@ namespace Serilog.Tests.Context
                 log.Information("Hello");
 
             Assert.NotNull(lastEvent);
-            return 42.Equals(lastEvent.Properties["Number"].LiteralValue());
+            return 42.Equals(lastEvent!.Properties["Number"].LiteralValue());
         }
     }
 #endif

--- a/test/Serilog.Tests/LoggerConfigurationTests.cs
+++ b/test/Serilog.Tests/LoggerConfigurationTests.cs
@@ -474,7 +474,7 @@ namespace Serilog.Tests
 
             log.Information($"{{{destructuringSymbol}X}}", x);
             Assert.NotNull(evt);
-            return evt.Properties["X"].ToString();
+            return evt!.Properties["X"].ToString();
         }
 
         [Fact]

--- a/test/Serilog.Tests/Serilog.Tests.csproj
+++ b/test/Serilog.Tests/Serilog.Tests.csproj
@@ -1,13 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net452;net46</TargetFrameworks>
-    <AssemblyName>Serilog.Tests</AssemblyName>
     <AssemblyOriginatorKeyFile>../../assets/Serilog.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
-    <PackageId>Serilog.Tests</PackageId>
     <Nullable>enable</Nullable>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
+    <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Serilog.Tests/Settings/KeyValuePairSettingsTests.cs
+++ b/test/Serilog.Tests/Settings/KeyValuePairSettingsTests.cs
@@ -34,7 +34,7 @@ namespace Serilog.Tests.Settings
             log.Information("Has a test property");
 
             Assert.NotNull(evt);
-            Assert.Equal("FinalValue", evt.Properties["App"].LiteralValue());
+            Assert.Equal("FinalValue", evt!.Properties["App"].LiteralValue());
         }
 
         [Fact]
@@ -61,7 +61,7 @@ namespace Serilog.Tests.Settings
             log.Information("Has a test property");
 
             Assert.NotNull(evt);
-            Assert.Equal("Test", evt.Properties["App"].LiteralValue());
+            Assert.Equal("Test", evt!.Properties["App"].LiteralValue());
         }
 
         [Fact]
@@ -407,7 +407,7 @@ namespace Serilog.Tests.Settings
 
             log.Information("Destructuring a big graph {@DeeplyNested}", nestedObject);
             Assert.NotNull(evt);
-            var formattedProperty = evt.Properties["DeeplyNested"].ToString();
+            var formattedProperty = evt!.Properties["DeeplyNested"].ToString();
 
             Assert.Contains("C", formattedProperty);
             Assert.DoesNotContain("D", formattedProperty);
@@ -427,7 +427,7 @@ namespace Serilog.Tests.Settings
 
             log.Information("Destructuring a long string {@LongString}", "ABCDEFGH");
             Assert.NotNull(evt);
-            var formattedProperty = evt.Properties["LongString"].ToString();
+            var formattedProperty = evt!.Properties["LongString"].ToString();
 
             Assert.Equal("\"AB…\"", formattedProperty);
         }
@@ -447,7 +447,7 @@ namespace Serilog.Tests.Settings
             var collection = new[] { 1, 2, 3, 4, 5, 6 };
             log.Information("Destructuring a big collection {@BigCollection}", collection);
             Assert.NotNull(evt);
-            var formattedProperty = evt.Properties["BigCollection"].ToString();
+            var formattedProperty = evt!.Properties["BigCollection"].ToString();
 
             Assert.Contains("3", formattedProperty);
             Assert.DoesNotContain("4", formattedProperty);
@@ -468,7 +468,7 @@ namespace Serilog.Tests.Settings
 
             log.Information("Destructuring with hard-coded policy {@Input}", new { Foo = "Bar" });
             Assert.NotNull(evt);
-            var formattedProperty = evt.Properties["Input"].ToString();
+            var formattedProperty = evt!.Properties["Input"].ToString();
 
             Assert.Equal("\"hardcoded\"", formattedProperty);
         }
@@ -487,7 +487,7 @@ namespace Serilog.Tests.Settings
 
             log.Information("Destructuring as scalar {@Scalarized}", new Version(2, 3));
             Assert.NotNull(evt);
-            var prop = evt.Properties["Scalarized"];
+            var prop = evt!.Properties["Scalarized"];
 
             Assert.IsType<ScalarValue>(prop);
         }
@@ -506,7 +506,7 @@ namespace Serilog.Tests.Settings
 
             log.Information("Destructuring as scalar {@Scalarized}", new Version(2, 3));
             Assert.NotNull(evt);
-            var prop = evt.Properties["Scalarized"];
+            var prop = evt!.Properties["Scalarized"];
 
             Assert.IsType<ScalarValue>(prop);
         }
@@ -526,7 +526,7 @@ namespace Serilog.Tests.Settings
 
             log.Information("Destructuring with policy {@Version}", new Version(2, 3));
             Assert.NotNull(evt);
-            var prop = evt.Properties["Version"];
+            var prop = evt!.Properties["Version"];
 
             Assert.IsType<ScalarValue>(prop);
             Assert.Equal(2, (prop as ScalarValue)?.Value);
@@ -660,7 +660,7 @@ namespace Serilog.Tests.Settings
             log.Write(Some.InformationEvent());
 
             Assert.NotNull(evt);
-            Assert.True(evt.Properties.ContainsKey("ThreadId"), "Event should have enriched property ThreadId");
+            Assert.True(evt!.Properties.ContainsKey("ThreadId"), "Event should have enriched property ThreadId");
         }
 
         [Fact]


### PR DESCRIPTION
No idea how this got through CI, but the build on `dev` is broken because of a missing `FEATURE_DEFAULT_INTERFACE` define for net5.0 (my bad :-))