### PR TITLE
Collect and propagate current trace and span ids through `LogEvent`

### DIFF
--- a/Serilog.sln
+++ b/Serilog.sln
@@ -8,7 +8,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "assets", "assets", "{E9D1B5
 		appveyor.yml = appveyor.yml
 		Build.ps1 = Build.ps1
 		build.sh = build.sh
-		CHANGES.md = CHANGES.md
 		Directory.Build.props = Directory.Build.props
 		Directory.Build.targets = Directory.Build.targets
 		global.json = global.json

--- a/Serilog.sln.DotSettings
+++ b/Serilog.sln.DotSettings
@@ -218,6 +218,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=destructure/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Enricher/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Enrichers/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=formattable/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Obsoletion/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=stringified/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>
 	

--- a/src/Serilog/Core/Logger.cs
+++ b/src/Serilog/Core/Logger.cs
@@ -365,7 +365,7 @@ public sealed class Logger : ILogger, ILogEventSink, IDisposable
         _messageTemplateProcessor.Process(messageTemplate, propertyValues, out var parsedTemplate, out var boundProperties);
 
         var currentActivity = Activity.Current;
-        var logEvent = new LogEvent(logTimestamp, level, exception, parsedTemplate, boundProperties, currentActivity?.TraceId, currentActivity?.SpanId);
+        var logEvent = new LogEvent(logTimestamp, level, exception, parsedTemplate, boundProperties, currentActivity?.TraceId ?? default, currentActivity?.SpanId ?? default);
         Dispatch(logEvent);
     }
 

