### PR TITLE
Revert "Update ILogger XML documentation"

### DIFF
--- a/src/Serilog/ILogger.cs
+++ b/src/Serilog/ILogger.cs
@@ -25,14 +25,12 @@ namespace Serilog
     /// The core Serilog logging API, used for writing log events.
     /// </summary>
     /// <example>
-    /// <code>
     /// var log = new LoggerConfiguration()
     ///     .WriteTo.Console()
     ///     .CreateLogger();
     ///
     /// var thing = "World";
     /// log.Information("Hello, {Thing}!", thing);
-    /// </code>
     /// </example>
     /// <remarks>
     /// The methods on <see cref="ILogger"/> (and its static sibling <see cref="Log"/>) are guaranteed
@@ -369,9 +367,7 @@ namespace Serilog
         /// </summary>
         /// <param name="messageTemplate">Message template describing the event.</param>
         /// <example>
-        /// <code>
         /// Log.Verbose("Staring into space, wondering if we're alone.");
-        /// <code>
         /// </example>
         [MessageTemplateFormatMethod("messageTemplate")]
         void Verbose(string messageTemplate)
@@ -386,9 +382,7 @@ namespace Serilog
         /// <param name="messageTemplate">Message template describing the event.</param>
         /// <param name="propertyValue">Object positionally formatted into the message template.</param>
         /// <example>
-        /// <code>
         /// Log.Verbose("Staring into space, wondering if we're alone.");
-        /// <code>
         /// </example>
         [MessageTemplateFormatMethod("messageTemplate")]
         void Verbose<T>(string messageTemplate, T propertyValue)
@@ -404,10 +398,7 @@ namespace Serilog
         /// <param name="propertyValue0">Object positionally formatted into the message template.</param>
         /// <param name="propertyValue1">Object positionally formatted into the message template.</param>
         /// <example>
-        /// <code>
         /// Log.Verbose("Staring into space, wondering if we're alone.");
-        /// <code>
-        /// <code>
         /// </example>
         [MessageTemplateFormatMethod("messageTemplate")]
         void Verbose<T0, T1>(string messageTemplate, T0 propertyValue0, T1 propertyValue1)
@@ -424,9 +415,7 @@ namespace Serilog
         /// <param name="propertyValue1">Object positionally formatted into the message template.</param>
         /// <param name="propertyValue2">Object positionally formatted into the message template.</param>
         /// <example>
-        /// <code>
         /// Log.Verbose("Staring into space, wondering if we're alone.");
-        /// <code>
         /// </example>
         [MessageTemplateFormatMethod("messageTemplate")]
         void Verbose<T0, T1, T2>(string messageTemplate, T0 propertyValue0, T1 propertyValue1, T2 propertyValue2)
@@ -441,9 +430,7 @@ namespace Serilog
         /// <param name="messageTemplate">Message template describing the event.</param>
         /// <param name="propertyValues">Objects positionally formatted into the message template.</param>
         /// <example>
-        /// <code>
         /// Log.Verbose("Staring into space, wondering if we're alone.");
-        /// <code>
         /// </example>
         [MessageTemplateFormatMethod("messageTemplate")]
         void Verbose(string messageTemplate, params object?[]? propertyValues)
@@ -458,9 +445,7 @@ namespace Serilog
         /// <param name="exception">Exception related to the event.</param>
         /// <param name="messageTemplate">Message template describing the event.</param>
         /// <example>
-        /// <code>
         /// Log.Verbose(ex, "Staring into space, wondering where this comet came from.");
-        /// <code>
         /// </example>
         [MessageTemplateFormatMethod("messageTemplate")]
         void Verbose(Exception? exception, string messageTemplate)
@@ -476,9 +461,7 @@ namespace Serilog
         /// <param name="messageTemplate">Message template describing the event.</param>
         /// <param name="propertyValue">Object positionally formatted into the message template.</param>
         /// <example>
-        /// <code>
         /// Log.Verbose(ex, "Staring into space, wondering where this comet came from.");
-        /// <code>
         /// </example>
         [MessageTemplateFormatMethod("messageTemplate")]
         void Verbose<T>(Exception? exception, string messageTemplate, T propertyValue)
