### PR TITLE
Use `JsonValueFormatter` to implement classic `JsonFormatter`

### DIFF
--- a/src/Serilog/Formatting/Json/JsonFormatter.cs
+++ b/src/Serilog/Formatting/Json/JsonFormatter.cs
@@ -80,9 +80,15 @@ public sealed class JsonFormatter : ITextFormatter
         if (logEvent.Properties.Count != 0)
         {
             output.Write(",\"Properties\":{");
+
+            char? propertyDelimiter = null;
             foreach (var property in logEvent.Properties)
             {
-                output.Write(',');
+                if (propertyDelimiter != null)
+                    output.Write(propertyDelimiter.Value);
+                else
+                    propertyDelimiter = ',';
+
                 JsonValueFormatter.WriteQuotedJsonString(property.Key, output);
                 output.Write(':');
                 _jsonValueFormatter.Format(property.Value, output);
@@ -126,8 +132,9 @@ public sealed class JsonFormatter : ITextFormatter
         {
             if (propertyDelimiter != null)
                 output.Write(propertyDelimiter.Value);
+            else
+                propertyDelimiter = ',';
 
-            propertyDelimiter = ',';
             output.Write('"');
             output.Write(propertyFormats.Key);
             output.Write("\":[");

--- a/src/Serilog/Formatting/Json/JsonFormatter.cs
+++ b/src/Serilog/Formatting/Json/JsonFormatter.cs
@@ -59,7 +59,7 @@ public sealed class JsonFormatter : ITextFormatter
 
         output.Write("{\"Timestamp\":\"");
         output.Write(logEvent.Timestamp.ToString("O"));
-        output.Write(",\"Level\":\"");
+        output.Write("\",\"Level\":\"");
         output.Write(logEvent.Level);
         output.Write("\",\"MessageTemplate\":");
         JsonValueFormatter.WriteQuotedJsonString(logEvent.MessageTemplate.Text, output);

--- a/src/Serilog/Formatting/Json/JsonFormatter.cs
+++ b/src/Serilog/Formatting/Json/JsonFormatter.cs
@@ -18,6 +18,8 @@ namespace Serilog.Formatting.Json;
 /// Formats log events in a simple JSON structure. Instances of this class
 /// are safe for concurrent access by multiple threads.
 /// </summary>
+/// <remarks>New code should prefer formatters from <c>Serilog.Formatting.Compact</c>, or <c>ExpressionTemplate</c> from
+/// <c>Serilog.Expressions</c>.</remarks>
 public sealed class JsonFormatter : ITextFormatter
 {
     readonly string _closingDelimiter;
@@ -55,23 +57,39 @@ public sealed class JsonFormatter : ITextFormatter
         Guard.AgainstNull(logEvent);
         Guard.AgainstNull(output);
 
-        output.Write('{');
+        output.Write("{\"Timestamp\":\"");
+        output.Write(logEvent.Timestamp.ToString("O"));
+        output.Write(",\"Level\":\"");
+        output.Write(logEvent.Level);
+        output.Write("\",\"MessageTemplate\":");
+        JsonValueFormatter.WriteQuotedJsonString(logEvent.MessageTemplate.Text, output);
 
-        char? delim = null;
-        WriteTimestamp(logEvent.Timestamp, ref delim, output);
-        WriteLevel(logEvent.Level, ref delim, output);
-        WriteMessageTemplate(logEvent.MessageTemplate.Text, ref delim, output);
         if (_renderMessage)
         {
-            var message = logEvent.RenderMessage(_formatProvider);
-            WriteRenderedMessage(message, ref delim, output);
+            output.Write("\",\"RenderedMessage\":");
+            var message = logEvent.MessageTemplate.Render(logEvent.Properties);
+            JsonValueFormatter.WriteQuotedJsonString(message, output);
         }
 
         if (logEvent.Exception != null)
-            WriteException(logEvent.Exception, ref delim, output);
+        {
+            output.Write(",\"Exception\":");
+            JsonValueFormatter.WriteQuotedJsonString(logEvent.Exception.ToString(), output);
+        }
 
         if (logEvent.Properties.Count != 0)
-            WriteProperties(logEvent.Properties, output);
+        {
+            output.Write(",\"Properties\":{");
+            foreach (var property in logEvent.Properties)
+            {
+                output.Write(',');
+                JsonValueFormatter.WriteQuotedJsonString(property.Key, output);
+                output.Write(':');
+                _jsonValueFormatter.Format(property.Value, output);
+            }
+
+            output.Write('}');
+        }
 
         var tokensWithFormat = logEvent.MessageTemplate.TokenArray
             .OfType<PropertyToken>()
@@ -81,35 +99,33 @@ public sealed class JsonFormatter : ITextFormatter
 
         if (tokensWithFormat.Length != 0)
         {
-            WriteRenderings(tokensWithFormat, logEvent.Properties, output);
+            output.Write(",\"Renderings\":{");
+            WriteRenderingsValues(tokensWithFormat, logEvent.Properties, output);
+            output.Write('}');
         }
 
         output.Write('}');
         output.Write(_closingDelimiter);
     }
 
-    /// <summary>
-    /// Writes out individual renderings of attached properties
-    /// </summary>
-    void WriteRenderings(IGrouping<string, PropertyToken>[] tokensWithFormat, IReadOnlyDictionary<string, LogEventPropertyValue> properties, TextWriter output)
+    void WriteRenderingsValues(IEnumerable<IGrouping<string, PropertyToken>> tokensWithFormat, IReadOnlyDictionary<string, LogEventPropertyValue> properties, TextWriter output)
     {
-        output.Write(",\"Renderings\":{");
-        WriteRenderingsValues(tokensWithFormat, properties, output);
-        output.Write('}');
-    }
+        static void WriteNameValuePair(string name, string value, ref char? precedingDelimiter, TextWriter output)
+        {
+            if (precedingDelimiter != null)
+                output.Write(precedingDelimiter.Value);
 
-    /// <summary>
-    /// Writes out the values of individual renderings of attached properties
-    /// </summary>
-    void WriteRenderingsValues(IGrouping<string, PropertyToken>[] tokensWithFormat, IReadOnlyDictionary<string, LogEventPropertyValue> properties, TextWriter output)
-    {
+            JsonValueFormatter.WriteQuotedJsonString(name, output);
+            output.Write(':');
+            JsonValueFormatter.WriteQuotedJsonString(value, output);
+            precedingDelimiter = ',';
+        }
+
         char? propertyDelimiter = null;
         foreach (var propertyFormats in tokensWithFormat)
         {
             if (propertyDelimiter != null)
-            {
                 output.Write(propertyDelimiter.Value);
-            }
 
             propertyDelimiter = ',';
             output.Write('"');
@@ -120,105 +136,24 @@ public sealed class JsonFormatter : ITextFormatter
             foreach (var format in propertyFormats)
             {
                 if (formatDelimiter != null)
-                {
                     output.Write(formatDelimiter.Value);
-                }
+
                 formatDelimiter = ',';
 
                 output.Write('{');
                 char? elementDelimiter = null;
 
-                WriteJsonProperty("Format", format.Format, ref elementDelimiter, output);
+                // Caller ensures that `tokensWithFormat` contains only property tokens that have non-null `Format`s.
+                WriteNameValuePair("Format", format.Format!, ref elementDelimiter, output);
 
                 using var sw = ReusableStringWriter.GetOrCreate();
                 MessageTemplateRenderer.RenderPropertyToken(format, properties, sw, _formatProvider, isLiteral: true, isJson: false);
-                WriteJsonProperty("Rendering", sw.ToString(), ref elementDelimiter, output);
+                WriteNameValuePair("Rendering", sw.ToString(), ref elementDelimiter, output);
 
                 output.Write('}');
             }
 
             output.Write(']');
         }
-    }
-
-    /// <summary>
-    /// Writes out the attached properties
-    /// </summary>
-    void WriteProperties(IReadOnlyDictionary<string, LogEventPropertyValue> properties, TextWriter output)
-    {
-        output.Write(",\"Properties\":{");
-        char? precedingDelimiter = null;
-        foreach (var property in properties)
-        {
-            if (precedingDelimiter != null)
-            {
-                output.Write(precedingDelimiter.Value);
-            }
-
-            output.Write('"');
-            output.Write(property.Key);
-            output.Write("\":");
-            _jsonValueFormatter.Format(property.Value, output);
-            precedingDelimiter = ',';
-        }
-        output.Write('}');
-    }
-
-
-    /// <summary>
-    /// Writes out the attached exception
-    /// </summary>
-    void WriteException(Exception exception, ref char? delim, TextWriter output)
-    {
-        WriteJsonProperty("Exception", exception, ref delim, output);
-    }
-
-    /// <summary>
-    /// (Optionally) writes out the rendered message
-    /// </summary>
-    void WriteRenderedMessage(string message, ref char? delim, TextWriter output)
-    {
-        WriteJsonProperty("RenderedMessage", message, ref delim, output);
-    }
-
-    /// <summary>
-    /// Writes out the message template for the logevent.
-    /// </summary>
-    void WriteMessageTemplate(string template, ref char? delim, TextWriter output)
-    {
-        WriteJsonProperty("MessageTemplate", template, ref delim, output);
-    }
-
-    /// <summary>
-    /// Writes out the log level
-    /// </summary>
-    void WriteLevel(LogEventLevel level, ref char? delim, TextWriter output)
-    {
-        WriteJsonProperty("Level", level, ref delim, output);
-    }
-
-    /// <summary>
-    /// Writes out the log timestamp
-    /// </summary>
-    void WriteTimestamp(DateTimeOffset timestamp, ref char? delim, TextWriter output)
-    {
-        WriteJsonProperty("Timestamp", timestamp, ref delim, output);
-    }
-
-    /// <summary>
-    /// Writes out a json property with the specified value on output writer
-    /// </summary>
-    void WriteJsonProperty(string name, object? value, ref char? precedingDelimiter, TextWriter output)
-    {
-        if (precedingDelimiter != null)
-        {
-            output.Write(precedingDelimiter.Value);
-        }
-
-        output.Write('"');
-        output.Write(name);
-        output.Write("\":");
-        _jsonValueFormatter.Format(new ScalarValue(value), output);
-        precedingDelimiter = ',';
     }
 }

--- a/test/Serilog.ApprovalTests/Serilog.approved.txt
+++ b/test/Serilog.ApprovalTests/Serilog.approved.txt
@@ -463,7 +463,7 @@ namespace Serilog.Formatting
 }
 namespace Serilog.Formatting.Json
 {
-    public class JsonFormatter : Serilog.Formatting.ITextFormatter
+    public sealed class JsonFormatter : Serilog.Formatting.ITextFormatter
     {
         public JsonFormatter(string? closingDelimiter = null, bool renderMessage = false, System.IFormatProvider? formatProvider = null) { }
         public void Format(Serilog.Events.LogEvent logEvent, System.IO.TextWriter output) { }

--- a/test/Serilog.Tests/Formatting/Json/JsonFormatterTests.cs
+++ b/test/Serilog.Tests/Formatting/Json/JsonFormatterTests.cs
@@ -217,7 +217,6 @@ public class JsonFormatterTests
 
         var e = DelegatingSink.GetLogEvent(l => l.Information("Value is {ADictionary}", dict), cfg => cfg.Destructure.AsDictionary<MyDictionary>());
         var f = FormatJson(e);
-
         Assert.Equal("world", (string)f.Properties.ADictionary["hello"]);
         Assert.Equal(1.2, (double)f.Properties.ADictionary.nums[0]);
     }


### PR DESCRIPTION
Since 3.0 removes all the obsolete `JsonFormatter` virtual methods, we can now seal this and remove the duplicated functionality that existed solely for subclass use.

Feeling like this one's a decent win :-)