### PR TITLE
ReusableStringWriter: Dispose instance with too big buffer

### DIFF
--- a/src/Serilog/Rendering/ReusableStringWriter.cs
+++ b/src/Serilog/Rendering/ReusableStringWriter.cs
@@ -9,6 +9,11 @@ class ReusableStringWriter : StringWriter
     static ReusableStringWriter? _pooledWriter;
 
     /// <summary>
+    /// Max capacity of StringBuilder we keep for next using
+    /// </summary>
+    const int StringBuilderCapacityThreshold = 32678;
+
+    /// <summary>
     /// Gets already created StringWriter if there is one available or creates a new one.
     /// </summary>
     /// <param name="formatProvider"></param>
@@ -34,9 +39,15 @@ class ReusableStringWriter : StringWriter
     /// </summary>
     protected override void Dispose(bool disposing)
     {
+        var sb = GetStringBuilder();
+        if (sb.Capacity > StringBuilderCapacityThreshold)
+        {
+            base.Dispose();
+            return;
+        }
         // We don't call base.Dispose because all it does is mark the writer as closed so it can't be
         // written to and we want to keep it open as reusable writer.
-        GetStringBuilder().Clear();
+        sb.Clear();
         _pooledWriter = this;
     }
 }


### PR DESCRIPTION
Fixes https://github.com/serilog/serilog/issues/1963 
StringBuilderCapacityThreshold is subject to discuss