@@ -495,9 +478,7 @@ namespace Serilog
         /// <param name="propertyValue0">Object positionally formatted into the message template.</param>
         /// <param name="propertyValue1">Object positionally formatted into the message template.</param>
         /// <example>
-        /// <code>
         /// Log.Verbose(ex, "Staring into space, wondering where this comet came from.");
-        /// <code>
         /// </example>
         [MessageTemplateFormatMethod("messageTemplate")]
         void Verbose<T0, T1>(Exception? exception, string messageTemplate, T0 propertyValue0, T1 propertyValue1)
@@ -515,9 +496,7 @@ namespace Serilog
         /// <param name="propertyValue1">Object positionally formatted into the message template.</param>
         /// <param name="propertyValue2">Object positionally formatted into the message template.</param>
         /// <example>
-        /// <code>
         /// Log.Verbose(ex, "Staring into space, wondering where this comet came from.");
-        /// <code>
         /// </example>
         [MessageTemplateFormatMethod("messageTemplate")]
         void Verbose<T0, T1, T2>(Exception? exception, string messageTemplate, T0 propertyValue0, T1 propertyValue1, T2 propertyValue2)
@@ -533,9 +512,7 @@ namespace Serilog
         /// <param name="messageTemplate">Message template describing the event.</param>
         /// <param name="propertyValues">Objects positionally formatted into the message template.</param>
         /// <example>
-        /// <code>
         /// Log.Verbose(ex, "Staring into space, wondering where this comet came from.");
-        /// <code>
         /// </example>
         [MessageTemplateFormatMethod("messageTemplate")]
         void Verbose(Exception? exception, string messageTemplate, params object?[]? propertyValues)
@@ -549,9 +526,7 @@ namespace Serilog
         /// </summary>
         /// <param name="messageTemplate">Message template describing the event.</param>
         /// <example>
-        /// <code>
         /// Log.Debug("Starting up at {StartedAt}.", DateTime.Now);
-        /// <code>
         /// </example>
         [MessageTemplateFormatMethod("messageTemplate")]
         void Debug(string messageTemplate)
@@ -566,9 +541,7 @@ namespace Serilog
         /// <param name="messageTemplate">Message template describing the event.</param>
         /// <param name="propertyValue">Object positionally formatted into the message template.</param>
         /// <example>
-        /// <code>
         /// Log.Debug("Starting up at {StartedAt}.", DateTime.Now);
-        /// <code>
         /// </example>
         [MessageTemplateFormatMethod("messageTemplate")]
         void Debug<T>(string messageTemplate, T propertyValue)
@@ -584,9 +557,7 @@ namespace Serilog
         /// <param name="propertyValue0">Object positionally formatted into the message template.</param>
         /// <param name="propertyValue1">Object positionally formatted into the message template.</param>
         /// <example>
-        /// <code>
         /// Log.Debug("Starting up at {StartedAt}.", DateTime.Now);
-        /// <code>
         /// </example>
         [MessageTemplateFormatMethod("messageTemplate")]
         void Debug<T0, T1>(string messageTemplate, T0 propertyValue0, T1 propertyValue1)
@@ -603,9 +574,7 @@ namespace Serilog
         /// <param name="propertyValue1">Object positionally formatted into the message template.</param>
         /// <param name="propertyValue2">Object positionally formatted into the message template.</param>
         /// <example>
-        /// <code>
         /// Log.Debug("Starting up at {StartedAt}.", DateTime.Now);
-        /// <code>
         /// </example>
         [MessageTemplateFormatMethod("messageTemplate")]
         void Debug<T0, T1, T2>(string messageTemplate, T0 propertyValue0, T1 propertyValue1, T2 propertyValue2)
@@ -620,9 +589,7 @@ namespace Serilog
         /// <param name="messageTemplate">Message template describing the event.</param>
         /// <param name="propertyValues">Objects positionally formatted into the message template.</param>
         /// <example>
-        /// <code>
         /// Log.Debug("Starting up at {StartedAt}.", DateTime.Now);
-        /// <code>
         /// </example>
         [MessageTemplateFormatMethod("messageTemplate")]
         void Debug(string messageTemplate, params object?[]? propertyValues)
