### PR TITLE
Initial support for `IAsyncDisposable` sinks

### DIFF
--- a/src/Serilog/Capturing/PropertyValueConverter.cs
+++ b/src/Serilog/Capturing/PropertyValueConverter.cs
@@ -228,7 +228,7 @@ partial class PropertyValueConverter : ILogEventPropertyFactory, ILogEventProper
         return false;
     }
 
-#if ITUPLE
+#if FEATURE_ITUPLE
 
     bool TryConvertValueTuple(object value, Destructuring destructuring, [NotNullWhen(true)] out LogEventPropertyValue? result)
     {
@@ -264,7 +264,7 @@ partial class PropertyValueConverter : ILogEventPropertyFactory, ILogEventProper
         var definition = valueType.GetGenericTypeDefinition();
 
         // Ignore the 8+ value case for now.
-#if VALUETUPLE
+#if FEATURE_VALUETUPLE
         if (definition == typeof(ValueTuple<>) || definition == typeof(ValueTuple<,>) ||
             definition == typeof(ValueTuple<,,>) || definition == typeof(ValueTuple<,,,>) ||
             definition == typeof(ValueTuple<,,,,>) || definition == typeof(ValueTuple<,,,,,>) ||

--- a/src/Serilog/Context/LogContext.cs
+++ b/src/Serilog/Context/LogContext.cs
@@ -37,9 +37,9 @@ namespace Serilog.Context;
 /// (and so is preserved across async/await calls).</remarks>
 public static class LogContext
 {
-#if ASYNCLOCAL
+#if FEATURE_ASYNCLOCAL
     static readonly AsyncLocal<EnricherStack?> Data = new();
-#elif REMOTING
+#elif FEATURE_REMOTING
     static readonly string DataSlotName = typeof(LogContext).FullName + "@" + Guid.NewGuid();
 #else // DOTNET_51
     [ThreadStatic]
@@ -199,7 +199,7 @@ public static class LogContext
         }
     }
 
-#if ASYNCLOCAL
+#if FEATURE_ASYNCLOCAL
 
     static EnricherStack? Enrichers
     {
@@ -207,7 +207,7 @@ public static class LogContext
         set => Data.Value = value;
     }
 
-#elif REMOTING
+#elif FEATURE_REMOTING
 
     static EnricherStack? Enrichers
     {

--- a/src/Serilog/Core/Pipeline/MessageTemplateCache.cs
+++ b/src/Serilog/Core/Pipeline/MessageTemplateCache.cs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if HASHTABLE
+#if FEATURE_HASHTABLE
 #endif
 
 namespace Serilog.Core.Pipeline;
@@ -22,7 +22,7 @@ class MessageTemplateCache : IMessageTemplateParser
     readonly IMessageTemplateParser _innerParser;
     readonly object _templatesLock = new();
 
-#if HASHTABLE
+#if FEATURE_HASHTABLE
     readonly Hashtable _templates = new();
 #else
     readonly Dictionary<string, MessageTemplate> _templates = new();
@@ -43,7 +43,7 @@ class MessageTemplateCache : IMessageTemplateParser
         if (messageTemplate.Length > MaxCachedTemplateLength)
             return _innerParser.Parse(messageTemplate);
 
-#if HASHTABLE
+#if FEATURE_HASHTABLE
         // ReSharper disable once InconsistentlySynchronizedField
         // ignored warning because this is by design
         var result = (MessageTemplate?)_templates[messageTemplate];

--- a/src/Serilog/Core/Pipeline/SilentLogger.cs
+++ b/src/Serilog/Core/Pipeline/SilentLogger.cs
@@ -14,14 +14,8 @@
 
 namespace Serilog.Core.Pipeline;
 
-class SilentLogger : ILogger
+sealed class SilentLogger : ILogger
 {
-    public static readonly ILogger Instance = new SilentLogger();
-
-    SilentLogger()
-    {
-    }
-
     public ILogger ForContext(ILogEventEnricher enricher) => this;
 
     public ILogger ForContext(IEnumerable<ILogEventEnricher> enrichers) => this;

--- a/src/Serilog/Core/Sinks/ConditionalSink.cs
+++ b/src/Serilog/Core/Sinks/ConditionalSink.cs
@@ -14,7 +14,10 @@
 
 namespace Serilog.Core.Sinks;
 
-class ConditionalSink : ILogEventSink, IDisposable
+sealed class ConditionalSink : ILogEventSink, IDisposable
+#if FEATURE_ASYNCDISPOSABLE
+    , IAsyncDisposable
+#endif
 {
     readonly ILogEventSink _wrapped;
     readonly Func<LogEvent, bool> _condition;
@@ -35,4 +38,15 @@ class ConditionalSink : ILogEventSink, IDisposable
     {
         (_wrapped as IDisposable)?.Dispose();
     }
+
+#if FEATURE_ASYNCDISPOSABLE
+    public ValueTask DisposeAsync()
+    {
+        if (_wrapped is IAsyncDisposable asyncDisposable)
+            return asyncDisposable.DisposeAsync();
+
+        Dispose();
+        return default;
+    }
+#endif
 }

--- a/src/Serilog/Core/Sinks/DisposingAggregateSink.cs
+++ b/src/Serilog/Core/Sinks/DisposingAggregateSink.cs
@@ -14,7 +14,7 @@
 
 namespace Serilog.Core.Sinks;
 
-class DisposingAggregateSink : ILogEventSink, IDisposable
+sealed class DisposingAggregateSink : ILogEventSink, IDisposable
 #if FEATURE_ASYNCDISPOSABLE
     , IAsyncDisposable
 #endif

--- a/src/Serilog/Core/Sinks/DisposingAggregateSink.cs
+++ b/src/Serilog/Core/Sinks/DisposingAggregateSink.cs
@@ -74,7 +74,7 @@ sealed class DisposingAggregateSink : ILogEventSink, IDisposable
             {
                 try
                 {
-                    await asyncDisposable.DisposeAsync();
+                    await asyncDisposable.DisposeAsync().ConfigureAwait(false);
                 }
                 catch (Exception ex)
                 {

--- a/src/Serilog/Core/Sinks/RestrictedSink.cs
+++ b/src/Serilog/Core/Sinks/RestrictedSink.cs
@@ -14,7 +14,10 @@
 
 namespace Serilog.Core.Sinks;
 
-class RestrictedSink : ILogEventSink, IDisposable
+sealed class RestrictedSink : ILogEventSink, IDisposable
+#if FEATURE_ASYNCDISPOSABLE
+    , IAsyncDisposable
+#endif
 {
     readonly ILogEventSink _sink;
     readonly LoggingLevelSwitch _levelSwitch;
@@ -39,4 +42,15 @@ class RestrictedSink : ILogEventSink, IDisposable
     {
         (_sink as IDisposable)?.Dispose();
     }
+
+#if FEATURE_ASYNCDISPOSABLE
+    public ValueTask DisposeAsync()
+    {
+        if (_sink is IAsyncDisposable asyncDisposable)
+            return asyncDisposable.DisposeAsync();
+
+        Dispose();
+        return default;
+    }
+#endif
 }

--- a/src/Serilog/GlobalUsings.cs
+++ b/src/Serilog/GlobalUsings.cs
@@ -25,7 +25,7 @@ global using Serilog.Policies;
 global using Serilog.Rendering;
 global using Serilog.Settings.KeyValuePairs;
 
-#if REMOTING
+#if FEATURE_REMOTING
 global using System.Runtime.Remoting;
 global using System.Runtime.Remoting.Lifetime;
 global using System.Runtime.Remoting.Messaging;

--- a/src/Serilog/Log.cs
+++ b/src/Serilog/Log.cs
@@ -33,7 +33,7 @@ namespace Serilog;
 /// </remarks>
 public static class Log
 {
-    static ILogger _logger = SilentLogger.Instance;
+    static ILogger _logger = Serilog.Core.Logger.None;
 
     /// <summary>
     /// The globally-shared logger.
@@ -50,10 +50,22 @@ public static class Log
     /// </summary>
     public static void CloseAndFlush()
     {
-        var logger = Interlocked.Exchange(ref _logger, SilentLogger.Instance);
+        var logger = Interlocked.Exchange(ref _logger, Serilog.Core.Logger.None);
 
         (logger as IDisposable)?.Dispose();
     }
+
+#if FEATURE_ASYNCDISPOSABLE
+    /// <summary>
+    /// Resets <see cref="Logger"/> to the default and disposes the original if possible
+    /// </summary>
+    public static ValueTask CloseAndFlushAsync()
+    {
+        var logger = Interlocked.Exchange(ref _logger, Serilog.Core.Logger.None);
+
+        return (logger as IAsyncDisposable)?.DisposeAsync() ?? default;
+    }
+#endif
 
     /// <summary>
     /// Create a logger that enriches log events via the provided enrichers.

--- a/src/Serilog/LoggerConfiguration.cs
+++ b/src/Serilog/LoggerConfiguration.cs
@@ -172,17 +172,49 @@ public class LoggerConfiguration
             overrideMap = new(_overrides, _minimumLevel, _levelSwitch);
         }
 
-        var disposableSinks = _logEventSinks.Concat(_auditSinks).OfType<IDisposable>().ToArray();
+        var disposableSinks = _logEventSinks
+            .Concat(_auditSinks)
+            .Where(s => s is IDisposable
+#if FEATURE_ASYNCDISPOSABLE
+                or IAsyncDisposable
+#endif
+                )
+            .ToArray();
+
         void Dispose()
         {
             foreach (var disposable in disposableSinks)
             {
-                disposable.Dispose();
+                (disposable as IDisposable)?.Dispose();
             }
         }
 
-        return _levelSwitch == null ?
-            new(processor, _minimumLevel, sink, enricher, Dispose, overrideMap) :
-            new(processor, _levelSwitch, sink, enricher, Dispose, overrideMap);
+#if FEATURE_ASYNCDISPOSABLE
+        async ValueTask DisposeAsync()
+        {
+            foreach (var disposable in disposableSinks)
+            {
+                if (disposable is IAsyncDisposable asyncDisposable)
+                {
+                    await asyncDisposable.DisposeAsync();
+                }
+                else
+                {
+                    ((IDisposable)disposable).Dispose();
+                }
+            }
+        }
+#endif
+
+        return new(
+            processor,
+            _levelSwitch != null ? LevelAlias.Minimum : _minimumLevel, _levelSwitch,
+            sink,
+            enricher,
+            Dispose,
+#if FEATURE_ASYNCDISPOSABLE
+            DisposeAsync,
+#endif
+            overrideMap);
     }
 }

--- a/src/Serilog/LoggerConfiguration.cs
+++ b/src/Serilog/LoggerConfiguration.cs
@@ -196,7 +196,7 @@ public class LoggerConfiguration
             {
                 if (disposable is IAsyncDisposable asyncDisposable)
                 {
-                    await asyncDisposable.DisposeAsync();
+                    await asyncDisposable.DisposeAsync().ConfigureAwait(false);
                 }
                 else
                 {

--- a/src/Serilog/Serilog.csproj
+++ b/src/Serilog/Serilog.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>Simple .NET logging with fully-structured events</Description>
     <VersionPrefix>2.12.0</VersionPrefix>
@@ -15,37 +15,37 @@
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net45' ">
     <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
-    <DefineConstants>$(DefineConstants);REMOTING;HASHTABLE</DefineConstants>
+    <DefineConstants>$(DefineConstants);FEATURE_REMOTING;FEATURE_HASHTABLE</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net46' ">
     <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
-    <DefineConstants>$(DefineConstants);ASYNCLOCAL;HASHTABLE</DefineConstants>
+    <DefineConstants>$(DefineConstants);FEATURE_ASYNCLOCAL;FEATURE_HASHTABLE</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net47' ">
     <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
-    <DefineConstants>$(DefineConstants);ASYNCLOCAL;HASHTABLE;VALUETUPLE</DefineConstants>
+    <DefineConstants>$(DefineConstants);FEATURE_ASYNCLOCAL;FEATURE_HASHTABLE;FEATURE_VALUETUPLE</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
-    <DefineConstants>$(DefineConstants);ASYNCLOCAL;HASHTABLE</DefineConstants>
+    <DefineConstants>$(DefineConstants);FEATURE_ASYNCLOCAL;FEATURE_HASHTABLE</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
-    <DefineConstants>$(DefineConstants);ASYNCLOCAL;HASHTABLE;VALUETUPLE</DefineConstants>
+    <DefineConstants>$(DefineConstants);FEATURE_ASYNCLOCAL;FEATURE_HASHTABLE;FEATURE_VALUETUPLE</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.1' ">
-    <DefineConstants>$(DefineConstants);ASYNCLOCAL;HASHTABLE;FEATURE_DEFAULT_INTERFACE;FEATURE_SPAN;VALUETUPLE</DefineConstants>
+    <DefineConstants>$(DefineConstants);FEATURE_ASYNCLOCAL;FEATURE_HASHTABLE;FEATURE_DEFAULT_INTERFACE;FEATURE_SPAN;FEATURE_VALUETUPLE;FEATURE_ASYNCDISPOSABLE</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net5.0' ">
-    <DefineConstants>$(DefineConstants);ASYNCLOCAL;HASHTABLE;FEATURE_DEFAULT_INTERFACE;FEATURE_SPAN;VALUETUPLE</DefineConstants>
+    <DefineConstants>$(DefineConstants);FEATURE_ASYNCLOCAL;FEATURE_HASHTABLE;FEATURE_DEFAULT_INTERFACE;FEATURE_SPAN;FEATURE_VALUETUPLE;FEATURE_ASYNCDISPOSABLE</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
-    <DefineConstants>$(DefineConstants);ASYNCLOCAL;HASHTABLE;FEATURE_DEFAULT_INTERFACE;FEATURE_SPAN;FEATURE_DATE_AND_TIME_ONLY;VALUETUPLE;ITUPLE</DefineConstants>
+    <DefineConstants>$(DefineConstants);FEATURE_ASYNCLOCAL;FEATURE_HASHTABLE;FEATURE_DEFAULT_INTERFACE;FEATURE_SPAN;FEATURE_DATE_AND_TIME_ONLY;FEATURE_VALUETUPLE;FEATURE_ITUPLE;FEATURE_ASYNCDISPOSABLE</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">

--- a/test/Serilog.Tests/Capturing/PropertyValueConverterTests.cs
+++ b/test/Serilog.Tests/Capturing/PropertyValueConverterTests.cs
@@ -264,7 +264,7 @@ public class PropertyValueConverterTests
         Assert.Equal(typeof(string), pv.LiteralValue());
     }
 
-#if GETCURRENTMETHOD
+#if FEATURE_GETCURRENTMETHOD
     [Fact]
     public void SurvivesDestructuringMethodBase()
     {
@@ -383,7 +383,7 @@ public class PropertyValueConverterTests
             Assert.IsType<SequenceValue>(_converter.CreatePropertyValue(t));
     }
 
-#if !ITUPLE
+#if !FEATURE_ITUPLE
 
     [Fact]
     public void EightPlusValueTupleElementsAreIgnoredByCapturing()

--- a/test/Serilog.Tests/Context/LogContextTests.cs
+++ b/test/Serilog.Tests/Context/LogContextTests.cs
@@ -4,7 +4,7 @@ public class LogContextTests
 {
     static LogContextTests()
     {
-#if REMOTING
+#if FEATURE_REMOTING
         LifetimeServices.LeaseTime = TimeSpan.FromMilliseconds(100);
         LifetimeServices.LeaseManagerPollTime = TimeSpan.FromMilliseconds(10);
 #endif
@@ -12,7 +12,7 @@ public class LogContextTests
 
     public LogContextTests()
     {
-#if REMOTING
+#if FEATURE_REMOTING
         // ReSharper disable AssignNullToNotNullAttribute
         CallContext.LogicalSetData(typeof(LogContext).FullName, null);
         // ReSharper restore AssignNullToNotNullAttribute
@@ -251,7 +251,7 @@ public class LogContextTests
         }
     }
 
-#if APPDOMAIN
+#if TEST_FEATURE_APPDOMAIN
     // Must not actually try to pass context across domains,
     // since user property types may not be serializable.
     [Fact]
@@ -277,7 +277,7 @@ public class LogContextTests
     }
 #endif
 
-#if APPDOMAIN && REMOTING
+#if TEST_FEATURE_APPDOMAIN && FEATURE_REMOTING
     [Fact]
     public void DoesNotThrowOnCrossDomainCallsWhenLeaseExpired()
     {
@@ -363,7 +363,7 @@ public class LogContextTests
     }
 }
 
-#if REMOTING
+#if FEATURE_REMOTING
 class InMemoryRemoteObjectTracker : ITrackingHandler
 {
     public int DisconnectCount { get; set; }
@@ -376,7 +376,7 @@ class InMemoryRemoteObjectTracker : ITrackingHandler
 }
 #endif
 
-#if APPDOMAIN
+#if TEST_FEATURE_APPDOMAIN
 public class RemotelyCallable : MarshalByRefObject
 {
     public bool IsCallable()

--- a/test/Serilog.Tests/Core/ChildLoggerKnownLimitationsTests.cs
+++ b/test/Serilog.Tests/Core/ChildLoggerKnownLimitationsTests.cs
@@ -137,7 +137,7 @@ public class ChildLoggerKnownLimitationsTests
     [Theory]
     [MemberData(nameof(GetMinimumLevelOverrideInheritanceTestCases))]
     public void WriteToLoggerMinimumLevelOverrideInheritanceNotSupportedScenarios(
-        string rootOverrideSource,
+        string? rootOverrideSource,
         int rootOverrideLevelIncrement,
         string? childOverrideSource,
         int childOverrideLevelIncrement)

--- a/test/Serilog.Tests/Core/ChildLoggerTests.cs
+++ b/test/Serilog.Tests/Core/ChildLoggerTests.cs
@@ -140,7 +140,7 @@ public class ChildLoggerTests
         // Visualizing the pipeline from left to right ....
         //
         //   Event  --> Root Logger --> Child Logger -> YES or
-        //    lvl       override/lvl    override/levl     NO ?
+        //    lvl       override/lvl    override/lvl     NO ?
         //
         static object?[] T(string? rs, int? rl, string? cs, int? cl, bool r, LogEventLevel dl = LevelAlias.Minimum)
         {
@@ -194,7 +194,7 @@ public class ChildLoggerTests
         int childOverrideLevelIncrement,
         bool eventShouldGetToChild)
     {
-        var incomingEventLevel = Information;
+        const LogEventLevel incomingEventLevel = Information;
         var rootOverrideLevel = incomingEventLevel + rootOverrideLevelIncrement;
         var childOverrideLevel = incomingEventLevel + childOverrideLevelIncrement;
 
@@ -244,7 +244,7 @@ public class ChildLoggerTests
         int childOverrideLevelIncrement,
         bool eventShouldGetToChild)
     {
-        var incomingEventLevel = Information;
+        const LogEventLevel incomingEventLevel = Information;
         var rootOverrideLevel = incomingEventLevel + rootOverrideLevelIncrement;
         var childOverrideLevel = incomingEventLevel + childOverrideLevelIncrement;
 

--- a/test/Serilog.Tests/Core/LoggerTests.cs
+++ b/test/Serilog.Tests/Core/LoggerTests.cs
@@ -374,5 +374,18 @@ public class LoggerTests
         Assert.True(sinkB.IsDisposedAsync);
     }
 
+    [Fact]
+    public async Task RestrictedSinksAreDisposedAsyncWhenLoggerIsDisposedAsync()
+    {
+        var sink = new AsyncDisposeTrackingSink();
+        var logger = new LoggerConfiguration()
+            .WriteTo.Sink(sink, Error)
+            .CreateLogger();
+
+        await logger.DisposeAsync();
+
+        Assert.True(sink.IsDisposedAsync);
+    }
+
 #endif
 }

--- a/test/Serilog.Tests/Core/LoggerTests.cs
+++ b/test/Serilog.Tests/Core/LoggerTests.cs
@@ -259,4 +259,120 @@ public class LoggerTests
         Assert.True(sinkA.IsDisposed);
         Assert.True(sinkB.IsDisposed);
     }
+
+#if FEATURE_ASYNCDISPOSABLE
+
+    [Fact]
+    public async Task ASingleSinkIsDisposedWhenLoggerIsDisposedAsync()
+    {
+        var sink = new DisposeTrackingSink();
+        var log = new LoggerConfiguration()
+            .WriteTo.Sink(sink)
+            .CreateLogger();
+
+        await log.DisposeAsync();
+
+        Assert.True(sink.IsDisposed);
+    }
+
+    [Fact]
+    public void ASingleAsyncSinkIsDisposedWhenLoggerIsDisposed()
+    {
+        var sink = new DisposeTrackingSink();
+        var log = new LoggerConfiguration()
+            .WriteTo.Sink(sink)
+            .CreateLogger();
+
+        log.Dispose();
+
+        Assert.True(sink.IsDisposed);
+    }
+
+    [Fact]
+    public async Task ASingleAsyncSinkIsDisposedWhenLoggerIsDisposedAsync()
+    {
+        var sink = new AsyncDisposeTrackingSink();
+        var log = new LoggerConfiguration()
+            .WriteTo.Sink(sink)
+            .CreateLogger();
+
+        await log.DisposeAsync();
+
+        Assert.True(sink.IsDisposedAsync);
+    }
+
+    [Fact]
+    public async Task AggregatedSinksAreDisposedWhenLoggerIsDisposedAsync()
+    {
+        var sinkA = new DisposeTrackingSink();
+        var sinkB = new DisposeTrackingSink();
+        var log = new LoggerConfiguration()
+            .WriteTo.Sink(sinkA)
+            .WriteTo.Sink(sinkB)
+            .CreateLogger();
+
+        await log.DisposeAsync();
+
+        Assert.True(sinkA.IsDisposed);
+        Assert.True(sinkB.IsDisposed);
+    }
+
+    [Fact]
+    public async Task AggregatedAsyncSinksAreDisposedWhenLoggerIsDisposedAsync()
+    {
+        var sinkA = new DisposeTrackingSink();
+        var sinkB = new AsyncDisposeTrackingSink();
+        var log = new LoggerConfiguration()
+            .WriteTo.Sink(sinkA)
+            .WriteTo.Sink(sinkB)
+            .CreateLogger();
+
+        await log.DisposeAsync();
+
+        Assert.True(sinkA.IsDisposed);
+        Assert.True(sinkB.IsDisposedAsync);
+    }
+
+    [Fact]
+    public async Task WrappedSinksAreDisposedWhenLoggerIsDisposedAsync()
+    {
+        var sink = new DisposeTrackingSink();
+        var log = new LoggerConfiguration()
+            .WriteTo.Dummy(wrapped => wrapped.Sink(sink))
+            .CreateLogger();
+
+        await log.DisposeAsync();
+
+        Assert.True(sink.IsDisposed);
+    }
+
+    [Fact]
+    public async Task WrappedAsyncSinksAreDisposedWhenLoggerIsDisposedAsync()
+    {
+        var sink = new AsyncDisposeTrackingSink();
+        var log = new LoggerConfiguration()
+            .WriteTo.Dummy(wrapped => wrapped.Sink(sink))
+            .CreateLogger();
+
+        await log.DisposeAsync();
+
+        Assert.True(sink.IsDisposedAsync);
+    }
+
+    [Fact]
+    public async Task WrappedAggregatedAsyncSinksAreDisposedWhenLoggerIsDisposedAsync()
+    {
+        var sinkA = new DisposeTrackingSink();
+        var sinkB = new AsyncDisposeTrackingSink();
+        var log = new LoggerConfiguration()
+            .WriteTo.Dummy(wrapped => wrapped.Sink(sinkA).WriteTo.Sink(sinkB))
+            .CreateLogger();
+
+        await log.DisposeAsync();
+
+        Assert.True(sinkA.IsDisposed);
+        Assert.True(sinkB.IsDisposedAsync);
+    }
+
+#endif
 }

--- a/test/Serilog.Tests/GlobalUsings.cs
+++ b/test/Serilog.Tests/GlobalUsings.cs
@@ -31,7 +31,7 @@ global using Xunit;
 global using Xunit.Sdk;
 global using static Serilog.Events.LogEventLevel;
 
-#if REMOTING
+#if FEATURE_REMOTING
 global using System.Runtime.Remoting;
 global using System.Runtime.Remoting.Lifetime;
 global using System.Runtime.Remoting.Messaging;

--- a/test/Serilog.Tests/LogTests.cs
+++ b/test/Serilog.Tests/LogTests.cs
@@ -12,7 +12,7 @@ public class LogTests
     }
 
     [Fact]