--- a/src/Serilog/Core/Logger.cs
+++ b/src/Serilog/Core/Logger.cs
@@ -81,7 +81,7 @@ public sealed class Logger : ILogger, ILogEventSink, IDisposable
     /// <returns>A logger that will enrich log events as specified.</returns>
     public ILogger ForContext(ILogEventEnricher enricher)
     {
-        if (enricher == null)
+        if (enricher == null!)
             return this; // No context here, so little point writing to SelfLog.
 
         return new Logger(
@@ -104,7 +104,7 @@ public sealed class Logger : ILogger, ILogEventSink, IDisposable
     /// <returns>A logger that will enrich log events as specified.</returns>
     public ILogger ForContext(IEnumerable<ILogEventEnricher> enrichers)
     {
-        if (enrichers == null)
+        if (enrichers == null!)
             return this; // No context here, so little point writing to SelfLog.
 
         return ForContext(new SafeAggregateEnricher(enrichers));
@@ -166,7 +166,7 @@ public sealed class Logger : ILogger, ILogEventSink, IDisposable
     /// <returns>A logger that will enrich log events as specified.</returns>
     public ILogger ForContext(Type source)
     {
-        if (source == null)
+        if (source == null!)
             return this; // Little point in writing to SelfLog here because we don't have any contextual information
 
         return ForContext(Constants.SourceContextPropertyName, source.FullName);
@@ -354,7 +354,7 @@ public sealed class Logger : ILogger, ILogEventSink, IDisposable
     public void Write(LogEventLevel level, Exception? exception, string messageTemplate, params object?[]? propertyValues)
     {
         if (!IsEnabled(level)) return;
-        if (messageTemplate == null) return;
+        if (messageTemplate == null!) return;
 
         // Catch a common pitfall when a single non-object array is cast to object[]
         if (propertyValues != null &&
@@ -375,7 +375,7 @@ public sealed class Logger : ILogger, ILogEventSink, IDisposable
     /// <param name="logEvent">The event to write.</param>
     public void Write(LogEvent logEvent)
     {
-        if (logEvent == null) return;
+        if (logEvent == null!) return;
         if (!IsEnabled(logEvent.Level)) return;
         Dispatch(logEvent);
     }

--- a/src/Serilog/Core/Logger.cs
+++ b/src/Serilog/Core/Logger.cs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System.Diagnostics;
+
 #pragma warning disable Serilog004 // Constant MessageTemplate verifier
 
 namespace Serilog.Core;
@@ -362,7 +364,8 @@ public sealed class Logger : ILogger, ILogEventSink, IDisposable
         var logTimestamp = DateTimeOffset.Now;
         _messageTemplateProcessor.Process(messageTemplate, propertyValues, out var parsedTemplate, out var boundProperties);
 
-        var logEvent = new LogEvent(logTimestamp, level, exception, parsedTemplate, boundProperties);
+        var currentActivity = Activity.Current;
+        var logEvent = new LogEvent(logTimestamp, level, exception, parsedTemplate, boundProperties, currentActivity?.TraceId, currentActivity?.SpanId);
         Dispatch(logEvent);
     }
 

--- a/src/Serilog/Events/LogEvent.cs
+++ b/src/Serilog/Events/LogEvent.cs
@@ -23,6 +23,8 @@ namespace Serilog.Events;
 public class LogEvent
 {
     readonly Dictionary<string, LogEventPropertyValue> _properties;
+    ActivityTraceId _traceId;
+    ActivitySpanId _spanId;
 
     LogEvent(
         DateTimeOffset timestamp,
@@ -36,8 +38,8 @@ public class LogEvent
         Timestamp = timestamp;
         Level = level;
         Exception = exception;
-        TraceId = traceId;
-        SpanId = spanId;
+        _traceId = traceId ?? default;
+        _spanId = spanId ?? default;
         MessageTemplate = Guard.AgainstNull(messageTemplate);
         _properties = Guard.AgainstNull(properties);
     }
@@ -100,13 +102,13 @@ public class LogEvent
     /// The id of the trace that was active when the event was created, if any.
     /// </summary>
     [CLSCompliant(false)]
-    public ActivityTraceId? TraceId { get; }
+    public ActivityTraceId? TraceId => _traceId == default ? null : _traceId;
 
     /// <summary>
     /// The id of the span that was active when the event was created, if any.
     /// </summary>
     [CLSCompliant(false)]
-    public ActivitySpanId? SpanId { get; }
+    public ActivitySpanId? SpanId => _spanId == default ? null : _spanId;
 
     /// <summary>
     /// The message template describing the event.

--- a/src/Serilog/Events/LogEvent.cs
+++ b/src/Serilog/Events/LogEvent.cs
@@ -32,14 +32,14 @@ public class LogEvent
         Exception? exception,
         MessageTemplate messageTemplate,
         Dictionary<string, LogEventPropertyValue> properties,
-        ActivityTraceId? traceId,
-        ActivitySpanId? spanId)
+        ActivityTraceId traceId,
+        ActivitySpanId spanId)
     {
         Timestamp = timestamp;
         Level = level;
         Exception = exception;
-        _traceId = traceId ?? default;
-        _spanId = spanId ?? default;
+        _traceId = traceId;
+        _spanId = spanId;
         MessageTemplate = Guard.AgainstNull(messageTemplate);
         _properties = Guard.AgainstNull(properties);
     }
@@ -55,7 +55,7 @@ public class LogEvent
     /// <exception cref="ArgumentNullException">When <paramref name="messageTemplate"/> is <code>null</code></exception>
     /// <exception cref="ArgumentNullException">When <paramref name="properties"/> is <code>null</code></exception>
     public LogEvent(DateTimeOffset timestamp, LogEventLevel level, Exception? exception, MessageTemplate messageTemplate, IEnumerable<LogEventProperty> properties)
-        : this(timestamp, level, exception, messageTemplate, properties, null, null)
+        : this(timestamp, level, exception, messageTemplate, properties, default, default)
     {
     }
 
@@ -72,7 +72,7 @@ public class LogEvent
     /// <exception cref="ArgumentNullException">When <paramref name="messageTemplate"/> is <code>null</code></exception>
     /// <exception cref="ArgumentNullException">When <paramref name="properties"/> is <code>null</code></exception>
     [CLSCompliant(false)]
-    public LogEvent(DateTimeOffset timestamp, LogEventLevel level, Exception? exception, MessageTemplate messageTemplate, IEnumerable<LogEventProperty> properties, ActivityTraceId? traceId, ActivitySpanId? spanId)
+    public LogEvent(DateTimeOffset timestamp, LogEventLevel level, Exception? exception, MessageTemplate messageTemplate, IEnumerable<LogEventProperty> properties, ActivityTraceId traceId, ActivitySpanId spanId)
         : this(timestamp, level, exception, messageTemplate, new Dictionary<string, LogEventPropertyValue>(), traceId, spanId)
     {
         Guard.AgainstNull(properties);
@@ -81,7 +81,7 @@ public class LogEvent
             AddOrUpdateProperty(property);
     }
 
-    internal LogEvent(DateTimeOffset timestamp, LogEventLevel level, Exception? exception, MessageTemplate messageTemplate, EventProperty[] properties, ActivityTraceId? traceId, ActivitySpanId? spanId)
+    internal LogEvent(DateTimeOffset timestamp, LogEventLevel level, Exception? exception, MessageTemplate messageTemplate, EventProperty[] properties, ActivityTraceId traceId, ActivitySpanId spanId)
         : this(timestamp, level, exception, messageTemplate, new Dictionary<string, LogEventPropertyValue>(Guard.AgainstNull(properties).Length), traceId, spanId)
     {
         for (var i = 0; i < properties.Length; ++i)
@@ -236,7 +236,7 @@ public class LogEvent
             Exception,
             MessageTemplate,
             properties,
-            TraceId,
-            SpanId);
+            TraceId ?? default,
+            SpanId ?? default);
     }
 }

--- a/src/Serilog/Events/LogEvent.cs
+++ b/src/Serilog/Events/LogEvent.cs
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System.Diagnostics;
+// ReSharper disable IntroduceOptionalParameters.Global
+
 namespace Serilog.Events;
 
 /// <summary>
@@ -21,11 +24,20 @@ public class LogEvent
 {
     readonly Dictionary<string, LogEventPropertyValue> _properties;
 
-    LogEvent(DateTimeOffset timestamp, LogEventLevel level, Exception? exception, MessageTemplate messageTemplate, Dictionary<string, LogEventPropertyValue> properties)
+    LogEvent(
+        DateTimeOffset timestamp,
+        LogEventLevel level,
+        Exception? exception,
+        MessageTemplate messageTemplate,
+        Dictionary<string, LogEventPropertyValue> properties,
+        ActivityTraceId? traceId,
+        ActivitySpanId? spanId)
     {
         Timestamp = timestamp;
         Level = level;
         Exception = exception;
+        TraceId = traceId;
+        SpanId = spanId;
         MessageTemplate = Guard.AgainstNull(messageTemplate);
         _properties = Guard.AgainstNull(properties);
     }
@@ -41,12 +53,8 @@ public class LogEvent
     /// <exception cref="ArgumentNullException">When <paramref name="messageTemplate"/> is <code>null</code></exception>
     /// <exception cref="ArgumentNullException">When <paramref name="properties"/> is <code>null</code></exception>
     public LogEvent(DateTimeOffset timestamp, LogEventLevel level, Exception? exception, MessageTemplate messageTemplate, IEnumerable<LogEventProperty> properties)
-        : this(timestamp, level, exception, messageTemplate, new Dictionary<string, LogEventPropertyValue>())
+        : this(timestamp, level, exception, messageTemplate, properties, null, null)
     {
-        Guard.AgainstNull(properties);
-
-        foreach (var property in properties)
-            AddOrUpdateProperty(property);
     }
 
     /// <summary>
@@ -57,10 +65,22 @@ public class LogEvent
     /// <param name="exception">An exception associated with the event, or null.</param>
     /// <param name="messageTemplate">The message template describing the event.</param>
     /// <param name="properties">Properties associated with the event, including those presented in <paramref name="messageTemplate"/>.</param>
+    /// <param name="traceId">The id of the trace that was active when the event was created, if any.</param>
+    /// <param name="spanId">The id of the span that was active when the event was created, if any.</param>
     /// <exception cref="ArgumentNullException">When <paramref name="messageTemplate"/> is <code>null</code></exception>
     /// <exception cref="ArgumentNullException">When <paramref name="properties"/> is <code>null</code></exception>
-    internal LogEvent(DateTimeOffset timestamp, LogEventLevel level, Exception? exception, MessageTemplate messageTemplate, EventProperty[] properties)
-        : this(timestamp, level, exception, messageTemplate, new Dictionary<string, LogEventPropertyValue>(Guard.AgainstNull(properties).Length))
+    [CLSCompliant(false)]
+    public LogEvent(DateTimeOffset timestamp, LogEventLevel level, Exception? exception, MessageTemplate messageTemplate, IEnumerable<LogEventProperty> properties, ActivityTraceId? traceId, ActivitySpanId? spanId)
+        : this(timestamp, level, exception, messageTemplate, new Dictionary<string, LogEventPropertyValue>(), traceId, spanId)
+    {
+        Guard.AgainstNull(properties);
+
+        foreach (var property in properties)
+            AddOrUpdateProperty(property);
+    }
+
+    internal LogEvent(DateTimeOffset timestamp, LogEventLevel level, Exception? exception, MessageTemplate messageTemplate, EventProperty[] properties, ActivityTraceId? traceId, ActivitySpanId? spanId)
+        : this(timestamp, level, exception, messageTemplate, new Dictionary<string, LogEventPropertyValue>(Guard.AgainstNull(properties).Length), traceId, spanId)
     {
         for (var i = 0; i < properties.Length; ++i)
             _properties[properties[i].Name] = properties[i].Value;
@@ -75,6 +95,18 @@ public class LogEvent
     /// The level of the event.
     /// </summary>
     public LogEventLevel Level { get; }
+
+    /// <summary>
+    /// The id of the trace that was active when the event was created, if any.
+    /// </summary>
+    [CLSCompliant(false)]
+    public ActivityTraceId? TraceId { get; }
+
+    /// <summary>
+    /// The id of the span that was active when the event was created, if any.
+    /// </summary>
+    [CLSCompliant(false)]
+    public ActivitySpanId? SpanId { get; }
 
     /// <summary>
     /// The message template describing the event.
@@ -201,6 +233,8 @@ public class LogEvent
             Level,
             Exception,
             MessageTemplate,
-            properties);
+            properties,
+            TraceId,
+            SpanId);
     }
 }