@@ -637,9 +604,7 @@ namespace Serilog
         /// <param name="exception">Exception related to the event.</param>
         /// <param name="messageTemplate">Message template describing the event.</param>
         /// <example>
-        /// <code>
         /// Log.Debug(ex, "Swallowing a mundane exception.");
-        /// <code>
         /// </example>
         [MessageTemplateFormatMethod("messageTemplate")]
         void Debug(Exception? exception, string messageTemplate)
@@ -655,9 +620,7 @@ namespace Serilog
         /// <param name="messageTemplate">Message template describing the event.</param>
         /// <param name="propertyValue">Object positionally formatted into the message template.</param>
         /// <example>
-        /// <code>
         /// Log.Debug(ex, "Swallowing a mundane exception.");
-        /// <code>
         /// </example>
         [MessageTemplateFormatMethod("messageTemplate")]
         void Debug<T>(Exception? exception, string messageTemplate, T propertyValue)
@@ -674,9 +637,7 @@ namespace Serilog
         /// <param name="propertyValue0">Object positionally formatted into the message template.</param>
         /// <param name="propertyValue1">Object positionally formatted into the message template.</param>
         /// <example>
-        /// <code>
         /// Log.Debug(ex, "Swallowing a mundane exception.");
-        /// <code>
         /// </example>
         [MessageTemplateFormatMethod("messageTemplate")]
         void Debug<T0, T1>(Exception? exception, string messageTemplate, T0 propertyValue0, T1 propertyValue1)
@@ -694,9 +655,7 @@ namespace Serilog
         /// <param name="propertyValue1">Object positionally formatted into the message template.</param>
         /// <param name="propertyValue2">Object positionally formatted into the message template.</param>
         /// <example>
-        /// <code>
         /// Log.Debug(ex, "Swallowing a mundane exception.");
-        /// <code>
         /// </example>
         [MessageTemplateFormatMethod("messageTemplate")]
         void Debug<T0, T1, T2>(Exception? exception, string messageTemplate, T0 propertyValue0, T1 propertyValue1, T2 propertyValue2)
@@ -712,9 +671,7 @@ namespace Serilog
         /// <param name="messageTemplate">Message template describing the event.</param>
         /// <param name="propertyValues">Objects positionally formatted into the message template.</param>
         /// <example>
-        /// <code>
         /// Log.Debug(ex, "Swallowing a mundane exception.");
-        /// <code>
         /// </example>
         [MessageTemplateFormatMethod("messageTemplate")]
         void Debug(Exception? exception, string messageTemplate, params object?[]? propertyValues)
@@ -728,9 +685,7 @@ namespace Serilog
         /// </summary>
         /// <param name="messageTemplate">Message template describing the event.</param>
         /// <example>
-        /// <code>
         /// Log.Information("Processed {RecordCount} records in {TimeMS}.", records.Length, sw.ElapsedMilliseconds);
-        /// <code>
         /// </example>
         [MessageTemplateFormatMethod("messageTemplate")]
         void Information(string messageTemplate)
@@ -745,9 +700,7 @@ namespace Serilog
         /// <param name="messageTemplate">Message template describing the event.</param>
         /// <param name="propertyValue">Object positionally formatted into the message template.</param>
         /// <example>
-        /// <code>
         /// Log.Information("Processed {RecordCount} records in {TimeMS}.", records.Length, sw.ElapsedMilliseconds);
-        /// <code>
         /// </example>
         [MessageTemplateFormatMethod("messageTemplate")]
         void Information<T>(string messageTemplate, T propertyValue)
@@ -763,9 +716,7 @@ namespace Serilog
         /// <param name="propertyValue0">Object positionally formatted into the message template.</param>
         /// <param name="propertyValue1">Object positionally formatted into the message template.</param>
         /// <example>
-        /// <code>
         /// Log.Information("Processed {RecordCount} records in {TimeMS}.", records.Length, sw.ElapsedMilliseconds);
-        /// <code>
         /// </example>
         [MessageTemplateFormatMethod("messageTemplate")]
         void Information<T0, T1>(string messageTemplate, T0 propertyValue0, T1 propertyValue1)