-    public void DisposesTheLogger()
+    public void CloseAndFlushDisposesTheLogger()
     {
         var disposableLogger = new DisposableLogger();
         Log.Logger = disposableLogger;
@@ -21,10 +21,31 @@ public class LogTests
     }
 
     [Fact]
-    public void ResetsLoggerToSilentLogger()
+    public void CloseAndFlushResetsLoggerToSilentLogger()
     {
         Log.Logger = new DisposableLogger();
         Log.CloseAndFlush();
         Assert.IsType<SilentLogger>(Log.Logger);
     }
+
+#if FEATURE_ASYNCDISPOSABLE
+
+    [Fact]
+    public async Task CloseAndFlushAsyncDisposesTheLogger()
+    {
+        var disposableLogger = new DisposableLogger();
+        Log.Logger = disposableLogger;
+        await Log.CloseAndFlushAsync();
+        Assert.True(disposableLogger.Disposed);
+    }
+
+    [Fact]
+    public async Task CloseAndFlushAsyncResetsLoggerToSilentLogger()
+    {
+        Log.Logger = new DisposableLogger();
+        await Log.CloseAndFlushAsync();
+        Assert.IsType<SilentLogger>(Log.Logger);
+    }
+
+#endif
 }

--- a/test/Serilog.Tests/LogTests.cs
+++ b/test/Serilog.Tests/LogTests.cs
@@ -17,7 +17,7 @@ public class LogTests
         var disposableLogger = new DisposableLogger();
         Log.Logger = disposableLogger;
         Log.CloseAndFlush();
