### PR TITLE
(ReadOnly)Memory<byte> scalar policy; NotSupportedExeption handling for PropertyValueConverter

### DIFF
--- a/src/Serilog/Policies/ByteMemoryScalarConversionPolicy.cs
+++ b/src/Serilog/Policies/ByteMemoryScalarConversionPolicy.cs
@@ -1,0 +1,86 @@
+// Copyright 2021 Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#if FEATURE_SPAN
+
+using System;
+
+using Serilog.Core;
+using Serilog.Events;
+
+namespace Serilog.Policies
+{
+    // Byte arrays, when logged, need to be copied so that they are
+    // safe from concurrent modification when written to asynchronous
+    // sinks. Byte arrays larger than 1k are written as descriptive strings.
+    sealed class ByteMemoryScalarConversionPolicy : IScalarConversionPolicy
+    {
+        const int MaximumByteArrayLength = 1024;
+        const int MaxTake = 16;
+
+        public bool TryConvertToScalar(object value, out ScalarValue result)
+        {
+            if (value is ReadOnlyMemory<byte> x)
+            {
+                result = new(ConvertToHexString(x));
+                return true;
+            }
+
+            if (value is Memory<byte> y)
+            {
+                result = new(ConvertToHexString(y));
+                return true;
+            }
+
+            result = null;
+            return false;
+        }
+
+        static string ConvertToHexString(ReadOnlyMemory<byte> bytes)
+        {
+            if (bytes.Length > MaximumByteArrayLength)
+            {
+                return ConvertToHexString(bytes[..MaxTake], $"... ({bytes.Length} bytes)");
+            }
+
+            return ConvertToHexString(bytes, tail: "");
+        }
+
+        static string ConvertToHexString(ReadOnlyMemory<byte> src, string tail)
+        {
+            var stringLength = src.Length * 2 + tail.Length;
+
+            return string.Create(stringLength, (src, tail), (dest, state) =>
+            {
+                var (src, tail) = state;
+
+                var byteSpan = src.Span;
+                foreach (var b in byteSpan)
+                {
+                    if (b.TryFormat(dest, out var written, "X2"))
+                    {
+                        dest = dest[written..];
+                    }
+                }
+
+                for (var i = 0; i < tail.Length; ++i)
+                {
+                    dest[i] = tail[i];
+                }
+            });
+        }
+    }
+}
+
+#endif

--- a/test/Serilog.Tests/Capturing/PropertyValueConverterTests.cs
+++ b/test/Serilog.Tests/Capturing/PropertyValueConverterTests.cs
@@ -200,6 +200,58 @@ namespace Serilog.Tests.Capturing
             Assert.EndsWith("(1025 bytes)", lv);
         }
 
+#if FEATURE_SPAN
+        [Fact]
+        public void ByteSpansAreConvertedToStrings()
+        {
+            var bytes = Enumerable.Range(0, 10).Select(b => (byte)b).ToArray().AsMemory();
+            var pv = _converter.CreatePropertyValue(bytes);
+            var lv = (string)pv.LiteralValue();
+            Assert.Equal("00010203040506070809", lv);
+        }
+
+        [Fact]
+        public void ByteSpansLargerThan1kAreLimitedAndConvertedToStrings()
+        {
+            var bytes = Enumerable.Range(0, 1025).Select(b => (byte)b).ToArray().AsMemory();
+            var pv = _converter.CreatePropertyValue(bytes);
+            var lv = (string)pv.LiteralValue();
+            Assert.EndsWith("(1025 bytes)", lv);
+        }
+
+        [Theory]
+        [InlineData(10)]
+        [InlineData(1000)]
+        [InlineData(10000)]
+        public void ByteSpansAreConvertedToTheSameStringsAsArrays(int length)
+        {
+            var bytes = Enumerable.Range(0, length).Select(b => (byte)b).ToArray();
+            var bytesSpan = bytes.AsMemory();
+
+            var bytesResult = _converter.CreatePropertyValue(bytes).LiteralValue();
+            var bytesSpanResult = _converter.CreatePropertyValue(bytesSpan).LiteralValue();
+
+            Assert.Equal(bytesResult, bytesSpanResult);
+        }
+
+        [Fact]
+        public void FailsGracefullyWhenAccessingPropertiesViaReflectionThrows()
+        {
+            var thrower = new int[] { 1, 2, 3 }.AsMemory();
+
+            var pv = _converter.CreatePropertyValue(thrower, Destructuring.Destructure);
+            var sv = (StructureValue)pv;
+            Assert.Equal(3, sv.Properties.Count);
+            var t = sv.Properties.Single(m => m.Name == "Span");
+            Assert.Equal("Accessing this property is not supported via Reflection API", t.Value.LiteralValue());
+            var l = sv.Properties.Single(m => m.Name == "Length");
+            Assert.Equal(3, l.Value.LiteralValue());
+            var k = sv.Properties.Single(m => m.Name == "IsEmpty");
+            Assert.False((bool)k.Value.LiteralValue());
+            var s = sv.Properties.Single(m => m.Name == "Span");
+        }
+#endif
+
         public class Thrower
         {
             public string Throws => throw new NotSupportedException();

--- a/test/Serilog.Tests/Serilog.Tests.csproj
+++ b/test/Serilog.Tests/Serilog.Tests.csproj
@@ -34,9 +34,9 @@
     <DefineConstants>$(DefineConstants);ASYNCLOCAL</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
-    <DefineConstants>$(DefineConstants);ASYNCLOCAL;FEATURE_DEFAULT_INTERFACE</DefineConstants>
+    <DefineConstants>$(DefineConstants);ASYNCLOCAL;FEATURE_DEFAULT_INTERFACE;FEATURE_SPAN</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net5.0' ">
-    <DefineConstants>$(DefineConstants);ASYNCLOCAL;FEATURE_DEFAULT_INTERFACE</DefineConstants>
+    <DefineConstants>$(DefineConstants);ASYNCLOCAL;FEATURE_DEFAULT_INTERFACE;FEATURE_SPAN</DefineConstants>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
fixes #1632 