@@ -782,9 +733,7 @@ namespace Serilog
         /// <param name="propertyValue1">Object positionally formatted into the message template.</param>
         /// <param name="propertyValue2">Object positionally formatted into the message template.</param>
         /// <example>
-        /// <code>
         /// Log.Information("Processed {RecordCount} records in {TimeMS}.", records.Length, sw.ElapsedMilliseconds);
-        /// <code>
         /// </example>
         [MessageTemplateFormatMethod("messageTemplate")]
         void Information<T0, T1, T2>(string messageTemplate, T0 propertyValue0, T1 propertyValue1, T2 propertyValue2)
@@ -799,9 +748,7 @@ namespace Serilog
         /// <param name="messageTemplate">Message template describing the event.</param>
         /// <param name="propertyValues">Objects positionally formatted into the message template.</param>
         /// <example>
-        /// <code>
         /// Log.Information("Processed {RecordCount} records in {TimeMS}.", records.Length, sw.ElapsedMilliseconds);
-        /// <code>
         /// </example>
         [MessageTemplateFormatMethod("messageTemplate")]
         void Information(string messageTemplate, params object?[]? propertyValues)
@@ -816,9 +763,7 @@ namespace Serilog
         /// <param name="exception">Exception related to the event.</param>
         /// <param name="messageTemplate">Message template describing the event.</param>
         /// <example>
-        /// <code>
         /// Log.Information(ex, "Processed {RecordCount} records in {TimeMS}.", records.Length, sw.ElapsedMilliseconds);
-        /// <code>
         /// </example>
         [MessageTemplateFormatMethod("messageTemplate")]
         void Information(Exception? exception, string messageTemplate)
@@ -834,9 +779,7 @@ namespace Serilog
         /// <param name="messageTemplate">Message template describing the event.</param>
         /// <param name="propertyValue">Object positionally formatted into the message template.</param>
         /// <example>
-        /// <code>
         /// Log.Information(ex, "Processed {RecordCount} records in {TimeMS}.", records.Length, sw.ElapsedMilliseconds);
-        /// <code>
         /// </example>
         [MessageTemplateFormatMethod("messageTemplate")]
         void Information<T>(Exception? exception, string messageTemplate, T propertyValue)
@@ -853,9 +796,7 @@ namespace Serilog
         /// <param name="propertyValue0">Object positionally formatted into the message template.</param>
         /// <param name="propertyValue1">Object positionally formatted into the message template.</param>
         /// <example>
-        /// <code>
         /// Log.Information(ex, "Processed {RecordCount} records in {TimeMS}.", records.Length, sw.ElapsedMilliseconds);
-        /// <code>
         /// </example>
         [MessageTemplateFormatMethod("messageTemplate")]
         void Information<T0, T1>(Exception? exception, string messageTemplate, T0 propertyValue0, T1 propertyValue1)
@@ -873,9 +814,7 @@ namespace Serilog
         /// <param name="propertyValue1">Object positionally formatted into the message template.</param>
         /// <param name="propertyValue2">Object positionally formatted into the message template.</param>
         /// <example>
-        /// <code>
         /// Log.Information(ex, "Processed {RecordCount} records in {TimeMS}.", records.Length, sw.ElapsedMilliseconds);
-        /// <code>
         /// </example>
         [MessageTemplateFormatMethod("messageTemplate")]
         void Information<T0, T1, T2>(Exception? exception, string messageTemplate, T0 propertyValue0, T1 propertyValue1, T2 propertyValue2)
@@ -891,9 +830,7 @@ namespace Serilog
         /// <param name="messageTemplate">Message template describing the event.</param>
         /// <param name="propertyValues">Objects positionally formatted into the message template.</param>
         /// <example>
-        /// <code>
         /// Log.Information(ex, "Processed {RecordCount} records in {TimeMS}.", records.Length, sw.ElapsedMilliseconds);
-        /// <code>
         /// </example>
         [MessageTemplateFormatMethod("messageTemplate")]
         void Information(Exception? exception, string messageTemplate, params object?[]? propertyValues)
@@ -907,9 +844,7 @@ namespace Serilog
         /// </summary>
         /// <param name="messageTemplate">Message template describing the event.</param>
         /// <example>