-        Assert.True(disposableLogger.Disposed);
+        Assert.True(disposableLogger.IsDisposed);
     }
 
     [Fact]
@@ -36,7 +36,7 @@ public class LogTests
         var disposableLogger = new DisposableLogger();
         Log.Logger = disposableLogger;
         await Log.CloseAndFlushAsync();
-        Assert.True(disposableLogger.Disposed);
+        Assert.True(disposableLogger.IsDisposedAsync);
     }
 
     [Fact]

--- a/test/Serilog.Tests/LoggerConfigurationTests.cs
+++ b/test/Serilog.Tests/LoggerConfigurationTests.cs
@@ -749,6 +749,21 @@ public class LoggerConfigurationTests
         Assert.Equal(Warning, evt.Level);
     }
 
+#if FEATURE_ASYNCDISPOSABLE
+    [Fact]
+    public async Task ConditionalSinksAreDisposedAsyncWithLogger()
+    {
+        var sink = new AsyncDisposeTrackingSink();
+        var logger = new LoggerConfiguration()
+            .WriteTo.Conditional(_ => true, w => w.Sink(sink))
+            .CreateLogger();
+
+        await logger.DisposeAsync();
+
+        Assert.True(sink.IsDisposedAsync);
+    }
+#endif
+
     [Fact]
     public void EnrichersCanBeWrapped()
     {

--- a/test/Serilog.Tests/MethodOverloadConventionTests.cs
+++ b/test/Serilog.Tests/MethodOverloadConventionTests.cs
@@ -1042,7 +1042,7 @@ public class MethodOverloadConventionTests
         }
 
         if (loggerType == typeof(SilentLogger))
