### PR TITLE
Adding ability to dispose nested loggers in WriteTo.Logger

### DIFF
--- a/src/Serilog/Configuration/LoggerSinkConfiguration.cs
+++ b/src/Serilog/Configuration/LoggerSinkConfiguration.cs
@@ -142,9 +142,10 @@ public class LoggerSinkConfiguration
     /// events passed through the sink.</param>
     /// <returns>Configuration object allowing method chaining.</returns>
     /// <exception cref="ArgumentNullException">When <paramref name="logger"/> is <code>null</code></exception>
+    [EditorBrowsable(EditorBrowsableState.Never)]
     public LoggerConfiguration Logger(
         ILogger logger,
-        LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum)
+        LogEventLevel restrictedToMinimumLevel)
         => Logger(logger, attemptDispose: false, restrictedToMinimumLevel);
 
     /// <summary>
@@ -162,7 +163,7 @@ public class LoggerSinkConfiguration
     /// <exception cref="ArgumentNullException">When <paramref name="logger"/> is <code>null</code></exception>
     public LoggerConfiguration Logger(
         ILogger logger,
-        bool attemptDispose,
+        bool attemptDispose = false,
         LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum)
     {
         Guard.AgainstNull(logger);

--- a/src/Serilog/Configuration/LoggerSinkConfiguration.cs
+++ b/src/Serilog/Configuration/LoggerSinkConfiguration.cs
@@ -145,6 +145,25 @@ public class LoggerSinkConfiguration
     public LoggerConfiguration Logger(
         ILogger logger,
         LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum)
+        => Logger(logger, attemptDispose: false, restrictedToMinimumLevel);
+
+    /// <summary>
+    /// Write log events to a sub-logger, where further processing may occur. Events through
+    /// the sub-logger will be constrained by filters and enriched by enrichers that are
+    /// active in the parent. A sub-logger cannot be used to log at a more verbose level, but
+    /// a less verbose level is possible.
+    /// </summary>
+    /// <param name="logger">The sub-logger.</param>
+    /// <param name="attemptDispose">Whether to shut down automatically the sub-logger
+    /// when the parent logger is disposed.</param>
+    /// <param name="restrictedToMinimumLevel">The minimum level for
+    /// events passed through the sink.</param>
+    /// <returns>Configuration object allowing method chaining.</returns>
+    /// <exception cref="ArgumentNullException">When <paramref name="logger"/> is <code>null</code></exception>
+    public LoggerConfiguration Logger(
+        ILogger logger,
+        bool attemptDispose,
+        LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum)
     {
         Guard.AgainstNull(logger);
 
@@ -154,7 +173,7 @@ public class LoggerSinkConfiguration
                               "and may be removed completely in a future version.");
         }
 
-        var secondarySink = new SecondaryLoggerSink(logger, attemptDispose: false);
+        var secondarySink = new SecondaryLoggerSink(logger, attemptDispose: attemptDispose);
         return Sink(secondarySink, restrictedToMinimumLevel);
     }
 