-        /// <code>
         /// Log.Warning("Skipped {SkipCount} records.", skippedRecords.Length);
-        /// <code>
         /// </example>
         [MessageTemplateFormatMethod("messageTemplate")]
         void Warning(string messageTemplate)
@@ -924,9 +859,7 @@ namespace Serilog
         /// <param name="messageTemplate">Message template describing the event.</param>
         /// <param name="propertyValue">Object positionally formatted into the message template.</param>
         /// <example>
-        /// <code>
         /// Log.Warning("Skipped {SkipCount} records.", skippedRecords.Length);
-        /// <code>
         /// </example>
         [MessageTemplateFormatMethod("messageTemplate")]
         void Warning<T>(string messageTemplate, T propertyValue)
@@ -942,9 +875,7 @@ namespace Serilog
         /// <param name="propertyValue0">Object positionally formatted into the message template.</param>
         /// <param name="propertyValue1">Object positionally formatted into the message template.</param>
         /// <example>
-        /// <code>
         /// Log.Warning("Skipped {SkipCount} records.", skippedRecords.Length);
-        /// <code>
         /// </example>
         [MessageTemplateFormatMethod("messageTemplate")]
         void Warning<T0, T1>(string messageTemplate, T0 propertyValue0, T1 propertyValue1)
@@ -961,9 +892,7 @@ namespace Serilog
         /// <param name="propertyValue1">Object positionally formatted into the message template.</param>
         /// <param name="propertyValue2">Object positionally formatted into the message template.</param>
         /// <example>
-        /// <code>
         /// Log.Warning("Skipped {SkipCount} records.", skippedRecords.Length);
-        /// <code>
         /// </example>
         [MessageTemplateFormatMethod("messageTemplate")]
         void Warning<T0, T1, T2>(string messageTemplate, T0 propertyValue0, T1 propertyValue1, T2 propertyValue2)
@@ -978,9 +907,7 @@ namespace Serilog
         /// <param name="messageTemplate">Message template describing the event.</param>
         /// <param name="propertyValues">Objects positionally formatted into the message template.</param>
         /// <example>
-        /// <code>
         /// Log.Warning("Skipped {SkipCount} records.", skippedRecords.Length);
-        /// <code>
         /// </example>
         [MessageTemplateFormatMethod("messageTemplate")]
         void Warning(string messageTemplate, params object?[]? propertyValues)
@@ -995,9 +922,7 @@ namespace Serilog
         /// <param name="exception">Exception related to the event.</param>
         /// <param name="messageTemplate">Message template describing the event.</param>
         /// <example>
-        /// <code>
         /// Log.Warning(ex, "Skipped {SkipCount} records.", skippedRecords.Length);
-        /// <code>
         /// </example>
         [MessageTemplateFormatMethod("messageTemplate")]
         void Warning(Exception? exception, string messageTemplate)
@@ -1013,9 +938,7 @@ namespace Serilog
         /// <param name="messageTemplate">Message template describing the event.</param>
         /// <param name="propertyValue">Object positionally formatted into the message template.</param>
         /// <example>
-        /// <code>
         /// Log.Warning(ex, "Skipped {SkipCount} records.", skippedRecords.Length);
-        /// <code>
         /// </example>
         [MessageTemplateFormatMethod("messageTemplate")]
         void Warning<T>(Exception? exception, string messageTemplate, T propertyValue)
@@ -1032,9 +955,7 @@ namespace Serilog
         /// <param name="propertyValue0">Object positionally formatted into the message template.</param>
         /// <param name="propertyValue1">Object positionally formatted into the message template.</param>
         /// <example>
-        /// <code>
         /// Log.Warning(ex, "Skipped {SkipCount} records.", skippedRecords.Length);
-        /// <code>
         /// </example>
         [MessageTemplateFormatMethod("messageTemplate")]
         void Warning<T0, T1>(Exception? exception, string messageTemplate, T0 propertyValue0, T1 propertyValue1)
@@ -1052,9 +973,7 @@ namespace Serilog
         /// <param name="propertyValue1">Object positionally formatted into the message template.</param>
         /// <param name="propertyValue2">Object positionally formatted into the message template.</param>
         /// <example>