--- a/src/Serilog/Formatting/Display/MessageTemplateTextFormatter.cs
+++ b/src/Serilog/Formatting/Display/MessageTemplateTextFormatter.cs
@@ -24,6 +24,7 @@ namespace Serilog.Formatting.Display;
 /// to them. Second, tokens without matching properties are skipped
 /// rather than being written as raw text.
 /// </summary>
+/// <remarks>New code should prefer <c>ExpressionTemplate</c> from <c>Serilog.Expressions</c>.</remarks>
 public class MessageTemplateTextFormatter : ITextFormatter
 {
     readonly IFormatProvider? _formatProvider;
@@ -69,6 +70,14 @@ public class MessageTemplateTextFormatter : ITextFormatter
             {
                 var moniker = LevelOutputFormat.GetLevelMoniker(logEvent.Level, pt.Format);
                 Padding.Apply(output, moniker, pt.Alignment);
+            }
+            else if (pt.PropertyName == OutputProperties.TraceIdPropertyName)
+            {
+                Padding.Apply(output, logEvent.TraceId?.ToString() ?? "", pt.Alignment);
+            }
+            else if (pt.PropertyName == OutputProperties.SpanIdPropertyName)
+            {
+                Padding.Apply(output, logEvent.SpanId?.ToString() ?? "", pt.Alignment);
             }
             else if (pt.PropertyName == OutputProperties.NewLinePropertyName)
             {

--- a/src/Serilog/Formatting/Display/OutputProperties.cs
+++ b/src/Serilog/Formatting/Display/OutputProperties.cs
@@ -36,6 +36,16 @@ public static class OutputProperties
     public const string LevelPropertyName = "Level";
 
     /// <summary>
+    /// The id of the trace that was active at the log event's time of creation, if any.
+    /// </summary>
+    public const string TraceIdPropertyName = "TraceId";
+
+    /// <summary>
+    /// The id of the span that was active at the log event's time of creation, if any.
+    /// </summary>
+    public const string SpanIdPropertyName = "SpanId";
+
+    /// <summary>
     /// A new line.
     /// </summary>
     public const string NewLinePropertyName = "NewLine";

--- a/src/Serilog/Formatting/Json/JsonFormatter.cs
+++ b/src/Serilog/Formatting/Json/JsonFormatter.cs
@@ -71,6 +71,18 @@ public sealed class JsonFormatter : ITextFormatter
             JsonValueFormatter.WriteQuotedJsonString(message, output);
         }
 
+        if (logEvent.TraceId != null)
+        {
+            output.Write(",\"TraceId\":");
+            JsonValueFormatter.WriteQuotedJsonString(logEvent.TraceId.ToString()!, output);
+        }
+
+        if (logEvent.SpanId != null)
+        {
+            output.Write(",\"SpanId\":");
+            JsonValueFormatter.WriteQuotedJsonString(logEvent.SpanId.ToString()!, output);
+        }
+
         if (logEvent.Exception != null)
         {
             output.Write(",\"Exception\":");

--- a/src/Serilog/ILogger.cs
+++ b/src/Serilog/ILogger.cs
@@ -337,7 +337,7 @@ public interface ILogger
         if (BindMessageTemplate(messageTemplate, propertyValues, out var parsedTemplate, out var boundProperties))
         {
             var currentActivity = Activity.Current;
-            var logEvent = new LogEvent(logTimestamp, level, exception, parsedTemplate, boundProperties, currentActivity?.TraceId, currentActivity?.SpanId);
+            var logEvent = new LogEvent(logTimestamp, level, exception, parsedTemplate, boundProperties, currentActivity?.TraceId ?? default, currentActivity?.SpanId ?? default);
             Write(logEvent);
         }
     }

--- a/src/Serilog/Serilog.csproj
+++ b/src/Serilog/Serilog.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>Simple .NET logging with fully-structured events</Description>
-    <VersionPrefix>3.0.2</VersionPrefix>
+    <VersionPrefix>3.1.0</VersionPrefix>
     <Authors>Serilog Contributors</Authors>
     <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT'">net462;net471</TargetFrameworks>
     <TargetFrameworks>$(TargetFrameworks);netstandard2.1;netstandard2.0;net5.0;net6.0;net7.0</TargetFrameworks>
@@ -66,6 +66,19 @@
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net462' ">
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="7.0.2" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net471' ">
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="7.0.2" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="7.0.2" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.1' ">
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="7.0.2" />
   </ItemGroup>
 
 </Project>

--- a/test/Serilog.ApprovalTests/Serilog.approved.txt
+++ b/test/Serilog.ApprovalTests/Serilog.approved.txt
@@ -358,11 +358,17 @@ namespace Serilog.Events
     public class LogEvent
     {
         public LogEvent(System.DateTimeOffset timestamp, Serilog.Events.LogEventLevel level, System.Exception? exception, Serilog.Events.MessageTemplate messageTemplate, System.Collections.Generic.IEnumerable<Serilog.Events.LogEventProperty> properties) { }
+        [System.CLSCompliant(false)]
+        public LogEvent(System.DateTimeOffset timestamp, Serilog.Events.LogEventLevel level, System.Exception? exception, Serilog.Events.MessageTemplate messageTemplate, System.Collections.Generic.IEnumerable<Serilog.Events.LogEventProperty> properties, System.Diagnostics.ActivityTraceId? traceId, System.Diagnostics.ActivitySpanId? spanId) { }
         public System.Exception? Exception { get; }
         public Serilog.Events.LogEventLevel Level { get; }
         public Serilog.Events.MessageTemplate MessageTemplate { get; }
         public System.Collections.Generic.IReadOnlyDictionary<string, Serilog.Events.LogEventPropertyValue> Properties { get; }
+        [System.CLSCompliant(false)]
+        public System.Diagnostics.ActivitySpanId? SpanId { get; }
         public System.DateTimeOffset Timestamp { get; }
+        [System.CLSCompliant(false)]
+        public System.Diagnostics.ActivityTraceId? TraceId { get; }
         public void AddOrUpdateProperty(Serilog.Events.LogEventProperty property) { }
         public void AddPropertyIfAbsent(Serilog.Events.LogEventProperty property) { }
         public void RemovePropertyIfPresent(string propertyName) { }
@@ -452,7 +458,9 @@ namespace Serilog.Formatting.Display
         public const string MessagePropertyName = "Message";
         public const string NewLinePropertyName = "NewLine";
         public const string PropertiesPropertyName = "Properties";
+        public const string SpanIdPropertyName = "SpanId";
         public const string TimestampPropertyName = "Timestamp";
+        public const string TraceIdPropertyName = "TraceId";
     }
 }
 namespace Serilog.Formatting

