### PR TITLE
simplify build scripts

### DIFF
--- a/Build.ps1
+++ b/Build.ps1
@@ -30,6 +30,6 @@ if($LASTEXITCODE -ne 0) { exit 2 }
 
 Write-Output "build: Testing"
 
-& dotnet test --configuration Release --no-build --no-restore
+& dotnet test  test\Serilog.Tests --configuration Release --no-build --no-restore
 
 if($LASTEXITCODE -ne 0) { exit 3 }

--- a/Build.ps1
+++ b/Build.ps1
@@ -1,15 +1,11 @@
 Write-Output "build: Build started"
 
-& dotnet --info
-
 Push-Location $PSScriptRoot
 
 if(Test-Path .\artifacts) {
     Write-Output "build: Cleaning .\artifacts"
     Remove-Item .\artifacts -Force -Recurse
 }
-
-& dotnet restore --no-cache
 
 $branch = @{ $true = $env:APPVEYOR_REPO_BRANCH; $false = $(git symbolic-ref --short -q HEAD) }[$NULL -ne $env:APPVEYOR_REPO_BRANCH];
 $revision = @{ $true = "{0:00000}" -f [convert]::ToInt32("0" + $env:APPVEYOR_BUILD_NUMBER, 10); $false = "local" }[$NULL -ne $env:APPVEYOR_BUILD_NUMBER];
@@ -20,20 +16,20 @@ $buildSuffix = @{ $true = "$($suffix)-$($commitHash)"; $false = "$($branch)-$($c
 Write-Output "build: Package version suffix is $suffix"
 Write-Output "build: Build version suffix is $buildSuffix"
 
-& dotnet build -configuration Release --version-suffix=$buildSuffix /p:ContinuousIntegrationBuild=true
+& dotnet build --configuration Release --version-suffix=$buildSuffix /p:ContinuousIntegrationBuild=true
 
 if($LASTEXITCODE -ne 0) { exit 1 }
 
 if($suffix) {
-    & dotnet pack -configuration Release --no-build --no-restore -o ..\..\artifacts --version-suffix=$suffix
+    & dotnet pack --configuration Release --no-build --no-restore -o ..\..\artifacts --version-suffix=$suffix
 } else {
-    & dotnet pack -configuration Release --no-build --no-restore -o ..\..\artifacts
+    & dotnet pack --configuration Release --no-build --no-restore -o ..\..\artifacts
 }
 
 if($LASTEXITCODE -ne 0) { exit 2 }
 
 Write-Output "build: Testing"
 
-& dotnet test -configuration Release --no-build --no-restore
+& dotnet test --configuration Release --no-build --no-restore
 
 if($LASTEXITCODE -ne 0) { exit 3 }

--- a/Build.ps1
+++ b/Build.ps1
@@ -21,9 +21,9 @@ Write-Output "build: Build version suffix is $buildSuffix"
 if($LASTEXITCODE -ne 0) { exit 1 }
 
 if($suffix) {
-    & dotnet pack --configuration Release --no-build --no-restore -o ..\..\artifacts --version-suffix=$suffix
+    & dotnet pack src\Serilog --configuration Release --no-build --no-restore -o artifacts --version-suffix=$suffix
 } else {
-    & dotnet pack --configuration Release --no-build --no-restore -o ..\..\artifacts
+    & dotnet pack src\Serilog --configuration Release --no-build --no-restore -o artifacts
 }
 
 if($LASTEXITCODE -ne 0) { exit 2 }

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,7 +5,7 @@
     <LangVersion>latest</LangVersion>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
     <SignAssembly>true</SignAssembly>
-    <AssemblyOriginatorKeyFile>$(SolutionDir)assets/Serilog.snk</AssemblyOriginatorKeyFile>
+    <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)assets/Serilog.snk</AssemblyOriginatorKeyFile>
     <CheckEolTargetFramework>false</CheckEolTargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,7 +5,7 @@
     <LangVersion>latest</LangVersion>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
     <SignAssembly>true</SignAssembly>