-        /// <code>
         /// Log.Warning(ex, "Skipped {SkipCount} records.", skippedRecords.Length);
-        /// <code>
         /// </example>
         [MessageTemplateFormatMethod("messageTemplate")]
         void Warning<T0, T1, T2>(Exception? exception, string messageTemplate, T0 propertyValue0, T1 propertyValue1, T2 propertyValue2)
@@ -1070,9 +989,7 @@ namespace Serilog
         /// <param name="messageTemplate">Message template describing the event.</param>
         /// <param name="propertyValues">Objects positionally formatted into the message template.</param>
         /// <example>
-        /// <code>
         /// Log.Warning(ex, "Skipped {SkipCount} records.", skippedRecords.Length);
-        /// <code>
         /// </example>
         [MessageTemplateFormatMethod("messageTemplate")]
         void Warning(Exception? exception, string messageTemplate, params object?[]? propertyValues)
@@ -1086,9 +1003,7 @@ namespace Serilog
         /// </summary>
         /// <param name="messageTemplate">Message template describing the event.</param>
         /// <example>
-        /// <code>
         /// Log.Error("Failed {ErrorCount} records.", brokenRecords.Length);
-        /// <code>
         /// </example>
         [MessageTemplateFormatMethod("messageTemplate")]
         void Error(string messageTemplate)
@@ -1103,9 +1018,7 @@ namespace Serilog
         /// <param name="messageTemplate">Message template describing the event.</param>
         /// <param name="propertyValue">Object positionally formatted into the message template.</param>
         /// <example>
-        /// <code>
         /// Log.Error("Failed {ErrorCount} records.", brokenRecords.Length);
-        /// <code>
         /// </example>
         [MessageTemplateFormatMethod("messageTemplate")]
         void Error<T>(string messageTemplate, T propertyValue)
@@ -1121,9 +1034,7 @@ namespace Serilog
         /// <param name="propertyValue0">Object positionally formatted into the message template.</param>
         /// <param name="propertyValue1">Object positionally formatted into the message template.</param>
         /// <example>
-        /// <code>
         /// Log.Error("Failed {ErrorCount} records.", brokenRecords.Length);
-        /// <code>
         /// </example>
         [MessageTemplateFormatMethod("messageTemplate")]
         void Error<T0, T1>(string messageTemplate, T0 propertyValue0, T1 propertyValue1)
@@ -1140,9 +1051,7 @@ namespace Serilog
         /// <param name="propertyValue1">Object positionally formatted into the message template.</param>
         /// <param name="propertyValue2">Object positionally formatted into the message template.</param>
         /// <example>
-        /// <code>
         /// Log.Error("Failed {ErrorCount} records.", brokenRecords.Length);
-        /// <code>
         /// </example>
         [MessageTemplateFormatMethod("messageTemplate")]
         void Error<T0, T1, T2>(string messageTemplate, T0 propertyValue0, T1 propertyValue1, T2 propertyValue2)
@@ -1157,9 +1066,7 @@ namespace Serilog
         /// <param name="messageTemplate">Message template describing the event.</param>
         /// <param name="propertyValues">Objects positionally formatted into the message template.</param>
         /// <example>
-        /// <code>
         /// Log.Error("Failed {ErrorCount} records.", brokenRecords.Length);
-        /// <code>
         /// </example>
         [MessageTemplateFormatMethod("messageTemplate")]
         void Error(string messageTemplate, params object?[]? propertyValues)
@@ -1174,9 +1081,7 @@ namespace Serilog
         /// <param name="exception">Exception related to the event.</param>
         /// <param name="messageTemplate">Message template describing the event.</param>
         /// <example>
-        /// <code>
         /// Log.Error(ex, "Failed {ErrorCount} records.", brokenRecords.Length);
-        /// <code>
         /// </example>
         [MessageTemplateFormatMethod("messageTemplate")]
         void Error(Exception? exception, string messageTemplate)
@@ -1192,9 +1097,7 @@ namespace Serilog
         /// <param name="messageTemplate">Message template describing the event.</param>
         /// <param name="propertyValue">Object positionally formatted into the message template.</param>
         /// <example>