-            return SilentLogger.Instance;
+            return new SilentLogger();
 
         throw new ArgumentException($"Logger Type of {loggerType} is not supported");
     }

--- a/test/Serilog.Tests/Serilog.Tests.csproj
+++ b/test/Serilog.Tests/Serilog.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;net5.0;netcoreapp3.1;netcoreapp2.1;net452;net46;net48</TargetFrameworks>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
@@ -20,24 +20,24 @@
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net452' ">
-    <DefineConstants>$(DefineConstants);APPDOMAIN;REMOTING;GETCURRENTMETHOD</DefineConstants>
+    <DefineConstants>$(DefineConstants);TEST_FEATURE_APPDOMAIN;FEATURE_REMOTING;FEATURE_GETCURRENTMETHOD</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net46' ">
-    <DefineConstants>$(DefineConstants);APPDOMAIN;ASYNCLOCAL;GETCURRENTMETHOD</DefineConstants>
+    <DefineConstants>$(DefineConstants);TEST_FEATURE_APPDOMAIN;FEATURE_ASYNCLOCAL;FEATURE_GETCURRENTMETHOD</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net48' ">
-    <DefineConstants>$(DefineConstants);APPDOMAIN;ASYNCLOCAL;GETCURRENTMETHOD</DefineConstants>
+    <DefineConstants>$(DefineConstants);TEST_FEATURE_APPDOMAIN;FEATURE_ASYNCLOCAL;FEATURE_GETCURRENTMETHOD</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.1' ">
-    <DefineConstants>$(DefineConstants);ASYNCLOCAL</DefineConstants>
+    <DefineConstants>$(DefineConstants);FEATURE_ASYNCLOCAL</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
-    <DefineConstants>$(DefineConstants);ASYNCLOCAL;FEATURE_DEFAULT_INTERFACE;FEATURE_SPAN</DefineConstants>
+    <DefineConstants>$(DefineConstants);FEATURE_ASYNCLOCAL;FEATURE_DEFAULT_INTERFACE;FEATURE_SPAN;FEATURE_ASYNCDISPOSABLE</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net5.0' ">
-    <DefineConstants>$(DefineConstants);ASYNCLOCAL;FEATURE_DEFAULT_INTERFACE;FEATURE_SPAN</DefineConstants>
+    <DefineConstants>$(DefineConstants);FEATURE_ASYNCLOCAL;FEATURE_DEFAULT_INTERFACE;FEATURE_SPAN;FEATURE_ASYNCDISPOSABLE</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
-    <DefineConstants>$(DefineConstants);ASYNCLOCAL;FEATURE_DEFAULT_INTERFACE;FEATURE_SPAN;FEATURE_DATE_AND_TIME_ONLY;ITUPLE</DefineConstants>
+    <DefineConstants>$(DefineConstants);FEATURE_ASYNCLOCAL;FEATURE_DEFAULT_INTERFACE;FEATURE_SPAN;FEATURE_DATE_AND_TIME_ONLY;FEATURE_ITUPLE;FEATURE_ASYNCDISPOSABLE</DefineConstants>
   </PropertyGroup>
 </Project>

