### PR TITLE
remove MessageTemplateToken.StartIndex

### DIFF
--- a/src/Serilog/Parsing/MessageTemplateParser.cs
+++ b/src/Serilog/Parsing/MessageTemplateParser.cs
@@ -36,7 +36,7 @@ public class MessageTemplateParser : IMessageTemplateParser
         return new(messageTemplate, Tokenize(messageTemplate));
     }
 
-    static TextToken emptyTextToken = new("", 0);
+    static TextToken emptyTextToken = new("");
 
     static IEnumerable<MessageTemplateToken> Tokenize(string messageTemplate)
     {
@@ -77,7 +77,7 @@ public class MessageTemplateParser : IMessageTemplateParser
         if (startAt == messageTemplate.Length || messageTemplate[startAt] != '}')
         {
             next = startAt;
-            return new TextToken(messageTemplate.Substring(first, next - first), first);
+            return new TextToken(messageTemplate.Substring(first, next - first));
         }
 
         next = startAt + 1;
@@ -85,10 +85,10 @@ public class MessageTemplateParser : IMessageTemplateParser
         var rawText = messageTemplate.Substring(first, next - first);
         var tagContent = rawText.Substring(1, next - (first + 2));
         if (tagContent.Length == 0)
-            return new TextToken(rawText, first);
+            return new TextToken(rawText);
 
         if (!TrySplitTagContent(tagContent, out var propertyNameAndDestructuring, out var format, out var alignment))
-            return new TextToken(rawText, first);
+            return new TextToken(rawText);
 
         var propertyName = propertyNameAndDestructuring;
         var destructuring = Destructuring.Default;
@@ -96,13 +96,13 @@ public class MessageTemplateParser : IMessageTemplateParser
             propertyName = propertyName.Substring(1);
 
         if (propertyName.Length == 0)
-            return new TextToken(rawText, first);
+            return new TextToken(rawText);
 
         for (var i = 0; i < propertyName.Length; ++i)
         {
             var c = propertyName[i];
             if (!IsValidInPropertyName(c))
-                return new TextToken(rawText, first);
+                return new TextToken(rawText);
         }
 
         if (format != null)
@@ -111,7 +111,7 @@ public class MessageTemplateParser : IMessageTemplateParser
             {
                 var c = format[i];
                 if (!IsValidInFormat(c))
-                    return new TextToken(rawText, first);
+                    return new TextToken(rawText);
             }
         }
 
@@ -122,15 +122,15 @@ public class MessageTemplateParser : IMessageTemplateParser
             {
                 var c = alignment[i];
                 if (!IsValidInAlignment(c))
-                    return new TextToken(rawText, first);
+                    return new TextToken(rawText);
             }
 
             var lastDash = alignment.LastIndexOf('-');
             if (lastDash > 0)
-                return new TextToken(rawText, first);
+                return new TextToken(rawText);
 
             if (!int.TryParse(lastDash == -1 ? alignment : alignment.Substring(1), out var width) || width == 0)
-                return new TextToken(rawText, first);
+                return new TextToken(rawText);
 
             var direction = lastDash == -1 ?
                 AlignmentDirection.Right :
@@ -144,8 +144,7 @@ public class MessageTemplateParser : IMessageTemplateParser
             rawText,
             format,
             alignmentValue,
-            destructuring,
-            first);
+            destructuring);
     }
 
     static bool TrySplitTagContent(string tagContent, [NotNullWhen(true)] out string? propertyNameAndDestructuring, out string? format, out string? alignment)
@@ -251,8 +250,6 @@ public class MessageTemplateParser : IMessageTemplateParser
 
     static TextToken ParseTextToken(int startAt, string messageTemplate, out int next)
     {
-        var first = startAt;
-
         var accum = new StringBuilder();
         do
         {
@@ -287,6 +284,6 @@ public class MessageTemplateParser : IMessageTemplateParser
         } while (startAt < messageTemplate.Length);
 
         next = startAt;
-        return new(accum.ToString(), first);
+        return new(accum.ToString());
     }
 }

