### PR TITLE
Enables updating the configured min-level overrides at runtime

### DIFF
--- a/src/Serilog/Configuration/LoggerMinimumLevelConfiguration.cs
+++ b/src/Serilog/Configuration/LoggerMinimumLevelConfiguration.cs
@@ -22,15 +22,15 @@ public class LoggerMinimumLevelConfiguration
     readonly LoggerConfiguration _loggerConfiguration;
     readonly Action<LogEventLevel> _setMinimum;
     readonly Action<LoggingLevelSwitch> _setLevelSwitch;
-    readonly Action<string, LoggingLevelSwitch> _addOverride;
+    readonly LevelOverrideMapWrapper _wrapper;
 
     internal LoggerMinimumLevelConfiguration(LoggerConfiguration loggerConfiguration, Action<LogEventLevel> setMinimum,
-        Action<LoggingLevelSwitch> setLevelSwitch, Action<string, LoggingLevelSwitch> addOverride)
+        Action<LoggingLevelSwitch> setLevelSwitch, LevelOverrideMapWrapper wrapper)
     {
         _loggerConfiguration = Guard.AgainstNull(loggerConfiguration);
         _setMinimum = Guard.AgainstNull(setMinimum);
         _setLevelSwitch = setLevelSwitch;
-        _addOverride = Guard.AgainstNull(addOverride);
+        _wrapper = Guard.AgainstNull(wrapper);
     }
 
     /// <summary>
@@ -113,15 +113,12 @@ public class LoggerMinimumLevelConfiguration
     /// <exception cref="ArgumentNullException">When <paramref name="levelSwitch"/> is <code>null</code></exception>
     public LoggerConfiguration Override(string source, LoggingLevelSwitch levelSwitch)
     {
-        Guard.AgainstNull(source);
-        Guard.AgainstNull(levelSwitch);
-
-        var trimmed = source.Trim();
-        if (trimmed.Length == 0) throw new ArgumentException($"A source {nameof(source)} must be provided.", nameof(source));
-
-        _addOverride(trimmed, levelSwitch);
+        Overrides.Add(source, levelSwitch);
         return _loggerConfiguration;
     }
+
+    /// <summary/>
+    public LoggerMinimumLevelOverridesConfiguration Overrides  => new(_loggerConfiguration, _wrapper);
 
     /// <summary>
     /// Override the minimum level for events from a specific namespace or type name.

--- a/src/Serilog/Configuration/LoggerMinimumLevelOverridesConfiguration.cs
+++ b/src/Serilog/Configuration/LoggerMinimumLevelOverridesConfiguration.cs
@@ -1,0 +1,48 @@
+namespace Serilog.Configuration;
+
+/// <summary/>
+public class LoggerMinimumLevelOverridesConfiguration
+{
+    readonly LoggerConfiguration _loggerConfiguration;
+    readonly LevelOverrideMapWrapper _wrapper;
+
+    internal LoggerMinimumLevelOverridesConfiguration(LoggerConfiguration loggerConfiguration, LevelOverrideMapWrapper wrapper)
+    {
+        _loggerConfiguration = Guard.AgainstNull(loggerConfiguration);
+        _wrapper = Guard.AgainstNull(wrapper);
+    }
+
+    /// <summary/>
+    public LoggerConfiguration Add(string source, LoggingLevelSwitch levelSwitch)
+    {
+        Guard.AgainstNull(source);
+        Guard.AgainstNull(levelSwitch);
+
+        var trimmed = source.Trim();
+        if (trimmed.Length == 0) throw new ArgumentException($"A {nameof(source)} must be provided.", nameof(source));
+
+        _wrapper.Add(trimmed, levelSwitch);
+
+        return _loggerConfiguration;
+    }
+
+    /// <summary/>
+    public LoggerConfiguration Set(IDictionary<string, LoggingLevelSwitch> overrides)
+    {
+        Guard.AgainstNull(overrides);
+
+        Dictionary<string, LoggingLevelSwitch> trimmedOverrides = new();
+
+        foreach (var levelOverride in overrides)
+        {
+            var trimmed = levelOverride.Key.Trim();
+            if (trimmed.Length == 0) throw new ArgumentException("A source must be provided.", nameof(overrides));
+
+            trimmedOverrides.Add(trimmed, levelOverride.Value);
+        }
+
+        _wrapper.Replace(trimmedOverrides);
+
+        return _loggerConfiguration;
+    }
+}

