### PR TITLE
fix(LevelOverrideMap): change levelSwitch check

### DIFF
--- a/src/Serilog/Core/LevelOverrideMap.cs
+++ b/src/Serilog/Core/LevelOverrideMap.cs
@@ -68,7 +68,7 @@ class LevelOverrideMap
     {
         foreach (var levelOverride in _overrides)
         {
-            if (context.StartsWith(levelOverride.Context) &&
+            if (context.StartsWith(levelOverride.Context, StringComparison.CurrentCultureIgnoreCase) &&
                 (context.Length == levelOverride.Context.Length || context[levelOverride.Context.Length] == '.'))
             {
                 minimumLevel = LevelAlias.Minimum;

--- a/src/Serilog/Core/LevelOverrideMap.cs
+++ b/src/Serilog/Core/LevelOverrideMap.cs
@@ -68,7 +68,7 @@ class LevelOverrideMap
     {
         foreach (var levelOverride in _overrides)
         {
-            if (context.StartsWith(levelOverride.Context, StringComparison.CurrentCultureIgnoreCase) &&
+            if (context.StartsWith(levelOverride.Context, StringComparison.OrdinalIgnoreCase) &&
                 (context.Length == levelOverride.Context.Length || context[levelOverride.Context.Length] == '.'))
             {
                 minimumLevel = LevelAlias.Minimum;

--- a/test/Serilog.Tests/Core/LevelOverrideMapTests.cs
+++ b/test/Serilog.Tests/Core/LevelOverrideMapTests.cs
@@ -5,12 +5,14 @@ public class LevelOverrideMapTests
     [Theory]
     [InlineData("Serilog", false, LevelAlias.Minimum)]
     [InlineData("MyApp", true, Debug)]
+    [InlineData("MYAPP", true, Debug)]
     [InlineData("MyAppSomething", false, LevelAlias.Minimum)]
     [InlineData("MyOtherApp", false, LevelAlias.Minimum)]
     [InlineData("MyApp.Something", true, Debug)]
     [InlineData("MyApp.Api.Models.Person", true, Error)]
     [InlineData("MyApp.Api.Controllers.AboutController", true, Information)]
     [InlineData("MyApp.Api.Controllers.HomeController", true, Warning)]
+    [InlineData("MYAPP.API.CONTROLLERS.HOMECONTROLLER", true, Warning)]
     [InlineData("Api.Controllers.HomeController", false, LevelAlias.Minimum)]
     public void OverrideScenarios(string context, bool overrideExpected, LogEventLevel expected)
     {


### PR DESCRIPTION
changed the levelSwitch check from case sensitive namespace checks to a case insensitve check

Refs: #1944