### PR TITLE
Removed temporary array allocations for properties

### DIFF
--- a/src/Serilog/Capturing/MessageTemplateProcessor.cs
+++ b/src/Serilog/Capturing/MessageTemplateProcessor.cs
@@ -26,7 +26,11 @@ class MessageTemplateProcessor : ILogEventPropertyFactory, ILogEventPropertyValu
         _propertyBinder = new(_propertyValueConverter);
     }
 
-    public void Process(string messageTemplate, object?[]? messageTemplateParameters, out MessageTemplate parsedTemplate, out EventProperty[] properties)
+#if FEATURE_SPAN
+    public void Process(string messageTemplate, ReadOnlySpan<object?> messageTemplateParameters, out MessageTemplate parsedTemplate, out EventProperty[] properties)
+#else
+    public void Process(string messageTemplate, object?[] messageTemplateParameters, out MessageTemplate parsedTemplate, out EventProperty[] properties)
+#endif
     {
         parsedTemplate = _parser.Parse(messageTemplate);
         properties = _propertyBinder.ConstructProperties(parsedTemplate, messageTemplateParameters);

--- a/src/Serilog/Capturing/PropertyBinder.cs
+++ b/src/Serilog/Capturing/PropertyBinder.cs
@@ -34,9 +34,13 @@ class PropertyBinder
     /// represented in the message template.</param>
     /// <returns>A list of properties; if the template is malformed then
     /// this will be empty.</returns>
-    public EventProperty[] ConstructProperties(MessageTemplate messageTemplate, object?[]? messageTemplateParameters)
+#if FEATURE_SPAN
+    public EventProperty[] ConstructProperties(MessageTemplate messageTemplate, ReadOnlySpan<object?> messageTemplateParameters)
+#else
+    public EventProperty[] ConstructProperties(MessageTemplate messageTemplate, object?[] messageTemplateParameters)
+#endif
     {
-        if (messageTemplateParameters == null || messageTemplateParameters.Length == 0)
+        if (messageTemplateParameters.Length == 0)
         {
             if (messageTemplate.NamedProperties != null || messageTemplate.PositionalProperties != null)
                 SelfLog.WriteLine("Required properties not provided for: {0}", messageTemplate);
@@ -47,10 +51,14 @@ class PropertyBinder
         if (messageTemplate.PositionalProperties != null)
             return ConstructPositionalProperties(messageTemplate, messageTemplateParameters, messageTemplate.PositionalProperties);
 
-        return ConstructNamedProperties(messageTemplate, messageTemplateParameters!);
+        return ConstructNamedProperties(messageTemplate, messageTemplateParameters);
     }
 
+#if FEATURE_SPAN
+    EventProperty[] ConstructPositionalProperties(MessageTemplate template, ReadOnlySpan<object?> messageTemplateParameters, PropertyToken[] positionalProperties)
+#else
     EventProperty[] ConstructPositionalProperties(MessageTemplate template, object?[] messageTemplateParameters, PropertyToken[] positionalProperties)
+#endif
     {
         var result = new EventProperty[messageTemplateParameters.Length];
         foreach (var property in positionalProperties)
@@ -83,7 +91,11 @@ class PropertyBinder
         return result;
     }
 
-    EventProperty[] ConstructNamedProperties(MessageTemplate template, object[] messageTemplateParameters)
+#if FEATURE_SPAN
+    EventProperty[] ConstructNamedProperties(MessageTemplate template, ReadOnlySpan<object?> messageTemplateParameters)
+#else
+    EventProperty[] ConstructNamedProperties(MessageTemplate template, object?[] messageTemplateParameters)
+#endif
     {
         var namedProperties = template.NamedProperties;
         if (namedProperties == null)

--- a/src/Serilog/Core/PropertiesInlineArray.cs
+++ b/src/Serilog/Core/PropertiesInlineArray.cs
@@ -1,0 +1,27 @@
+#if FEATURE_SPAN
+using System.Runtime.InteropServices;
+
+namespace Serilog.Core;
+
+[StructLayout(LayoutKind.Sequential)]
+struct PropertiesInlineArray
+{
+    object? Object1;
+    object? Object2;
+    object? Object3;
+
+    public Span<object?> AsSpan(int count)
+    {
+        if (count is < 0 or > 3)
+            ThrowArgumentOutOfRangeException(nameof(count));
+
+        return MemoryMarshal.CreateSpan(ref Object1, count);
+    }
+
+    [DoesNotReturn]
+    static void ThrowArgumentOutOfRangeException(string param)
+    {
+        throw new ArgumentOutOfRangeException(param);
+    }
+}
+#endif

--- a/test/Serilog.Tests/Core/LoggerTests.cs
+++ b/test/Serilog.Tests/Core/LoggerTests.cs
@@ -303,6 +303,20 @@ public class LoggerTests
         Assert.Equal(activity.SpanId, single.SpanId);
     }
 
+    [Fact]
+    public void NullMessageTemplateParametersDoNotBreakBinding()
+    {
+        var log = new LoggerConfiguration().WriteTo.Sink(new CollectingSink()).CreateLogger();
+
+        // ReSharper disable RedundantCast
+        // ReSharper disable StructuredMessageTemplateProblem
+        log.Information("test", (object?[]?) null);
+        log.Write(Warning, (Exception?)null, "test", (object?[]?)null);
+        log.BindMessageTemplate("test", (object?[]?)null, out _, out _);
+        // ReSharper restore RedundantCast
+        // ReSharper restore StructuredMessageTemplateProblem
+    }
+
 #if FEATURE_ASYNCDISPOSABLE
 
     [Fact]

--- a/test/Serilog.Tests/MethodOverloadConventionTests.cs
+++ b/test/Serilog.Tests/MethodOverloadConventionTests.cs
@@ -22,11 +22,40 @@ public class MethodOverloadConventionTests
     const string MessageTemplate = "messageTemplate";
 
 #if FEATURE_DEFAULT_INTERFACE
+
+    /// <remarks>
+    /// <para>
+    /// Some methods are excluded from the method body comparison.
+    /// </para>
+    ///
+    /// <para>
+    /// Logger.Write methods with generic parameters call
+    /// <see cref="M:Serilog.Core.Logger.Write(Serilog.Events.LogEventLevel,System.Exception,System.String,System.ReadOnlySpan{System.Object})"/>
+    /// method to avoid params array allocation.
+    /// </para>
+    ///
+    /// <para>
+    /// A similar <see cref="ReadOnlySpan{T}"/> accepting method does not exists in the <see cref="ILogger"/> interface,
+    /// and introducing it is a breaking change.
+    /// </para>
+    /// </remarks>
+    static MethodInfo[] ExcludedMethods =
+#if FEATURE_SPAN
+        typeof(ILogger).GetMethods()
+            .Where(mi => mi.Name == nameof(ILogger.Write))
+            .Where(mi => mi.GetGenericArguments().Length > 0)
+            .Where(mi => mi.GetGenericArguments().All(x => x.GetGenericParameterConstraints().Length == 0))
+            .ToArray();
+#else
+        Array.Empty<MethodInfo>();
+#endif
+
     public static IEnumerable<object[]> DefaultInterfaceMethods =>
         typeof(ILogger).GetMethods()
             .Where(mi => mi.GetMethodBody() != null)
             .Where(mi => mi.GetCustomAttribute(typeof(CustomDefaultMethodImplementationAttribute)) == null)
             .Where(mi => typeof(Logger).GetInterfaceMap(typeof(ILogger)).InterfaceMethods.Contains(mi))
+            .Where(mi => !ExcludedMethods.Contains(mi))
             .Select(mi => new object[] { mi });
 
     [Theory]


### PR DESCRIPTION
Similar to https://github.com/serilog/serilog/pull/1779, but uses on-stack allocation instead of pooling.