--- a/test/Serilog.ApprovalTests/Serilog.approved.txt
+++ b/test/Serilog.ApprovalTests/Serilog.approved.txt
@@ -359,7 +359,7 @@ namespace Serilog.Events
     {
         public LogEvent(System.DateTimeOffset timestamp, Serilog.Events.LogEventLevel level, System.Exception? exception, Serilog.Events.MessageTemplate messageTemplate, System.Collections.Generic.IEnumerable<Serilog.Events.LogEventProperty> properties) { }
         [System.CLSCompliant(false)]
-        public LogEvent(System.DateTimeOffset timestamp, Serilog.Events.LogEventLevel level, System.Exception? exception, Serilog.Events.MessageTemplate messageTemplate, System.Collections.Generic.IEnumerable<Serilog.Events.LogEventProperty> properties, System.Diagnostics.ActivityTraceId? traceId, System.Diagnostics.ActivitySpanId? spanId) { }
+        public LogEvent(System.DateTimeOffset timestamp, Serilog.Events.LogEventLevel level, System.Exception? exception, Serilog.Events.MessageTemplate messageTemplate, System.Collections.Generic.IEnumerable<Serilog.Events.LogEventProperty> properties, System.Diagnostics.ActivityTraceId traceId, System.Diagnostics.ActivitySpanId spanId) { }
         public System.Exception? Exception { get; }
         public Serilog.Events.LogEventLevel Level { get; }
         public Serilog.Events.MessageTemplate MessageTemplate { get; }

--- a/test/Serilog.PerformanceTests/PipelineBenchmark.cs
+++ b/test/Serilog.PerformanceTests/PipelineBenchmark.cs
@@ -30,9 +30,6 @@ public class PipelineBenchmark
         _log = new LoggerConfiguration()
             .WriteTo.Sink(new NullSink())
             .CreateLogger();
-
-        // Ensure template is cached
-        _log.Information(_exception, "Hello, {Name}!", "World");
     }
 
     [Benchmark]