--- a/src/Serilog/Core/LevelOverrideMap.cs
+++ b/src/Serilog/Core/LevelOverrideMap.cs
@@ -57,6 +57,11 @@ class LevelOverrideMap
             .ToArray();
     }
 
+    internal LevelOverrideMap WithOverrides(IDictionary<string, LoggingLevelSwitch> overrides)
+    {
+        return new LevelOverrideMap(overrides, _defaultMinimumLevel, _defaultLevelSwitch);
+    }
+
     public void GetEffectiveLevel(
 #if FEATURE_SPAN
         ReadOnlySpan<char> context,

--- a/src/Serilog/Core/LevelOverrideMapWrapper.cs
+++ b/src/Serilog/Core/LevelOverrideMapWrapper.cs
@@ -7,6 +7,8 @@ class LevelOverrideMapWrapper
 
     public LevelOverrideMap? Map => _map;
 
+    public event EventHandler? OverridesChanged;
+
     public void Add(string source, LoggingLevelSwitch levelSwitch)
     {
         _overrides[source] = levelSwitch;
@@ -22,6 +24,7 @@ class LevelOverrideMapWrapper
     public void RefreshMap()
     {
         _map = _map?.WithOverrides(_overrides);
+        OverridesChanged?.Invoke(this, EventArgs.Empty);
     }
 
     public void EnsureMap(LogEventLevel defaultMinimumLevel, LoggingLevelSwitch? defaultLevelSwitch)

--- a/src/Serilog/Core/LevelOverrideMapWrapper.cs
+++ b/src/Serilog/Core/LevelOverrideMapWrapper.cs
@@ -1,0 +1,34 @@
+namespace Serilog.Core;
+
+class LevelOverrideMapWrapper
+{
+    volatile LevelOverrideMap? _map;
+    IDictionary<string, LoggingLevelSwitch> _overrides = new Dictionary<string, LoggingLevelSwitch>();
+
+    public LevelOverrideMap? Map => _map;
+
+    public void Add(string source, LoggingLevelSwitch levelSwitch)
+    {
+        _overrides[source] = levelSwitch;
+        RefreshMap();
+    }
+
+    public void Replace(IDictionary<string, LoggingLevelSwitch> overrides)
+    {
+        _overrides = overrides;
+        RefreshMap();
+    }
+
+    public void RefreshMap()
+    {
+        _map = _map?.WithOverrides(_overrides);
+    }
+
+    public void EnsureMap(LogEventLevel defaultMinimumLevel, LoggingLevelSwitch? defaultLevelSwitch)
+    {
+        if (_overrides.Count > 0)
+        {
+            _map = new LevelOverrideMap(_overrides, defaultMinimumLevel, defaultLevelSwitch);
+        }
+    }
+}

--- a/src/Serilog/Core/Logger.cs
+++ b/src/Serilog/Core/Logger.cs
@@ -44,7 +44,7 @@ public sealed class Logger : ILogger, ILogEventSink, IDisposable
     // to its lower limit and fall through to the secondary check.
     readonly LogEventLevel _minimumLevel;
     readonly LoggingLevelSwitch? _levelSwitch;
-    readonly LevelOverrideMap? _overrideMap;
+    readonly LevelOverrideMapWrapper _overrideMap;
 
     internal Logger(
         MessageTemplateProcessor messageTemplateProcessor,
@@ -56,7 +56,7 @@ public sealed class Logger : ILogger, ILogEventSink, IDisposable
 #if FEATURE_ASYNCDISPOSABLE
         Func<ValueTask>? disposeAsync,
 #endif
-        LevelOverrideMap? overrideMap)
+        LevelOverrideMapWrapper overrideMap)
     {
         _messageTemplateProcessor = messageTemplateProcessor;
         _minimumLevel = minimumLevel;
@@ -70,7 +70,7 @@ public sealed class Logger : ILogger, ILogEventSink, IDisposable
         _enricher = enricher;
     }
 
-    internal bool HasOverrideMap => _overrideMap != null;
+    internal bool HasOverrideMap => _overrideMap.Map != null;
 
     /// <summary>
     /// Create a logger that enriches log events via the provided enrichers.
@@ -131,10 +131,10 @@ public sealed class Logger : ILogger, ILogEventSink, IDisposable
 
         var minimumLevel = _minimumLevel;
         var levelSwitch = _levelSwitch;
-        if (_overrideMap != null && propertyName == Constants.SourceContextPropertyName)
+        if (_overrideMap.Map != null && propertyName == Constants.SourceContextPropertyName)
         {
             if (value is string context)
-                _overrideMap.GetEffectiveLevel(context, out minimumLevel, out levelSwitch);
+                _overrideMap.Map.GetEffectiveLevel(context, out minimumLevel, out levelSwitch);
         }
 
         return new Logger(

--- a/src/Serilog/LoggerConfiguration.cs
+++ b/src/Serilog/LoggerConfiguration.cs
@@ -211,6 +211,7 @@ public class LoggerConfiguration
 #if FEATURE_ASYNCDISPOSABLE
             DisposeAsync,
 #endif
-            _overrideWrapper);
+            _overrideWrapper,
+            null);
     }
 }

