### PR TITLE
Reinstate `LoggerSinkConfiguration.Sink(ILogEventSink, LogEventLevel)`

### DIFF
--- a/Build.ps1
+++ b/Build.ps1
@@ -32,4 +32,8 @@ Write-Output "build: Testing"
 
 & dotnet test  test\Serilog.Tests --configuration Release --no-build --no-restore
 
-if($LASTEXITCODE -ne 0) { throw 'tests failed' }
+if($LASTEXITCODE -ne 0) { throw 'unit tests failed' }
+
+& dotnet test  test\Serilog.ApprovalTests --configuration Release --no-build --no-restore
+
+if($LASTEXITCODE -ne 0) { throw 'approval tests failed' }

--- a/src/Serilog/Configuration/LoggerSinkConfiguration.cs
+++ b/src/Serilog/Configuration/LoggerSinkConfiguration.cs
@@ -37,6 +37,7 @@ public class LoggerSinkConfiguration
     /// <seealso cref="Sink(ILogEventSink, LogEventLevel, LoggingLevelSwitch?)"/>
     /// <returns>Configuration object allowing method chaining.</returns>
     /// <remarks>Sink configuration methods that specify <paramref name="restrictedToMinimumLevel"/> should also specify <see cref="LoggingLevelSwitch"/>.</remarks>
+    [EditorBrowsable(EditorBrowsableState.Never)]
     public LoggerConfiguration Sink(
         ILogEventSink logEventSink,
         LogEventLevel restrictedToMinimumLevel)

--- a/src/Serilog/Configuration/LoggerSinkConfiguration.cs
+++ b/src/Serilog/Configuration/LoggerSinkConfiguration.cs
@@ -33,6 +33,22 @@ public class LoggerSinkConfiguration
     /// </summary>
     /// <param name="logEventSink">The sink.</param>
     /// <param name="restrictedToMinimumLevel">The minimum level for
+    /// events passed through the sink.</param>
+    /// <seealso cref="Sink(ILogEventSink, LogEventLevel, LoggingLevelSwitch?)"/>
+    /// <returns>Configuration object allowing method chaining.</returns>
+    /// <remarks>Sink configuration methods that specify <paramref name="restrictedToMinimumLevel"/> should also specify <see cref="LoggingLevelSwitch"/>.</remarks>
+    public LoggerConfiguration Sink(
+        ILogEventSink logEventSink,
+        LogEventLevel restrictedToMinimumLevel)
+    {
+        return Sink(logEventSink, restrictedToMinimumLevel, null);
+    }
+
+    /// <summary>
+    /// Write log events to the specified <see cref="ILogEventSink"/>.
+    /// </summary>
+    /// <param name="logEventSink">The sink.</param>
+    /// <param name="restrictedToMinimumLevel">The minimum level for
     /// events passed through the sink. Ignored when <paramref name="levelSwitch"/> is specified.</param>
     /// <param name="levelSwitch">A switch allowing the pass-through minimum level
     /// to be changed at runtime.</param>
@@ -40,6 +56,9 @@ public class LoggerSinkConfiguration
     public LoggerConfiguration Sink(
         ILogEventSink logEventSink,
         LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
+        // The warning here is redundant; the optional parameter allows `WriteTo.Sink(s)` usage. We would obsolete the two-argument
+        // version above for purposes of economy, but end-user `WriteTo.Sink(s, level)` is valid and shouldn't result in a warning.
+        // ReSharper disable once MethodOverloadWithOptionalParameter
         LoggingLevelSwitch? levelSwitch = null)
     {
         var sink = logEventSink;

--- a/test/Serilog.ApprovalTests/ApiApprovalTests.cs
+++ b/test/Serilog.ApprovalTests/ApiApprovalTests.cs
@@ -16,6 +16,11 @@ public class ApiApprovalTests
                 ExcludeAttributes = new[] { "System.Diagnostics.DebuggerDisplayAttribute" },
             });
 
-        publicApi.ShouldMatchApproved(options => options.WithFilenameGenerator((_, _, fileType, fileExtension) => $"{assembly.GetName().Name!}.{fileType}.{fileExtension}"));
+        publicApi.ShouldMatchApproved(options =>
+        {
+            // Comment this line out to view the failure as a diff. Leave it here so that CI builds don't hang when this test fails.
+            options.NoDiff();
+            options.WithFilenameGenerator((_, _, fileType, fileExtension) => $"{assembly.GetName().Name!}.{fileType}.{fileExtension}");
+        });
     }
 }