--- a/src/Serilog/Parsing/MessageTemplateToken.cs
+++ b/src/Serilog/Parsing/MessageTemplateToken.cs
@@ -20,21 +20,6 @@ namespace Serilog.Parsing;
 public abstract class MessageTemplateToken
 {
     /// <summary>
-    /// Construct a <see cref="MessageTemplateToken"/>.
-    /// </summary>
-    /// <param name="startIndex">The token's start index in the template.</param>
-    protected MessageTemplateToken(int startIndex)
-    {
-        StartIndex = startIndex;
-    }
-
-    /// <summary>
-    /// The token's start index in the template.
-    /// </summary>
-    // ReSharper disable once UnusedAutoPropertyAccessor.Global
-    public int StartIndex { get; }
-
-    /// <summary>
     /// The token's length.
     /// </summary>
     public abstract int Length { get; }

--- a/src/Serilog/Parsing/PropertyToken.cs
+++ b/src/Serilog/Parsing/PropertyToken.cs
@@ -32,7 +32,6 @@ public sealed class PropertyToken : MessageTemplateToken
     /// <exception cref="ArgumentNullException">When <paramref name="propertyName"/> is <code>null</code></exception>
     /// <exception cref="ArgumentNullException">When <paramref name="rawText"/> is <code>null</code></exception>
     public PropertyToken(string propertyName, string rawText, string? format = null, in Alignment? alignment = null, Destructuring destructuring = Destructuring.Default)
-        : base(startIndex)
     {
         PropertyName = Guard.AgainstNull(propertyName);
         Format = format;

--- a/src/Serilog/Parsing/PropertyToken.cs
+++ b/src/Serilog/Parsing/PropertyToken.cs
@@ -29,11 +29,9 @@ public sealed class PropertyToken : MessageTemplateToken
     /// <param name="format">The format applied to the property, if any.</param>
     /// <param name="alignment">The alignment applied to the property, if any.</param>
     /// <param name="destructuring">The destructuring strategy applied to the property, if any.</param>
-    /// <param name="startIndex">The token's start index in the template.</param>
     /// <exception cref="ArgumentNullException">When <paramref name="propertyName"/> is <code>null</code></exception>
     /// <exception cref="ArgumentNullException">When <paramref name="rawText"/> is <code>null</code></exception>
-    public PropertyToken(string propertyName, string rawText, string? format = null, Alignment? alignment = null, Destructuring destructuring = Destructuring.Default, int startIndex = -1)
-        : base(startIndex)
+    public PropertyToken(string propertyName, string rawText, string? format = null, Alignment? alignment = null, Destructuring destructuring = Destructuring.Default)
     {
         PropertyName = Guard.AgainstNull(propertyName);
         Format = format;

--- a/src/Serilog/Parsing/TextToken.cs
+++ b/src/Serilog/Parsing/TextToken.cs
@@ -23,10 +23,8 @@ public sealed class TextToken : MessageTemplateToken
     /// Construct a <see cref="TextToken"/>.
     /// </summary>
     /// <param name="text">The text of the token.</param>
-    /// <param name="startIndex">The token's start index in the template.</param>
     /// <exception cref="ArgumentNullException">When <paramref name="text"/> is <code>null</code></exception>
-    public TextToken(string text, int startIndex = -1)
-        : base(startIndex)
+    public TextToken(string text)
     {
         Text = Guard.AgainstNull(text);
     }

--- a/test/Serilog.Tests/Parsing/MessageTemplateParserTests.cs
+++ b/test/Serilog.Tests/Parsing/MessageTemplateParserTests.cs
@@ -32,7 +32,6 @@ public class MessageTemplateParserTests
         var tt = Assert.IsType<TextToken>(mt);
         Assert.Equal("", tt.Text);
         Assert.Equal("", tt.ToString());
-        Assert.Equal(0, tt.StartIndex);
         Assert.Equal(0, tt.Length);
     }
 
@@ -44,7 +43,6 @@ public class MessageTemplateParserTests
         var tt = Assert.IsType<TextToken>(mt);
         Assert.Equal("{}", tt.Text);
         Assert.Equal("{}", tt.ToString());
-        Assert.Equal(0, tt.StartIndex);
         Assert.Equal(2, tt.Length);
     }
 
@@ -181,31 +179,26 @@ public class MessageTemplateParserTests
         Assert.Equal("0", prop1.PropertyName);
         Assert.Equal("{0}", prop1.RawText);
         Assert.True(prop1.IsPositional);
-        Assert.Equal(0, prop1.StartIndex);
         Assert.Equal(3, prop1.Length);
 
         var prop2 = (TextToken)parsed[1];
         Assert.Equal(", ", prop2.Text);
-        Assert.Equal(3, prop2.StartIndex);
         Assert.Equal(2, prop2.Length);
 
         var prop3 = (PropertyToken)parsed[2];
         Assert.Equal("1", prop3.PropertyName);
         Assert.Equal("{1}", prop3.RawText);
         Assert.True(prop3.IsPositional);
-        Assert.Equal(5, prop3.StartIndex);
         Assert.Equal(3, prop3.Length);
 
         var prop4 = (TextToken)parsed[3];
         Assert.Equal(", ", prop4.Text);
-        Assert.Equal(8, prop4.StartIndex);
         Assert.Equal(2, prop4.Length);
 
         var prop5 = (PropertyToken)parsed[4];
         Assert.Equal("2", prop5.PropertyName);
         Assert.Equal("{2}", prop5.RawText);
         Assert.True(prop5.IsPositional);
-        Assert.Equal(10, prop5.StartIndex);
         Assert.Equal(3, prop5.Length);
     }
 
@@ -373,9 +366,9 @@ public class MessageTemplateParserTests
     {
         AssertParsedAs("{Greeting}, {Name}!",
             new PropertyToken("Greeting", "{Greeting}"),
-            new TextToken(", ", 10),
-            new PropertyToken("Name", "{Name}", startIndex: 12),
-            new TextToken("!", 18));
+            new TextToken(", "),
+            new PropertyToken("Name", "{Name}"),
+            new TextToken("!"));
     }
 
     [Fact]


### PR DESCRIPTION
@nblumhardt any ideas what MessageTemplateToken.StartIndex is for? it doesnt seem to be used in the code. and i cant see how it would add value to a consumer of serilog