### PR TITLE
Throw, rather than exit, when any command in the build script fails

### DIFF
--- a/Build.ps1
+++ b/Build.ps1
@@ -18,7 +18,7 @@ Write-Output "build: Build version suffix is $buildSuffix"
 
 & dotnet build --configuration Release --version-suffix=$buildSuffix /p:ContinuousIntegrationBuild=true
 
-if($LASTEXITCODE -ne 0) { exit 1 }
+if($LASTEXITCODE -ne 0) { throw 'build failed' }
 
 if($suffix) {
     & dotnet pack src\Serilog --configuration Release --no-build --no-restore -o artifacts --version-suffix=$suffix
@@ -26,10 +26,10 @@ if($suffix) {
     & dotnet pack src\Serilog --configuration Release --no-build --no-restore -o artifacts
 }
 
-if($LASTEXITCODE -ne 0) { exit 2 }
+if($LASTEXITCODE -ne 0) { throw 'pack failed' }
 
 Write-Output "build: Testing"
 
 & dotnet test  test\Serilog.Tests --configuration Release --no-build --no-restore
 
-if($LASTEXITCODE -ne 0) { exit 3 }
+if($LASTEXITCODE -ne 0) { throw 'tests failed' }


### PR DESCRIPTION
Fixes #1850

Instead of specifying a build script directly, `appveyor.yml` specifies a fragment of PowerShell that calls the build script. Build failures will only bubble up and cause this outer script to fail if they `throw`, since PowerShell largely ignores exit codes.