### PR TITLE
Fix #1464, don't log parameter count mismatch message incorrectly

### DIFF
--- a/src/Serilog/Capturing/PropertyBinder.cs
+++ b/src/Serilog/Capturing/PropertyBinder.cs
@@ -52,9 +52,6 @@ class PropertyBinder
 
     EventProperty[] ConstructPositionalProperties(MessageTemplate template, object?[] messageTemplateParameters, PropertyToken[] positionalProperties)
     {
-        if (positionalProperties.Length != messageTemplateParameters.Length)
-            SelfLog.WriteLine("Positional property count does not match parameter count: {0}", template);
-
         var result = new EventProperty[messageTemplateParameters.Length];
         foreach (var property in positionalProperties)
         {
@@ -76,6 +73,9 @@ class PropertyBinder
                 ++next;
             }
         }
+
+        if (result.Length != messageTemplateParameters.Length)
+            SelfLog.WriteLine("Positional property count does not match parameter count: {0}", template);
 
         if (next != result.Length)
             Array.Resize(ref result, next);

--- a/test/Serilog.Tests/Capturing/GettablePropertyFinderTests.cs
+++ b/test/Serilog.Tests/Capturing/GettablePropertyFinderTests.cs
@@ -1,6 +1,6 @@
 namespace Serilog.Tests.Capturing;
 
-public class GetablePropertyFinderTests
+public class GettablePropertyFinderTests
 {
     [Fact]
     public void GetPropertiesRecursiveIntegerTypeYieldNoResult()

--- a/test/Serilog.Tests/Debugging/SelfLogTests.cs
+++ b/test/Serilog.Tests/Debugging/SelfLogTests.cs
@@ -26,6 +26,47 @@ public class SelfLogTests
     }
 
     [Fact]
+    public void SelfLogReportsErrorWhenPositionalParameterCountIsMismatched()
+    {
+        Messages = new();
+        SelfLog.Enable(m =>
+        {
+            Messages.Add(m);
+        });
+
+        using var logger = new LoggerConfiguration()
+            .WriteTo.Logger(new SilentLogger())
+            .CreateLogger();
+
+        // ReSharper disable once StructuredMessageTemplateProblem
+        logger.Information("{0}{1}", "hello");
+
+        SelfLog.Disable();
+
+        Assert.Single(Messages);
+    }
+
+    [Fact]
+    public void SelfLogDoesNotReportErrorWhenPositionalParameterIsRepeated()
+    {
+        Messages = new();
+        SelfLog.Enable(m =>
+        {
+            Messages.Add(m);
+        });
+
+        using var logger = new LoggerConfiguration()
+            .WriteTo.Logger(new SilentLogger())
+            .CreateLogger();
+
+        logger.Information("{0}{0}", "hello");
+
+        SelfLog.Disable();
+
+        Assert.Empty(Messages);
+    }
+
+    [Fact]
     public void WritingToUndeclaredSinkWritesToSelfLog()
     {
         Messages = new();


### PR DESCRIPTION
Fixes #1464

The change is in `PropertyBinder`, but the tests (somewhat lazily) rely on `SelfLog`, so I've placed them alongside the others that will interact with it.