### PR TITLE
remove typeinfo from FindConfigurationMethods

### DIFF
--- a/src/Serilog/Settings/KeyValuePairs/CallableConfigurationMethodFinder.cs
+++ b/src/Serilog/Settings/KeyValuePairs/CallableConfigurationMethodFinder.cs
@@ -20,12 +20,9 @@ static class CallableConfigurationMethodFinder
     {
         var methods = configurationAssemblies
             .SelectMany(a => a.ExportedTypes
-                .Select(t => t.GetTypeInfo())
                 .Where(t => t.IsSealed && t.IsAbstract && !t.IsNested))
-            .SelectMany(t => t.DeclaredMethods)
-            .Where(m => m.IsStatic &&
-                        m.IsPublic &&
-                        m.IsDefined(typeof(ExtensionAttribute), false) &&
+            .SelectMany(t => t.GetMethods(BindingFlags.Static | BindingFlags.Public))
+            .Where(m => m.IsDefined(typeof(ExtensionAttribute), false) &&
                         m.GetParameters()[0].ParameterType == configType)
             .ToList();
 


### PR DESCRIPTION
better perf and simpler code by avoiding the GetTypeInfo and redundant methods included in DeclaredMethods