-        /// <code>
         /// Log.Error(ex, "Failed {ErrorCount} records.", brokenRecords.Length);
-        /// <code>
         /// </example>
         [MessageTemplateFormatMethod("messageTemplate")]
         void Error<T>(Exception? exception, string messageTemplate, T propertyValue)
@@ -1211,9 +1114,7 @@ namespace Serilog
         /// <param name="propertyValue0">Object positionally formatted into the message template.</param>
         /// <param name="propertyValue1">Object positionally formatted into the message template.</param>
         /// <example>
-        /// <code>
         /// Log.Error(ex, "Failed {ErrorCount} records.", brokenRecords.Length);
-        /// <code>
         /// </example>
         [MessageTemplateFormatMethod("messageTemplate")]
         void Error<T0, T1>(Exception? exception, string messageTemplate, T0 propertyValue0, T1 propertyValue1)
@@ -1231,9 +1132,7 @@ namespace Serilog
         /// <param name="propertyValue1">Object positionally formatted into the message template.</param>
         /// <param name="propertyValue2">Object positionally formatted into the message template.</param>
         /// <example>
-        /// <code>
         /// Log.Error(ex, "Failed {ErrorCount} records.", brokenRecords.Length);
-        /// <code>
         /// </example>
         [MessageTemplateFormatMethod("messageTemplate")]
         void Error<T0, T1, T2>(Exception? exception, string messageTemplate, T0 propertyValue0, T1 propertyValue1, T2 propertyValue2)
@@ -1249,11 +1148,7 @@ namespace Serilog
         /// <param name="messageTemplate">Message template describing the event.</param>
         /// <param name="propertyValues">Objects positionally formatted into the message template.</param>
         /// <example>
-        /// <code>
-        /// <code>
         /// Log.Error(ex, "Failed {ErrorCount} records.", brokenRecords.Length);
-        /// </code>
-        /// <code>
         /// </example>
         [MessageTemplateFormatMethod("messageTemplate")]
         void Error(Exception? exception, string messageTemplate, params object?[]? propertyValues)
@@ -1267,9 +1162,7 @@ namespace Serilog
         /// </summary>
         /// <param name="messageTemplate">Message template describing the event.</param>
         /// <example>
-        /// <code>
         /// Log.Fatal("Process terminating.");
-        /// <code>
         /// </example>
         [MessageTemplateFormatMethod("messageTemplate")]
         void Fatal(string messageTemplate)
@@ -1284,9 +1177,7 @@ namespace Serilog
         /// <param name="messageTemplate">Message template describing the event.</param>
         /// <param name="propertyValue">Object positionally formatted into the message template.</param>
         /// <example>
-        /// <code>
         /// Log.Fatal("Process terminating.");
-        /// <code>
         /// </example>
         [MessageTemplateFormatMethod("messageTemplate")]
         void Fatal<T>(string messageTemplate, T propertyValue)
@@ -1302,9 +1193,7 @@ namespace Serilog
         /// <param name="propertyValue0">Object positionally formatted into the message template.</param>
         /// <param name="propertyValue1">Object positionally formatted into the message template.</param>
         /// <example>
-        /// <code>
         /// Log.Fatal("Process terminating.");
-        /// <code>
         /// </example>
         [MessageTemplateFormatMethod("messageTemplate")]
         void Fatal<T0, T1>(string messageTemplate, T0 propertyValue0, T1 propertyValue1)
@@ -1321,9 +1210,7 @@ namespace Serilog
         /// <param name="propertyValue1">Object positionally formatted into the message template.</param>
         /// <param name="propertyValue2">Object positionally formatted into the message template.</param>
         /// <example>
-        /// <code>
         /// Log.Fatal("Process terminating.");
-        /// <code>
         /// </example>
         [MessageTemplateFormatMethod("messageTemplate")]
         void Fatal<T0, T1, T2>(string messageTemplate, T0 propertyValue0, T1 propertyValue1, T2 propertyValue2)
@@ -1338,9 +1225,7 @@ namespace Serilog
         /// <param name="messageTemplate">Message template describing the event.</param>
         /// <param name="propertyValues">Objects positionally formatted into the message template.</param>
         /// <example>