--- a/test/Serilog.Tests/Core/LoggerTests.cs
+++ b/test/Serilog.Tests/Core/LoggerTests.cs
@@ -7,6 +7,14 @@ namespace Serilog.Tests.Core;
 
 public class LoggerTests
 {
+    static LoggerTests()
+    {
+        // This is necessary to force activity id allocation on .NET Framework and early .NET Core versions. When this isn't
+        // done, log events end up carrying null trace and span ids (which is fine).
+        Activity.DefaultIdFormat = ActivityIdFormat.W3C;
+        Activity.ForceDefaultIdFormat = true;
+    }
+
     [Theory]
     [InlineData(typeof(Logger))]
 #if FEATURE_DEFAULT_INTERFACE
@@ -194,6 +202,7 @@ public class LoggerTests
         Assert.Equal("message", collectingSink.SingleEvent.Properties["prop"].LiteralValue());
         Assert.Equal(42, collectingSink.SingleEvent.Properties["number"].LiteralValue());
         Assert.Equal(
+            // ReSharper disable once CoVariantArrayConversion
             expected: new SequenceValue(new[] { new ScalarValue(1), new ScalarValue(2), new ScalarValue(3) }),
             actual: (SequenceValue)collectingSink.SingleEvent.Properties["values"],
             comparer: new LogEventPropertyValueComparer());
@@ -278,6 +287,8 @@ public class LoggerTests
         using var source = new ActivitySource(Some.String());
         using var activity = source.StartActivity(Some.String());
         Assert.NotNull(activity);
+        Assert.NotEqual("00000000000000000000000000000000", activity.TraceId.ToHexString());
+        Assert.NotEqual("0000000000000000", activity.SpanId.ToHexString());
 
         var sink = new CollectingSink();
         var log = new LoggerConfiguration()
@@ -287,6 +298,7 @@ public class LoggerTests
         log.Information("Hello, world!");
 
         var single = sink.SingleEvent;
+
         Assert.Equal(activity.TraceId, single.TraceId);
         Assert.Equal(activity.SpanId, single.SpanId);
     }

