### PR TITLE
Added missing DynamicallyAccessedMembers in PropertyValueConverter

### DIFF
--- a/src/Serilog/Capturing/PropertyValueConverter.cs
+++ b/src/Serilog/Capturing/PropertyValueConverter.cs
@@ -270,7 +270,7 @@ partial class PropertyValueConverter : ILogEventPropertyFactory, ILogEventProper
 
 #else
 
-    bool TryConvertValueTuple(object value, Type type, Destructuring destructuring, [NotNullWhen(true)] out LogEventPropertyValue? result)
+    bool TryConvertValueTuple(object value, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)] Type type, Destructuring destructuring, [NotNullWhen(true)] out LogEventPropertyValue? result)
     {
         if (!(value is IStructuralEquatable && type.IsConstructedGenericType))
         {


### PR DESCRIPTION
Fixes build without `FEATURE_ITUPLE` constant defined.

> `Error IL2070 : 'this' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicFields' in call to 'System.Type.GetFields(BindingFlags)'. The parameter 'type' of method 'Serilog.Capturing.PropertyValueConverter.TryConvertValueTuple(Object, Type, Destructuring, out LogEventPropertyValue)' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.`