-        /// <code>
         /// Log.Fatal("Process terminating.");
-        /// <code>
         /// </example>
         [MessageTemplateFormatMethod("messageTemplate")]
         void Fatal(string messageTemplate, params object?[]? propertyValues)
@@ -1355,9 +1240,7 @@ namespace Serilog
         /// <param name="exception">Exception related to the event.</param>
         /// <param name="messageTemplate">Message template describing the event.</param>
         /// <example>
-        /// <code>
         /// Log.Fatal(ex, "Process terminating.");
-        /// <code>
         /// </example>
         [MessageTemplateFormatMethod("messageTemplate")]
         void Fatal(Exception? exception, string messageTemplate)
@@ -1373,9 +1256,7 @@ namespace Serilog
         /// <param name="messageTemplate">Message template describing the event.</param>
         /// <param name="propertyValue">Object positionally formatted into the message template.</param>
         /// <example>
-        /// <code>
         /// Log.Fatal(ex, "Process terminating.");
-        /// <code>
         /// </example>
         [MessageTemplateFormatMethod("messageTemplate")]
         void Fatal<T>(Exception? exception, string messageTemplate, T propertyValue)
@@ -1392,9 +1273,7 @@ namespace Serilog
         /// <param name="propertyValue0">Object positionally formatted into the message template.</param>
         /// <param name="propertyValue1">Object positionally formatted into the message template.</param>
         /// <example>
-        /// <code>
         /// Log.Fatal(ex, "Process terminating.");
-        /// <code>
         /// </example>
         [MessageTemplateFormatMethod("messageTemplate")]
         void Fatal<T0, T1>(Exception? exception, string messageTemplate, T0 propertyValue0, T1 propertyValue1)
@@ -1412,9 +1291,7 @@ namespace Serilog
         /// <param name="propertyValue1">Object positionally formatted into the message template.</param>
         /// <param name="propertyValue2">Object positionally formatted into the message template.</param>
         /// <example>
-        /// <code>
         /// Log.Fatal(ex, "Process terminating.");
-        /// <code>
         /// </example>
         [MessageTemplateFormatMethod("messageTemplate")]
         void Fatal<T0, T1, T2>(Exception? exception, string messageTemplate, T0 propertyValue0, T1 propertyValue1, T2 propertyValue2)
@@ -1430,9 +1307,7 @@ namespace Serilog
         /// <param name="messageTemplate">Message template describing the event.</param>
         /// <param name="propertyValues">Objects positionally formatted into the message template.</param>
         /// <example>
-        /// <code>
         /// Log.Fatal(ex, "Process terminating.");
-        /// <code>
         /// </example>
         [MessageTemplateFormatMethod("messageTemplate")]
         void Fatal(Exception? exception, string messageTemplate, params object?[]? propertyValues)
@@ -1452,16 +1327,14 @@ namespace Serilog
         /// render the <paramref name="boundProperties"/> as text.</param>
         /// <param name="boundProperties">Captured properties from the template and <paramref name="propertyValues"/>.</param>
         /// <example>
-        /// <code>
         /// MessageTemplate template;
-        /// IEnumerable&lt;LogEventProperty&gt; properties;
+        /// IEnumerable&lt;LogEventProperty&gt; properties>;
         /// if (Log.BindMessageTemplate("Hello, {Name}!", new[] { "World" }, out template, out properties)
         /// {
         ///     var propsByName = properties.ToDictionary(p => p.Name, p => p.Value);
         ///     Console.WriteLine(template.Render(propsByName, null));
         ///     // -> "Hello, World!"
         /// }
-        /// </code>
         /// </example>
         [MessageTemplateFormatMethod("messageTemplate")]
 #if FEATURE_DEFAULT_INTERFACE


### PR DESCRIPTION
Reverts serilog/serilog#1664

@erichiller strange that your earlier PR didn't fail in CI - a number of the `<code>` blocks were malformed (closed with `<code>` instead of `</code>`).

The `dev` branch is now failing to build because of this, so reverting until we can redo it:

https://ci.appveyor.com/project/serilog/serilog/branch/dev

Cheers!