### PR TITLE
Removed temporary string allocations for rendering string in ScalarValue

### DIFF
--- a/src/Serilog/Events/ScalarValue.cs
+++ b/src/Serilog/Events/ScalarValue.cs
@@ -67,9 +67,13 @@ public class ScalarValue : LogEventPropertyValue
         {
             if (format != "l")
             {
+#if FEATURE_SPAN
+                MessageEscaper.WriteString(output, s);
+#else
                 output.Write('"');
                 output.Write(s.Replace("\"", "\\\""));
                 output.Write('"');
+#endif
             }
             else
             {

--- a/src/Serilog/Rendering/MessageEscaper.cs
+++ b/src/Serilog/Rendering/MessageEscaper.cs
@@ -1,0 +1,39 @@
+﻿#if FEATURE_SPAN
+namespace Serilog.Rendering;
+
+static class MessageEscaper
+{
+    internal static void WriteString(TextWriter output, ReadOnlySpan<char> value)
+    {
+        output.Write('"');
+        var firstIndex = value.IndexOf('"');
+        if (firstIndex < 0)
+        {
+            output.Write(value);
+        }
+        else
+        {
+            WriteEscapedInner(output, value, firstIndex);
+        }
+
+        output.Write('"');
+    }
+
+    static void WriteEscapedInner(TextWriter output, ReadOnlySpan<char> value, int index)
+    {
+        var pos = 0;
+        while (index >= 0)
+        {
+            output.Write(value.Slice(pos, index));
+            output.Write("\\\"");
+            pos += index + 1;
+            index = value.Slice(pos).IndexOf('"');
+        }
+
+        if (pos != value.Length)
+        {
+            output.Write(value.Slice(pos));
+        }
+    }
+}
+#endif

--- a/test/Serilog.PerformanceTests/MessageTemplateRenderingBenchmark.cs
+++ b/test/Serilog.PerformanceTests/MessageTemplateRenderingBenchmark.cs
@@ -13,6 +13,10 @@ public class MessageTemplateRenderingBenchmark
         Some.InformationEvent("Processed {@Position} for {Task} in {Elapsed:000} ms",
             new { Latitude = 25, Longitude = 134 }, "Benchmark", 34);
 
+    static readonly LogEvent EscapeString =
+        Some.InformationEvent("Template for string escape properties {ValueToEscape}",
+            $"This is simple {new string('"', 128)} string with \"quotes\"");
+
     readonly NullTextWriter _output = new();
 
     [Benchmark]
@@ -25,5 +29,11 @@ public class MessageTemplateRenderingBenchmark
     public void TemplateWithVariedProperties()
     {
         VariedProperties.MessageTemplate.Render(VariedProperties.Properties, _output);
+    }
+
+    [Benchmark]
+    public void TemplateWithQuotesEscapeString()
+    {
+        EscapeString.MessageTemplate.Render(EscapeString.Properties, _output);
     }
 }

--- a/test/Serilog.PerformanceTests/MessageTemplateRenderingBenchmark.cs
+++ b/test/Serilog.PerformanceTests/MessageTemplateRenderingBenchmark.cs
@@ -14,8 +14,13 @@ public class MessageTemplateRenderingBenchmark
             new { Latitude = 25, Longitude = 134 }, "Benchmark", 34);
 
     static readonly LogEvent EscapeString =
-        Some.InformationEvent("Template for string escape properties {ValueToEscape}",
-            $"This is simple {new string('"', 128)} string with \"quotes\"");
+        Some.InformationEvent("Template for string escape properties {ValueToEscape} Json: {JsonToEscape}",
+            $"This is simple string with \"quotes\"", Json);
+
+    const string Json =
+        "{\"StringField\":\"FieldsValues\",\"Amount\":666,\"Tax\":123.21,\"Id\":\"fae98759-d8a6-4b78-9bc8-60e4a2c33c7e\"," +
+        "\"StringField1\":\"FieldsValues\",\"Amount1\":666,\"Tax\":123.21,\"Id1\":\"437ac564-1c4c-4fdd-98b0-aecc7bf50a6b\"," +
+        "\"Data\":{\"Id\":21213,\"Name\":\"InnerName\",\"Value\":456.84},\"Data1\":{\"Id\":21213,\"Name\":\"InnerName\",\"Value\":456.84}}";
 
     readonly NullTextWriter _output = new();
 

--- a/test/Serilog.PerformanceTests/Support/NullTextWriter.cs
+++ b/test/Serilog.PerformanceTests/Support/NullTextWriter.cs
@@ -149,4 +149,8 @@ class NullTextWriter : TextWriter
     public override void WriteLine(ulong value)
     {
     }
+
+    public override void Write(ReadOnlySpan<char> value)
+    {
+    }
 }


### PR DESCRIPTION
Currenly when rendering ScalarValue for MessageTemplate it's always escape double quotes with "string.Replace" which leads to creating new string, we can avoid this by using Span's and manually replacing double quotes.


Before:

|                         Method |       Mean |     Error |    StdDev |   Gen0 | Allocated |
|------------------------------- |-----------:|----------:|----------:|-------:|----------:|
|       TemplateWithNoProperties |   2.100 ns | 0.1175 ns | 0.1722 ns |      - |         - |
|   TemplateWithVariedProperties | 167.852 ns | 1.0368 ns | 1.4869 ns | 0.0153 |      96 B |
| TemplateWithQuotesEscapeString | 682.964 ns | 5.0617 ns | 7.4194 ns | 0.1326 |     832 B |


After:
|                         Method |       Mean |     Error |    StdDev |   Gen0 | Allocated |
|------------------------------- |-----------:|----------:|----------:|-------:|----------:|
|       TemplateWithNoProperties |   2.045 ns | 0.0375 ns | 0.0537 ns |      - |         - |
|   TemplateWithVariedProperties | 183.667 ns | 2.7135 ns | 3.9774 ns | 0.0153 |      96 B |
| TemplateWithQuotesEscapeString | 296.243 ns | 2.3111 ns | 3.3875 ns |      - |         - |