--- a/test/Serilog.ApprovalTests/Serilog.approved.txt
+++ b/test/Serilog.ApprovalTests/Serilog.approved.txt
@@ -70,6 +70,7 @@ namespace Serilog.Configuration
         public Serilog.LoggerConfiguration Conditional(System.Func<Serilog.Events.LogEvent, bool> condition, System.Action<Serilog.Configuration.LoggerSinkConfiguration> configureSink) { }
         public Serilog.LoggerConfiguration Logger(Serilog.ILogger logger, Serilog.Events.LogEventLevel restrictedToMinimumLevel = 0) { }
         public Serilog.LoggerConfiguration Logger(System.Action<Serilog.LoggerConfiguration> configureLogger, Serilog.Events.LogEventLevel restrictedToMinimumLevel = 0, Serilog.Core.LoggingLevelSwitch? levelSwitch = null) { }
+        public Serilog.LoggerConfiguration Sink(Serilog.Core.ILogEventSink logEventSink, Serilog.Events.LogEventLevel restrictedToMinimumLevel) { }
         public Serilog.LoggerConfiguration Sink(Serilog.Core.ILogEventSink logEventSink, Serilog.Events.LogEventLevel restrictedToMinimumLevel = 0, Serilog.Core.LoggingLevelSwitch? levelSwitch = null) { }
         public Serilog.LoggerConfiguration Sink<TSink>(Serilog.Events.LogEventLevel restrictedToMinimumLevel = 0, Serilog.Core.LoggingLevelSwitch? levelSwitch = null)
             where TSink : Serilog.Core.ILogEventSink, new () { }
@@ -823,14 +824,13 @@ namespace Serilog.Parsing
     }
     public abstract class MessageTemplateToken
     {
-        protected MessageTemplateToken(int startIndex) { }
+        protected MessageTemplateToken() { }
         public abstract int Length { get; }
-        public int StartIndex { get; }
         public abstract void Render(System.Collections.Generic.IReadOnlyDictionary<string, Serilog.Events.LogEventPropertyValue> properties, System.IO.TextWriter output, System.IFormatProvider? formatProvider = null);
     }
     public sealed class PropertyToken : Serilog.Parsing.MessageTemplateToken
     {
-        public PropertyToken(string propertyName, string rawText, string? format = null, in Serilog.Parsing.Alignment? alignment = null, Serilog.Parsing.Destructuring destructuring = 0, int startIndex = -1) { }
+        public PropertyToken(string propertyName, string rawText, string? format = null, in Serilog.Parsing.Alignment? alignment = null, Serilog.Parsing.Destructuring destructuring = 0) { }
         public Serilog.Parsing.Alignment? Alignment { get; }
         public Serilog.Parsing.Destructuring Destructuring { get; }
         public string? Format { get; }
@@ -845,7 +845,7 @@ namespace Serilog.Parsing
     }
     public sealed class TextToken : Serilog.Parsing.MessageTemplateToken
     {
-        public TextToken(string text, int startIndex = -1) { }
+        public TextToken(string text) { }
         public override int Length { get; }
         public string Text { get; }
         public override bool Equals(object? obj) { }


### PR DESCRIPTION
I just switched Seq over to Serilog 3 dev and the latest versions of our dependencies, but because of some transitive dependencies in the build I hit:

```
System.MissingMethodException: Method not found: 'Serilog.LoggerConfiguration Serilog.Configuration.LoggerSinkConfiguration.Sink(Serilog.Core.ILogEventSink, Serilog.Events.LogEventLevel)'.
   at Serilog.SeqLoggerConfigurationExtensions.<>c__DisplayClass3_0.<Seq>b__0(LoggerSinkConfiguration wt)
   at Serilog.Configuration.LoggerSinkConfiguration.Wrap(LoggerSinkConfiguration loggerSinkConfiguration, Func`2 wrapSink, Action`1 configureWrappedSink, LogEventLevel restrictedToMinimumLevel, LoggingLevelSwitch levelSwitch)
   at Serilog.Configuration.LoggerSinkConfiguration.Conditional(Func`2 condition, Action`1 configureSink)
   at Serilog.SeqLoggerConfigurationExtensions.Seq(LoggerSinkConfiguration loggerSinkConfiguration, String serverUrl, LogEventLevel restrictedToMinimumLevel, Int32 batchPostingLimit, Nullable`1 period, String apiKey, String bufferBaseFilename, Nullable`1 bufferSizeLimitBytes, Nullable`1 eventBodyLimitBytes, LoggingLevelSwitch controlLevelSwitch, HttpMessageHandler messageHandler, Nullable`1 retainedInvalidPayloadsLimitBytes, Int32 queueSizeLimit)
   at Seq.Build.Program.Main(String[] rawArgs) in C:\projects\seq\ci\Seq.Build\Program.cs:line 33
```

We speculatively removed it in #1800.

I think this is going to be a common experience; for the cost of one overload that wasn't already `[Obsolete]` I think walking this change back is a good trade-off.

I've left the other removal from #1800 alone as we don't have any evidence of breakage at this point.