-    <AssemblyOriginatorKeyFile>$(SolutionDir)key.snk</AssemblyOriginatorKeyFile>
+    <AssemblyOriginatorKeyFile>$(SolutionDir)assets/key.snk</AssemblyOriginatorKeyFile>
     <CheckEolTargetFramework>false</CheckEolTargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,8 +5,7 @@
     <LangVersion>latest</LangVersion>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
     <SignAssembly>true</SignAssembly>
-    <AssemblyOriginatorKeyFile>../../assets/Serilog.snk</AssemblyOriginatorKeyFile>
-    <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
+    <AssemblyOriginatorKeyFile>$(SolutionDir)key.snk</AssemblyOriginatorKeyFile>
     <CheckEolTargetFramework>false</CheckEolTargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,7 +5,7 @@
     <LangVersion>latest</LangVersion>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
     <SignAssembly>true</SignAssembly>
-    <AssemblyOriginatorKeyFile>$(SolutionDir)assets/key.snk</AssemblyOriginatorKeyFile>
+    <AssemblyOriginatorKeyFile>$(SolutionDir)assets/Serilog.snk</AssemblyOriginatorKeyFile>
     <CheckEolTargetFramework>false</CheckEolTargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/build.sh
+++ b/build.sh
@@ -6,17 +6,8 @@ dotnet --info
 dotnet restore
 
 echo "🤖 Attempting to build..."
-for path in src/**/*.csproj; do
-    dotnet build -c Release ${path}
-done
+
+dotnet build -configuration Release
 
 echo "🤖 Running tests..."
-for path in test/*.Tests/*.csproj; do
-    dotnet test -f netcoreapp2.1 -c Release ${path}
-    dotnet test -f netcoreapp3.1 -c Release ${path}
-    dotnet test -f net5.0 -c Release ${path}
-done
-
-for path in test/*.PerformanceTests/*.PerformanceTests.csproj; do
-    dotnet build -c Release ${path}
-done
+dotnet test --configuration Release --no-build --no-restore

--- a/build.sh
+++ b/build.sh
@@ -2,12 +2,9 @@
 
 set -e
 
-dotnet --info
-dotnet restore
-
 echo "🤖 Attempting to build..."
 
-dotnet build -configuration Release
+dotnet build --configuration Release
 
 echo "🤖 Running tests..."
 dotnet test --configuration Release --no-build --no-restore

--- a/build.sh
+++ b/build.sh
@@ -7,4 +7,4 @@ echo "🤖 Attempting to build..."
 dotnet build --configuration Release
 
 echo "🤖 Running tests..."
-dotnet test --configuration Release --no-build --no-restore
+dotnet test test/Serilog.Tests --configuration Release --no-build --no-restore

--- a/src/Serilog/Serilog.csproj
+++ b/src/Serilog/Serilog.csproj
@@ -3,7 +3,8 @@
     <Description>Simple .NET logging with fully-structured events</Description>
     <VersionPrefix>3.0.0</VersionPrefix>
     <Authors>Serilog Contributors</Authors>
-    <TargetFrameworks>netstandard2.1;netstandard2.0;net462;net471;net5.0;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT'">net462;net471</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworks);netstandard2.1;netstandard2.0;net5.0;net6.0;net7.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageTags>serilog;logging;semantic;structured</PackageTags>
     <PackageIcon>icon.png</PackageIcon>

--- a/test/Serilog.Tests/Serilog.Tests.csproj
+++ b/test/Serilog.Tests/Serilog.Tests.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net7.0;net6.0;net5.0;netcoreapp3.1;netcoreapp2.1;net462;net48</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT'">net462;net48</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworks);net7.0;net6.0;net5.0;netcoreapp3.1;netcoreapp2.1;</TargetFrameworks>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
   </PropertyGroup>
 


### PR DESCRIPTION
 * fixes on mac and linux that we were missing test runs on net7 and net6
 * removes redundant restore = faster CI
 * remove redundant `dotnet --info`. we already get that from the dotnet install script in appveyor.yml
 * avoids extra build+restore that happen when u test if u omit  `--no-build --no-restore` = faster CI
 * less code