### PR TITLE
use is Enum for enum check in EnumScalarConversionPolicy

### DIFF
--- a/src/Serilog/Policies/EnumScalarConversionPolicy.cs
+++ b/src/Serilog/Policies/EnumScalarConversionPolicy.cs
@@ -18,7 +18,7 @@ class EnumScalarConversionPolicy : IScalarConversionPolicy
 {
     public bool TryConvertToScalar(object value, [NotNullWhen(true)] out ScalarValue? result)
     {
-        if (value.GetType().IsEnum)
+        if (value is Enum)
         {
             result = new ScalarValue(value);
             return true;


### PR DESCRIPTION
IMO more readable, and makes it consistent with the type checking in other policies