--- a/test/Serilog.Tests/Support/AsyncDisposeTrackingSink.cs
+++ b/test/Serilog.Tests/Support/AsyncDisposeTrackingSink.cs
@@ -1,0 +1,27 @@
+#if FEATURE_ASYNCDISPOSABLE
+
+namespace Serilog.Tests.Support;
+
+sealed class AsyncDisposeTrackingSink : ILogEventSink, IDisposable, IAsyncDisposable
+{
+    public bool IsDisposed { get; set; }
+    public bool IsDisposedAsync { get; set; }
+
+    public void Emit(LogEvent logEvent)
+    {
+    }
+
+    public void Dispose()
+    {
+        IsDisposed = true;
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        Dispose();
+        IsDisposedAsync = true;
+        return default;
+    }
+}
+
+#endif

--- a/test/Serilog.Tests/Support/DisposableLogger.cs
+++ b/test/Serilog.Tests/Support/DisposableLogger.cs
@@ -3,13 +3,26 @@
 namespace Serilog.Tests.Support;
 
 public class DisposableLogger : ILogger, IDisposable
+#if FEATURE_ASYNCDISPOSABLE
+    , IAsyncDisposable
+#endif
 {
-    public bool Disposed { get; set; }
+    public bool IsDisposed { get; set; }
+    public bool IsDisposedAsync { get; set; }
 
     public void Dispose()
     {
-        Disposed = true;
+        IsDisposed = true;
     }
+
+#if FEATURE_ASYNCDISPOSABLE
+    public ValueTask DisposeAsync()
+    {
+        Dispose();
+        IsDisposedAsync = true;
+        return default;
+    }
+#endif
 
     public ILogger ForContext(ILogEventEnricher enricher)
     {

--- a/test/Serilog.Tests/Support/DisposeTrackingSink.cs
+++ b/test/Serilog.Tests/Support/DisposeTrackingSink.cs
@@ -1,6 +1,6 @@
 ﻿namespace Serilog.Tests.Support;
 
-class DisposeTrackingSink : ILogEventSink, IDisposable
+sealed class DisposeTrackingSink : ILogEventSink, IDisposable
 {
     public bool IsDisposed { get; set; }
 


### PR DESCRIPTION
Resolves https://github.com/serilog/serilog/issues/1749

This is admittedly very heavy on `#if`. We may be able to do better by polyfilling `IAsyncDisposable` and `ValueTask` for older platforms - keen to explore this, too.

Gets some tests and feature flags in place, though, which should be a good start. Eyes appreciated :-)