### PR TITLE
suppress CheckEolTargetFramework

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,6 +7,7 @@
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>../../assets/Serilog.snk</AssemblyOriginatorKeyFile>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
+    <CheckEolTargetFramework>false</CheckEolTargetFramework>
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="all" />


### PR DESCRIPTION
so we dont get 

```
[NETSDK1138] The target framework 'netcoreapp2.1' is out of support and will not receive security updates in the future. 
Please refer to https://aka.ms/dotnet-core-support for more information about the support policy.
```