--- a/test/Serilog.Tests/Events/LogEventTests.cs
+++ b/test/Serilog.Tests/Events/LogEventTests.cs
@@ -1,0 +1,17 @@
+﻿using System.Diagnostics;
+
+namespace Serilog.Tests.Events;
+
+public class LogEventTests
+{
+    [Fact]
+    public void CopiedLogEventsPropagateTraceAndSpan()
+    {
+        var traceId = ActivityTraceId.CreateRandom();
+        var spanId = ActivitySpanId.CreateRandom();
+        var evt = Some.LogEvent(traceId: traceId, spanId: spanId);
+        var copy = evt.Copy();
+        Assert.Equal(traceId, copy.TraceId);
+        Assert.Equal(spanId, copy.SpanId);
+    }
+}

--- a/test/Serilog.Tests/Formatting/Display/MessageTemplateTextFormatterTests.cs
+++ b/test/Serilog.Tests/Formatting/Display/MessageTemplateTextFormatterTests.cs
@@ -363,7 +363,7 @@ public class MessageTemplateTextFormatterTests
     public void TraceAndSpanAreEmptyWhenAbsent()
     {
         var formatter = new MessageTemplateTextFormatter("{TraceId}/{SpanId}", CultureInfo.InvariantCulture);
-        var evt = Some.LogEvent(traceId: null, spanId: null);
+        var evt = Some.LogEvent(traceId: default, spanId: default);
         var sw = new StringWriter();
         formatter.Format(evt, sw);
         Assert.Equal("/", sw.ToString());

--- a/test/Serilog.Tests/Formatting/Display/MessageTemplateTextFormatterTests.cs
+++ b/test/Serilog.Tests/Formatting/Display/MessageTemplateTextFormatterTests.cs
@@ -1,4 +1,8 @@
 
+// ReSharper disable StringLiteralTypo
+
+using System.Diagnostics;
+
 namespace Serilog.Tests.Formatting.Display;
 
 public class MessageTemplateTextFormatterTests
@@ -53,12 +57,12 @@ public class MessageTemplateTextFormatterTests
     [InlineData(Verbose, 6, "Verbos")]
     [InlineData(Verbose, 7, "Verbose")]
     [InlineData(Verbose, 8, "Verbose")]
-    [InlineData(Debug, 1, "D")]
-    [InlineData(Debug, 2, "De")]
-    [InlineData(Debug, 3, "Dbg")]
-    [InlineData(Debug, 4, "Dbug")]
-    [InlineData(Debug, 5, "Debug")]
-    [InlineData(Debug, 6, "Debug")]
+    [InlineData(LogEventLevel.Debug, 1, "D")]
+    [InlineData(LogEventLevel.Debug, 2, "De")]
+    [InlineData(LogEventLevel.Debug, 3, "Dbg")]
+    [InlineData(LogEventLevel.Debug, 4, "Dbug")]
+    [InlineData(LogEventLevel.Debug, 5, "Debug")]
+    [InlineData(LogEventLevel.Debug, 6, "Debug")]
     [InlineData(Information, 1, "I")]
     [InlineData(Information, 2, "In")]
     [InlineData(Information, 3, "Inf")]
@@ -353,5 +357,27 @@ public class MessageTemplateTextFormatterTests
         var sw = new StringWriter();
         formatter.Format(evt, sw);
         Assert.Equal(expected, sw.ToString());
+    }
+
+    [Fact]
+    public void TraceAndSpanAreEmptyWhenAbsent()
+    {
+        var formatter = new MessageTemplateTextFormatter("{TraceId}/{SpanId}", CultureInfo.InvariantCulture);
+        var evt = Some.LogEvent(traceId: null, spanId: null);
+        var sw = new StringWriter();
+        formatter.Format(evt, sw);
+        Assert.Equal("/", sw.ToString());
+    }
+
+    [Fact]
+    public void TraceAndSpanAreIncludedWhenPresent()
+    {
+        var traceId = ActivityTraceId.CreateRandom();
+        var spanId = ActivitySpanId.CreateRandom();
+        var formatter = new MessageTemplateTextFormatter("{TraceId}/{SpanId}", CultureInfo.InvariantCulture);
+        var evt = Some.LogEvent(traceId: traceId, spanId: spanId);
+        var sw = new StringWriter();
+        formatter.Format(evt, sw);
+        Assert.Equal($"{traceId}/{spanId}", sw.ToString());
     }
 }

