### PR TITLE
Add `LevelAlias.Off`; fixes #1684

### DIFF
--- a/src/Serilog/Events/LevelAlias.cs
+++ b/src/Serilog/Events/LevelAlias.cs
@@ -31,4 +31,9 @@ public static class LevelAlias
     /// The most significant level of event.
     /// </summary>
     public const LogEventLevel Maximum = LogEventLevel.Fatal;
+
+    /// <summary>
+    /// A
+    /// </summary>
+    public const LogEventLevel Off = Maximum + 1;
 }

--- a/src/Serilog/Events/LevelAlias.cs
+++ b/src/Serilog/Events/LevelAlias.cs
@@ -33,7 +33,9 @@ public static class LevelAlias
     public const LogEventLevel Maximum = LogEventLevel.Fatal;
 
     /// <summary>
-    /// A
+    /// A value that, when used as a "minimum" level, will result in no
+    /// events being emitted.
     /// </summary>
+    /// <remarks>It is never correct to construct a <see cref="LogEvent"/> with this value.</remarks>
     public const LogEventLevel Off = Maximum + 1;
 }

--- a/test/Serilog.ApprovalTests/Serilog.approved.txt
+++ b/test/Serilog.ApprovalTests/Serilog.approved.txt
@@ -353,6 +353,7 @@ namespace Serilog.Events
     {
         public const Serilog.Events.LogEventLevel Maximum = 5;
         public const Serilog.Events.LogEventLevel Minimum = 0;
+        public const Serilog.Events.LogEventLevel Off = 6;
     }
     public class LogEvent
     {

--- a/test/Serilog.Tests/LoggerConfigurationTests.cs
+++ b/test/Serilog.Tests/LoggerConfigurationTests.cs
@@ -845,4 +845,37 @@ public class LoggerConfigurationTests
         var error = Assert.Single(enricher.Events);
         Assert.True(error.Level == Error);
     }
+
+    [Fact]
+    public void EventsAreNotEmittedWhenMinimumLevelIsOff()
+    {
+        var sink = new CollectingSink();
+
+        var logger = new LoggerConfiguration()
+            .MinimumLevel.Is(LevelAlias.Off)
+            .WriteTo.Sink(sink)
+            .CreateLogger();
+
+        logger.Fatal("Not emitted");
+
+        Assert.Empty(sink.Events);
+    }
+
+    [Fact]
+    public void EventsAreNotEmittedWhenMinimumLevelOverrideIsOff()
+    {
+        var sink = new CollectingSink();
+
+        var logger = new LoggerConfiguration()
+            .MinimumLevel.Override("Test", LevelAlias.Off)
+            .WriteTo.Sink(sink)
+            .CreateLogger();
+
+        logger.Fatal("Emitted");
+        logger.ForContext(Constants.SourceContextPropertyName, "Test").Fatal("Not emitted");
+        logger.ForContext(Constants.SourceContextPropertyName, "Another").Fatal("Emitted");
+
+        Assert.Equal(2, sink.Events.Count);
+        Assert.All(sink.Events, le => Assert.Equal("Emitted", le.MessageTemplate.Text));
+    }
 }


### PR DESCRIPTION
The question of what to do about turning logging completely off via a `MinimumLevel.Override`, and how to map MEL's `LogLevel.Off` in configuration, has been open for a long time.

The arguments against putting this on `LogEventLevel` center around `Off` not being a valid value to find attached to a `LogEvent`.

This PR is an attempt to side-step the issue via `LevelAlias`. Adding `Off` here doesn't sanction constructing an event with the `Off` level, but gives us and everyone else an indication that the `Off` value will be respected in minimum level overrides and JSON configuration (some downstream work required in _Serilog.Settings.Configuration_ for this).

What do you think?