--- a/test/Serilog.ApprovalTests/Serilog.approved.txt
+++ b/test/Serilog.ApprovalTests/Serilog.approved.txt
@@ -68,8 +68,8 @@ namespace Serilog.Configuration
     public class LoggerSinkConfiguration
     {
         public Serilog.LoggerConfiguration Conditional(System.Func<Serilog.Events.LogEvent, bool> condition, System.Action<Serilog.Configuration.LoggerSinkConfiguration> configureSink) { }
-        public Serilog.LoggerConfiguration Logger(Serilog.ILogger logger, Serilog.Events.LogEventLevel restrictedToMinimumLevel = 0) { }
-        public Serilog.LoggerConfiguration Logger(Serilog.ILogger logger, bool attemptDispose, Serilog.Events.LogEventLevel restrictedToMinimumLevel = 0) { }
+        public Serilog.LoggerConfiguration Logger(Serilog.ILogger logger, Serilog.Events.LogEventLevel restrictedToMinimumLevel) { }
+        public Serilog.LoggerConfiguration Logger(Serilog.ILogger logger, bool attemptDispose = false, Serilog.Events.LogEventLevel restrictedToMinimumLevel = 0) { }
         public Serilog.LoggerConfiguration Logger(System.Action<Serilog.LoggerConfiguration> configureLogger, Serilog.Events.LogEventLevel restrictedToMinimumLevel = 0, Serilog.Core.LoggingLevelSwitch? levelSwitch = null) { }
         public Serilog.LoggerConfiguration Sink(Serilog.Core.ILogEventSink logEventSink, Serilog.Events.LogEventLevel restrictedToMinimumLevel) { }
         public Serilog.LoggerConfiguration Sink(Serilog.Core.ILogEventSink logEventSink, Serilog.Events.LogEventLevel restrictedToMinimumLevel = 0, Serilog.Core.LoggingLevelSwitch? levelSwitch = null) { }

--- a/test/Serilog.ApprovalTests/Serilog.approved.txt
+++ b/test/Serilog.ApprovalTests/Serilog.approved.txt
@@ -69,6 +69,7 @@ namespace Serilog.Configuration
     {
         public Serilog.LoggerConfiguration Conditional(System.Func<Serilog.Events.LogEvent, bool> condition, System.Action<Serilog.Configuration.LoggerSinkConfiguration> configureSink) { }
         public Serilog.LoggerConfiguration Logger(Serilog.ILogger logger, Serilog.Events.LogEventLevel restrictedToMinimumLevel = 0) { }
+        public Serilog.LoggerConfiguration Logger(Serilog.ILogger logger, bool attemptDispose, Serilog.Events.LogEventLevel restrictedToMinimumLevel = 0) { }
         public Serilog.LoggerConfiguration Logger(System.Action<Serilog.LoggerConfiguration> configureLogger, Serilog.Events.LogEventLevel restrictedToMinimumLevel = 0, Serilog.Core.LoggingLevelSwitch? levelSwitch = null) { }
         public Serilog.LoggerConfiguration Sink(Serilog.Core.ILogEventSink logEventSink, Serilog.Events.LogEventLevel restrictedToMinimumLevel) { }
         public Serilog.LoggerConfiguration Sink(Serilog.Core.ILogEventSink logEventSink, Serilog.Events.LogEventLevel restrictedToMinimumLevel = 0, Serilog.Core.LoggingLevelSwitch? levelSwitch = null) { }

--- a/test/Serilog.Tests/Core/ChildLoggerDisposalTests.cs
+++ b/test/Serilog.Tests/Core/ChildLoggerDisposalTests.cs
@@ -1,0 +1,54 @@
+﻿namespace Serilog.Tests.Core;
+
+public class ChildLoggerDisposalTests
+{
+    [Fact]
+    public void ByDefaultChildLoggerIsNotDisposedOnOuterDisposal()
+    {
+        var child = new DisposableLogger();
+        var outer = new LoggerConfiguration()
+            .WriteTo.Logger(child)
+            .CreateLogger();
+        outer.Dispose();
+        Assert.False(child.IsDisposed);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void WhenExplicitlyConfiguredChildLoggerShouldBeDisposedAccordingToConfiguration(bool attemptDispose)
+    {
+        var child = new DisposableLogger();
+        var outer = new LoggerConfiguration()
+            .WriteTo.Logger(child, attemptDispose)
+            .CreateLogger();
+        outer.Dispose();
+        Assert.Equal(attemptDispose, child.IsDisposed);
+    }
+
+#if FEATURE_ASYNCDISPOSABLE
+    [Fact]
+    public async Task ByDefaultChildLoggerIsNotAsyncDisposedOnOuterDisposal()
+    {
+        var child = new DisposableLogger();
+        var outer = new LoggerConfiguration()
+            .WriteTo.Logger(child)
+            .CreateLogger();
+        await outer.DisposeAsync();
+        Assert.False(child.IsDisposedAsync);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task WhenExplicitlyConfiguredChildLoggerShouldBeAsyncDisposedAccordingToConfiguration(bool attemptDispose)
+    {
+        var child = new DisposableLogger();
+        var outer = new LoggerConfiguration()
+            .WriteTo.Logger(child, attemptDispose)
+            .CreateLogger();
+        await outer.DisposeAsync();
+        Assert.Equal(attemptDispose, child.IsDisposedAsync);
+    }
+#endif
+}

--- a/test/Serilog.Tests/Core/ChildLoggerDisposalTests.cs
+++ b/test/Serilog.Tests/Core/ChildLoggerDisposalTests.cs
@@ -13,6 +13,17 @@ public class ChildLoggerDisposalTests
         Assert.False(child.IsDisposed);
     }
 
+    [Fact]
+    public void ViaLegacyOverloadChildLoggerIsNotDisposedOnOuterDisposal()
+    {
+        var child = new DisposableLogger();
+        var outer = new LoggerConfiguration()
+            .WriteTo.Logger(child, Information)
+            .CreateLogger();
+        outer.Dispose();
+        Assert.False(child.IsDisposed);
+    }
+
     [Theory]
     [InlineData(true)]
     [InlineData(false)]
@@ -33,6 +44,17 @@ public class ChildLoggerDisposalTests
         var child = new DisposableLogger();
         var outer = new LoggerConfiguration()
             .WriteTo.Logger(child)
+            .CreateLogger();
+        await outer.DisposeAsync();
+        Assert.False(child.IsDisposedAsync);
+    }
+
+    [Fact]
+    public async Task ViaLegacyOverloadChildLoggerIsNotAsyncDisposedOnOuterDisposal()
+    {
+        var child = new DisposableLogger();
+        var outer = new LoggerConfiguration()
+            .WriteTo.Logger(child, Information)
             .CreateLogger();
         await outer.DisposeAsync();
         Assert.False(child.IsDisposedAsync);


### PR DESCRIPTION
Closes #1447: we can simply proxy a parameter to `SecondaryLoggerSink` to make this work.

The one thing I'm not so sure here is related to the public API change. I've decided to add a new overload method so that the older `WriteTo.Logger(logger, restrictedToMinimumLevel)` wouldn't break, but maybe I'm missing something less evident (or more preferable) here.