--- a/src/Serilog/LoggerConfiguration.cs
+++ b/src/Serilog/LoggerConfiguration.cs
@@ -25,7 +25,7 @@ public class LoggerConfiguration
     readonly List<ILogEventFilter> _filters = new();
     readonly List<Type> _additionalScalarTypes = new();
     readonly List<IDestructuringPolicy> _additionalDestructuringPolicies = new();
-    readonly Dictionary<string, LoggingLevelSwitch> _overrides = new();
+    readonly LevelOverrideMapWrapper _overrideWrapper = new();
     LogEventLevel _minimumLevel = LogEventLevel.Information;
     LoggingLevelSwitch? _levelSwitch;
     int _maximumDestructuringDepth = 10;
@@ -77,7 +77,7 @@ public class LoggerConfiguration
                     _levelSwitch = null;
                 },
                 sw => _levelSwitch = sw,
-                (s, lls) => _overrides[s] = lls);
+                _overrideWrapper);
         }
     }
 
@@ -166,11 +166,7 @@ public class LoggerConfiguration
                 break;
         }
 
-        LevelOverrideMap? overrideMap = null;
-        if (_overrides.Count != 0)
-        {
-            overrideMap = new(_overrides, _minimumLevel, _levelSwitch);
-        }
+        _overrideWrapper.EnsureMap(_minimumLevel, _levelSwitch);
 
         var disposableSinks = _logEventSinks
             .Concat(_auditSinks)
@@ -215,6 +211,6 @@ public class LoggerConfiguration
 #if FEATURE_ASYNCDISPOSABLE
             DisposeAsync,
 #endif
-            overrideMap);
+            _overrideWrapper);
     }
 }


### PR DESCRIPTION
In response to https://github.com/serilog/serilog-settings-configuration/issues/284#issuecomment-1289664499, this PR shows my attempt to add the ability to replace the set of minimum log level overrides at runtime. The goal is to make it possible to refresh when appsettings.json changes on disk.

My approach attempts to avoid compromising performance or multicore contention at:
https://github.com/serilog/serilog/blob/4d13be50c03e14b6072043799dc7e5dbe4139a19/src/Serilog/Core/LevelOverrideMap.cs#L35-L41
by atomically updating the `LevelOverrideMap` reference with a new snapshot, instead of switching to a concurrent collection.