### PR TITLE
Fix #1686 - nullable annotations for PropertyEnricher

### DIFF
--- a/src/Serilog/Core/Enrichers/PropertyEnricher.cs
+++ b/src/Serilog/Core/Enrichers/PropertyEnricher.cs
@@ -24,7 +24,7 @@ namespace Serilog.Core.Enrichers
     public class PropertyEnricher : ILogEventEnricher
     {
         readonly string _name;
-        readonly object _value;
+        readonly object? _value;
         readonly bool _destructureObjects;
 
         /// <summary>
@@ -37,7 +37,7 @@ namespace Serilog.Core.Enrichers
         /// be converted to scalars, which are generally stored as strings.</param>
         /// <exception cref="ArgumentNullException">When <paramref name="name"/> is <code>null</code></exception>
         /// <exception cref="ArgumentException">When <paramref name="name"/> is empty or only contains whitespace</exception>
-        public PropertyEnricher(string name, object value, bool destructureObjects = false)
+        public PropertyEnricher(string name, object? value, bool destructureObjects = false)
         {
             LogEventProperty.EnsureValidName(name);
 

--- a/src/Serilog/Core/ILogEventPropertyFactory.cs
+++ b/src/Serilog/Core/ILogEventPropertyFactory.cs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#nullable enable
+
 using Serilog.Events;
 
 namespace Serilog.Core
@@ -31,6 +33,6 @@ namespace Serilog.Core
         /// then the value will be converted to a structure; otherwise, unknown types will
         /// be converted to scalars, which are generally stored as strings.</param>
         /// <returns>Created <see cref="LogEventProperty"/> instance.</returns>
-        LogEventProperty CreateProperty(string name, object value, bool destructureObjects = false);
+        LogEventProperty CreateProperty(string name, object? value, bool destructureObjects = false);
     }
 }


### PR DESCRIPTION
Fixes https://github.com/serilog/serilog/issues/1686, and preempts a similar issue with `ILogEventPropertyFactory`.

Thanks for reporting this @taspeotis 👍 