--- a/test/Serilog.Tests/Formatting/Json/JsonFormatterTests.cs
+++ b/test/Serilog.Tests/Formatting/Json/JsonFormatterTests.cs
@@ -295,7 +295,7 @@ public class JsonFormatterTests
     [Fact]
     public void TraceAndSpanAreIgnoredWhenAbsent()
     {
-        var evt = Some.LogEvent(traceId: null, spanId: null);
+        var evt = Some.LogEvent(traceId: default, spanId: default);
         var sw = new StringWriter();
         var formatter = new JsonFormatter();
         formatter.Format(evt, sw);

--- a/test/Serilog.Tests/Formatting/Json/JsonFormatterTests.cs
+++ b/test/Serilog.Tests/Formatting/Json/JsonFormatterTests.cs
@@ -1,5 +1,6 @@
 using Newtonsoft.Json;
 using System.Collections.ObjectModel;
+using System.Diagnostics;
 
 namespace Serilog.Tests.Formatting.Json;
 
@@ -288,6 +289,32 @@ public class JsonFormatterTests
         formatter.Format(e, buffer);
         var json = buffer.ToString();
 
-        Assert.Contains(@",""MessageTemplate"":""value: {AProperty}"",""RenderedMessage"":""value: 12"",", json);
+        Assert.Contains(""","MessageTemplate":"value: {AProperty}","RenderedMessage":"value: 12",""", json);
+    }
+
+    [Fact]
+    public void TraceAndSpanAreIgnoredWhenAbsent()
+    {
+        var evt = Some.LogEvent(traceId: null, spanId: null);
+        var sw = new StringWriter();
+        var formatter = new JsonFormatter();
+        formatter.Format(evt, sw);
+        var formatted = sw.ToString();
+        Assert.DoesNotContain("TraceId", formatted);
+        Assert.DoesNotContain("SpanId", formatted);
+    }
+
+    [Fact]
+    public void TraceAndSpanAreIncludedWhenPresent()
+    {
+        var traceId = ActivityTraceId.CreateRandom();
+        var spanId = ActivitySpanId.CreateRandom();
+        var evt = Some.LogEvent(traceId: traceId, spanId: spanId);
+        var sw = new StringWriter();
+        var formatter = new JsonFormatter();
+        formatter.Format(evt, sw);
+        var formatted = sw.ToString();
+        Assert.Contains($"\"TraceId\":\"{traceId}\"", formatted);
+        Assert.Contains($"\"SpanId\":\"{spanId}\"", formatted);
     }
 }

