### PR TITLE
PropertyValueConverter optimization: avoiding hashset lookup for primitive types

### DIFF
--- a/src/Serilog/Capturing/PropertyValueConverter.cs
+++ b/src/Serilog/Capturing/PropertyValueConverter.cs
@@ -22,10 +22,7 @@ partial class PropertyValueConverter : ILogEventPropertyFactory, ILogEventProper
 {
     static readonly HashSet<Type> BuiltInScalarTypes = new()
     {
-        typeof(bool),
-        typeof(char),
-        typeof(byte), typeof(short), typeof(ushort), typeof(int), typeof(uint),
-        typeof(long), typeof(ulong), typeof(float), typeof(double), typeof(decimal),
+        typeof(decimal),
         typeof(string),
         typeof(DateTime), typeof(DateTimeOffset), typeof(TimeSpan),
         typeof(Guid), typeof(Uri),
@@ -63,6 +60,7 @@ partial class PropertyValueConverter : ILogEventPropertyFactory, ILogEventProper
 
         _scalarConversionPolicies = new IScalarConversionPolicy[]
         {
+            new PrimitiveScalarConversionPolicy(),
             new SimpleScalarConversionPolicy(BuiltInScalarTypes.Concat(additionalScalarTypes)),
             new EnumScalarConversionPolicy(),
             new ByteArrayScalarConversionPolicy(),
@@ -375,7 +373,8 @@ partial class PropertyValueConverter : ILogEventPropertyFactory, ILogEventProper
 
     static bool IsValidDictionaryKeyType(Type valueType)
     {
-        return BuiltInScalarTypes.Contains(valueType) ||
+        return valueType.IsPrimitive ||
+               BuiltInScalarTypes.Contains(valueType) ||
                valueType.IsEnum;
     }
 

--- a/src/Serilog/Policies/PrimitiveScalarConversionPolicy.cs
+++ b/src/Serilog/Policies/PrimitiveScalarConversionPolicy.cs
@@ -1,0 +1,32 @@
+// Copyright 2013-2017 Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Serilog.Policies;
+
+class PrimitiveScalarConversionPolicy : IScalarConversionPolicy
+{
+    public bool TryConvertToScalar(object value, [NotNullWhen(true)] out ScalarValue? result)
+    {
+        var type = value.GetType();
+
+        if (type.IsPrimitive)
+        {
+            result = new ScalarValue(value);
+            return true;
+        }
+
+        result = default;
+        return false;
+    }
+}

--- a/test/Serilog.PerformanceTests/PipelineBenchmark.cs
+++ b/test/Serilog.PerformanceTests/PipelineBenchmark.cs
@@ -40,4 +40,10 @@ public class PipelineBenchmark
     {
         _log.Information(_exception, "Hello, {Name}!", "World");
     }
+
+    [Benchmark]
+    public void IntProperties()
+    {
+        _log.Information(_exception, "Hello, {A} {B} {C}!", 1, 2, 3);
+    }
 }


### PR DESCRIPTION
Optimization for `PropertyValueConverter`. Skips hashset lookup in `SimpleScalarConversionPolicy` for primitive types. The [primitive types](https://learn.microsoft.com/en-us/dotnet/api/system.type.isprimitive?view=net-7.0#remarks) are Boolean, Byte, SByte, Int16, UInt16, Int32, UInt32, Int64, UInt64, IntPtr, UIntPtr, Char, Double, and Single.

It additionally handles `sbyte`, `nint`, `nuint`, but these types could be excluded with additional check without performance penalty. I'm not sure if `sbyte` was originally excluded on purpose.

```cs
type.IsPrimitive && type != typeof(sbyte) && type != typeof(IntPtr) && type != typeof(UIntPtr)
// or
type.IsPrimitive && Type.GetTypeCode(type) is not TypeCode.Object and not TypeCode.SByte
```

Before:

|        Method |     Mean |   Error |  StdDev |   Gen0 | Allocated |
|-------------- |---------:|--------:|--------:|-------:|----------:|
| IntProperties | 268.5 ns | 1.74 ns | 1.63 ns | 0.0296 |     496 B |

After:

|        Method |     Mean |   Error |  StdDev |   Gen0 | Allocated |
|-------------- |---------:|--------:|--------:|-------:|----------:|
| IntProperties | 195.1 ns | 3.42 ns | 3.20 ns | 0.0296 |     496 B |