### PR TITLE
Accept/pass through the standard `levelSwitch` option in `WriteTo.Logger()`

### DIFF
--- a/src/Serilog/Configuration/LoggerSinkConfiguration.cs
+++ b/src/Serilog/Configuration/LoggerSinkConfiguration.cs
@@ -159,12 +159,15 @@ public class LoggerSinkConfiguration
     /// when the parent logger is disposed.</param>
     /// <param name="restrictedToMinimumLevel">The minimum level for
     /// events passed through the sink.</param>
+    /// <param name="levelSwitch">A switch allowing the pass-through minimum level
+    /// to be changed at runtime. Can be <code>null</code></param>
     /// <returns>Configuration object allowing method chaining.</returns>
     /// <exception cref="ArgumentNullException">When <paramref name="logger"/> is <code>null</code></exception>
     public LoggerConfiguration Logger(
         ILogger logger,
         bool attemptDispose = false,
-        LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum)
+        LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
+        LoggingLevelSwitch? levelSwitch = null)
     {
         Guard.AgainstNull(logger);
 
@@ -175,7 +178,7 @@ public class LoggerSinkConfiguration
         }
 
         var secondarySink = new SecondaryLoggerSink(logger, attemptDispose: attemptDispose);
-        return Sink(secondarySink, restrictedToMinimumLevel);
+        return Sink(secondarySink, restrictedToMinimumLevel, levelSwitch);
     }
 
     /// <summary>

--- a/test/Serilog.ApprovalTests/ApiApprovalTests.cs
+++ b/test/Serilog.ApprovalTests/ApiApprovalTests.cs
@@ -18,8 +18,6 @@ public class ApiApprovalTests
 
         publicApi.ShouldMatchApproved(options =>
         {
-            // Comment this line out to view the failure as a diff. Leave it here so that CI builds don't hang when this test fails.
-            options.NoDiff();
             options.WithFilenameGenerator((_, _, fileType, fileExtension) => $"{assembly.GetName().Name!}.{fileType}.{fileExtension}");
         });
     }

--- a/test/Serilog.ApprovalTests/Serilog.approved.txt
+++ b/test/Serilog.ApprovalTests/Serilog.approved.txt
@@ -69,8 +69,8 @@ namespace Serilog.Configuration
     {
         public Serilog.LoggerConfiguration Conditional(System.Func<Serilog.Events.LogEvent, bool> condition, System.Action<Serilog.Configuration.LoggerSinkConfiguration> configureSink) { }
         public Serilog.LoggerConfiguration Logger(Serilog.ILogger logger, Serilog.Events.LogEventLevel restrictedToMinimumLevel) { }
-        public Serilog.LoggerConfiguration Logger(Serilog.ILogger logger, bool attemptDispose = false, Serilog.Events.LogEventLevel restrictedToMinimumLevel = 0) { }
         public Serilog.LoggerConfiguration Logger(System.Action<Serilog.LoggerConfiguration> configureLogger, Serilog.Events.LogEventLevel restrictedToMinimumLevel = 0, Serilog.Core.LoggingLevelSwitch? levelSwitch = null) { }
+        public Serilog.LoggerConfiguration Logger(Serilog.ILogger logger, bool attemptDispose = false, Serilog.Events.LogEventLevel restrictedToMinimumLevel = 0, Serilog.Core.LoggingLevelSwitch? levelSwitch = null) { }
         public Serilog.LoggerConfiguration Sink(Serilog.Core.ILogEventSink logEventSink, Serilog.Events.LogEventLevel restrictedToMinimumLevel) { }
         public Serilog.LoggerConfiguration Sink(Serilog.Core.ILogEventSink logEventSink, Serilog.Events.LogEventLevel restrictedToMinimumLevel = 0, Serilog.Core.LoggingLevelSwitch? levelSwitch = null) { }
         public Serilog.LoggerConfiguration Sink<TSink>(Serilog.Events.LogEventLevel restrictedToMinimumLevel = 0, Serilog.Core.LoggingLevelSwitch? levelSwitch = null)


### PR DESCRIPTION
This overload was introduced in #1890, so there's no compatibility concern here.