--- a/test/Serilog.Tests/LoggerConfigurationTests.cs
+++ b/test/Serilog.Tests/LoggerConfigurationTests.cs
@@ -602,12 +602,6 @@ public class LoggerConfigurationTests
         Assert.True(true, "No exception reached the caller");
     }
 
-    class ThrowingProperty
-    {
-        // ReSharper disable once UnusedMember.Local
-        public string Property => throw new("Boom!");
-    }
-
     [Fact]
     public void WrappingDecoratesTheConfiguredSink()
     {

--- a/test/Serilog.Tests/Support/Some.cs
+++ b/test/Serilog.Tests/Support/Some.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics;
+
 namespace Serilog.Tests.Support;
 
 static class Some
@@ -16,17 +18,25 @@ static class Some
 
     public static DateTimeOffset OffsetInstant() => new(Instant());
 
-    public static LogEvent LogEvent(string sourceContext, DateTimeOffset? timestamp = null, LogEventLevel level = Information)
+    public static LogEvent LogEvent(
+        DateTimeOffset? timestamp = null,
+        LogEventLevel level = Information,
+        Exception? exception = null,
+        string? messageTemplate = null,
+        object?[]? propertyValues = null,
+        ActivityTraceId? traceId = null,
+        ActivitySpanId? spanId = null)
     {
-        return new(timestamp ?? OffsetInstant(), level,
-            null, MessageTemplate(),
-            new List<LogEventProperty> { new(Constants.SourceContextPropertyName, new ScalarValue(sourceContext)) });
-    }
-
-    public static LogEvent LogEvent(DateTimeOffset? timestamp = null, LogEventLevel level = Information)
-    {
-        return new(timestamp ?? OffsetInstant(), level,
-            null, MessageTemplate(), Enumerable.Empty<LogEventProperty>());
+        var logger = new LoggerConfiguration().CreateLogger();
+        Assert.True(logger.BindMessageTemplate(messageTemplate ?? "DEFAULT TEMPLATE", propertyValues, out var parsedTemplate, out var boundProperties));
+        return new(
+            timestamp ?? OffsetInstant(),
+            level,
+            exception,
+            parsedTemplate,
+            boundProperties,
+            traceId,
+            spanId);
     }
 
     public static LogEvent InformationEvent(DateTimeOffset? timestamp = null)
@@ -36,7 +46,7 @@ static class Some
 
     public static LogEvent DebugEvent(DateTimeOffset? timestamp = null)
     {
-        return LogEvent(timestamp, Debug);
+        return LogEvent(timestamp, LogEventLevel.Debug);
     }
 
     public static LogEvent WarningEvent(DateTimeOffset? timestamp = null)

--- a/test/Serilog.Tests/Support/Some.cs
+++ b/test/Serilog.Tests/Support/Some.cs
@@ -24,8 +24,8 @@ static class Some
         Exception? exception = null,
         string? messageTemplate = null,
         object?[]? propertyValues = null,
-        ActivityTraceId? traceId = null,
-        ActivitySpanId? spanId = null)
+        ActivityTraceId traceId = default,
+        ActivitySpanId spanId = default)
     {
         var logger = new LoggerConfiguration().CreateLogger();
         Assert.True(logger.BindMessageTemplate(messageTemplate ?? "DEFAULT TEMPLATE", propertyValues, out var parsedTemplate, out var boundProperties));


### PR DESCRIPTION
Fixes #1923
Fixes https://github.com/serilog/serilog-aspnetcore/issues/207

Note that trace and span ids will only be collected when at least one activity listener is present - this will be the case in just about all practical implementation scenarios right now, I think, but is still worth bearing in mind.

The addition of `{TraceId}` and `{SpanId}` to `MessageTemplateTextFormatter` is technically a breaking change; existing user templates with top level trace and span properties will now pull in the values from `LogEvent` rather than identically-named properties. In most cases these will have the same value/representation, so I don't think it justifies a major version bump, though it'd need a prominent call-out in the release notes.

The immediate benefit from merging this PR will be the removal of the `ConditionalWeakTable` workaround in _Serilog.Sinks.OpenTelemetry_, and should hopefully pave the way for better integration with the OpenTelemetry SDK, if/when that happens.

Further down the line, most sinks for APMs/log servers/services will be able to pull in these properties for correlation purposes.

Final note, this adds a dependency on _System.Diagnostics.DiagnosticSource_ on older platforms; this is no different from how we support `ValueTuple`, so I've made peace with this :-)