### PR TITLE
Major version bump; opens dev for v3 development

### DIFF
--- a/src/Serilog/Serilog.csproj
+++ b/src/Serilog/Serilog.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>Simple .NET logging with fully-structured events</Description>
-    <VersionPrefix>2.12.1</VersionPrefix>
+    <VersionPrefix>3.0.0</VersionPrefix>
     <Authors>Serilog Contributors</Authors>
     <TargetFrameworks>netstandard2.1;netstandard2.0;netstandard1.3;netstandard1.0;net45;net46;net47;net5.0;net6.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>


### PR DESCRIPTION
I believe it's time to give the project a refresh; a new major version is a good marker for this, but I should be clear at the outset we won't be making any ecosystem-splitting breaking changes (all existing sinks, enrichers, and so on should continue to work as before).

In particular, for 3.0 I'm anticipating we:

 * Drop seriously out-of-date framework targets (`netstandard1.x`, and potentially full framework)
 * Drop obsolete APIs or upgrade obsoletions to error rather than warning where sink dependencies may exist
 * Consider behavioral changes currently recorded against the [3.0 milestone](https://github.com/serilog/serilog/milestone/13)

Along with this I think we'd ship a set of _Serilog.Extensions.*_ and _Serilog.AspNetCore_ packages that lock their versions to the framework versions they support.

Plus consider new functionality such as a baked-in `IDiagnosticContext`.