### PR TITLE
Corrected Example in MessageTemplateFormatMethod documentation comments

### DIFF
--- a/src/Serilog/Core/MessageTemplateFormatMethodAttribute.cs
+++ b/src/Serilog/Core/MessageTemplateFormatMethodAttribute.cs
@@ -8,7 +8,7 @@ namespace Serilog.Core
     /// </summary>
     /// <example>
     /// <code>
-    /// [LoggerMethod("messageTemplate")]
+    /// [MessageTemplateFormatMethod("messageTemplate")]
     /// public void Information(string messageTemplate, params object[] propertyValues)
     /// {
     ///     // Do something


### PR DESCRIPTION
The example in the documentation was using a wrong name for the attribute. Corrected the usage in the example