### PR TITLE
Tokens -> TokenArray

### DIFF
--- a/src/Serilog/Formatting/Json/JsonFormatter.cs
+++ b/src/Serilog/Formatting/Json/JsonFormatter.cs
@@ -133,7 +133,7 @@ public class JsonFormatter : ITextFormatter
         if (logEvent.Properties.Count != 0)
             WriteProperties(logEvent.Properties, output);
 
-        var tokensWithFormat = logEvent.MessageTemplate.Tokens
+        var tokensWithFormat = logEvent.MessageTemplate.TokenArray
             .OfType<PropertyToken>()
             .Where(pt => pt.Format != null)
             .GroupBy(pt => pt.PropertyName)


### PR DESCRIPTION
What do you think about exposing this property in public API? The same problem as in #1769 for Serilog.Sinks.Console: `foreach (var token in template.Tokens) ` usages in `OutputTemplateRenderer`, `PropertiesTokenRenderer` and `ThemedMessageTemplateRenderer`.