### PR TITLE
Add an overload to LogContext.PushProperty to accept a Func<T> delegate.

### DIFF
--- a/src/Serilog/Context/LogContext.cs
+++ b/src/Serilog/Context/LogContext.cs
@@ -79,6 +79,25 @@ namespace Serilog.Context
         }
 
         /// <summary>
+        /// Push a property onto the context using a delegate, returning an <see cref="IDisposable"/>
+        /// that must later be used to remove the property, along with any others that
+        /// may have been pushed on top of it and not yet popped. The property must
+        /// be popped from the same thread/logical call context.
+        /// </summary>
+        /// <param name="name">The name of the property.</param>
+        /// <param name="value">The delegate to the property.</param>
+        /// <returns>A handle to later remove the property from the context.</returns>
+        /// <param name="destructureObjects">If true, and the value is a non-primitive, non-array type,
+        /// then the value will be converted to a structure; otherwise, unknown types will
+        /// be converted to scalars, which are generally stored as strings.</param>
+        /// <returns>A token that must be disposed, in order, to pop properties back off the stack.</returns>
+        public static IDisposable PushProperty<T>(string name, Func<T> value, bool destructureObjects = false)
+        {
+            return Serilog.Context.LogContext.Push(new FunctionPropertyEnricher<T>(name, value, destructureObjects));
+        }
+
+
+        /// <summary>
         /// Push an enricher onto the context, returning an <see cref="IDisposable"/>
         /// that must later be used to remove the property, along with any others that
         /// may have been pushed on top of it and not yet popped. The property must

--- a/src/Serilog/Core/Enrichers/FunctionPropertyEnricher.cs
+++ b/src/Serilog/Core/Enrichers/FunctionPropertyEnricher.cs
@@ -1,0 +1,67 @@
+// Copyright 2013-2015 Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#nullable enable
+using System;
+using Serilog.Events;
+
+namespace Serilog.Core.Enrichers
+{
+    /// <summary>
+    /// Adds a new property enricher to the log event.
+    /// </summary>
+    public class FunctionPropertyEnricher<T> : ILogEventEnricher
+    {
+        readonly string _name;
+        readonly Func<T> _value;
+        readonly bool _destructureObjects;
+
+        /// <summary>
+        /// Create a new property enricher.
+        /// </summary>
+        /// <param name="name">The name of the property.</param>
+        /// <param name="value">The delegate to the property.</param>
+        /// <returns>A handle to later remove the property from the context.</returns>
+        /// <param name="destructureObjects">If true, and the value is a non-primitive, non-array type,
+        /// then the value will be converted to a structure; otherwise, unknown types will
+        /// be converted to scalars, which are generally stored as strings.</param>
+        /// <returns></returns>
+        /// <exception cref="ArgumentNullException">When <paramref name="name"/> is <code>null</code></exception>
+        /// <exception cref="ArgumentException">When <paramref name="name"/> is empty or only contains whitespace</exception>
+        public FunctionPropertyEnricher(string name, Func<T> value, bool destructureObjects = false)
+        {
+            LogEventProperty.EnsureValidName(name);
+
+            _name = name;
+            _value = value;
+            _destructureObjects = destructureObjects;
+        }
+
+        /// <summary>
+        /// Enrich the log event.
+        /// </summary>
+        /// <param name="logEvent">The log event to enrich.</param>
+        /// <param name="propertyFactory">Factory for creating new properties to add to the event.</param>
+        /// <exception cref="ArgumentNullException">When <paramref name="logEvent"/> is <code>null</code></exception>
+        /// <exception cref="ArgumentNullException">When <paramref name="propertyFactory"/> is <code>null</code></exception>
+        public void Enrich(LogEvent logEvent, ILogEventPropertyFactory propertyFactory)
+        {
+            if (logEvent == null) throw new ArgumentNullException(nameof(logEvent));
+            if (propertyFactory == null) throw new ArgumentNullException(nameof(propertyFactory));
+
+            var property = propertyFactory.CreateProperty(_name, _value(), _destructureObjects);
+            logEvent.AddPropertyIfAbsent(property);
+        }
+    }
+}


### PR DESCRIPTION
I logged an issue #1697  but didn't realise how easy it would be to add the functionaility and do a pull request.

I'm not sure how to best test this, especially to make sure it's thread safe.  I've tried the below which both work.

```C#
using Serilog;
using Serilog.Context;

Log.Logger = new LoggerConfiguration()
                    .Enrich.FromLogContext()
                    .WriteTo.Console(formatter: new Serilog.Formatting.Compact.CompactJsonFormatter())
                    .CreateLogger();

var stopWatch = System.Diagnostics.Stopwatch.StartNew();
Func<long> GetMillis = () => stopWatch.ElapsedMilliseconds;

using (LogContext.PushProperty("elapsed", GetMillis))
{
    for (int i = 0; i < 10; i++)
    {
        var t = new System.Threading.Thread(() => {
            Log.Information("Thread attempt {i}", i);
            Thread.Sleep(1000);
        });

        t.Start();
        t.Join();
    }

    for (int i = 0; i < 10; i++)
    {
        await Task.Run(async () =>
        {
            Log.Information("Task attempt {i}", i);
            await Task.Delay(1000);
        });
    }

}

Console.ReadKey();




```