### PR TITLE
chore(docs): Markdown housekeeping

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ The following are a set of guidelines for contributing to [Serilog](https://seri
 
 ## Where to start?
 
-The [Serilog repository][serilog] is the location for enhancements and fixes to the core library.  Generally we try to keep the core library lean and performant while attempting to deliver the features of a first class logging library.  
+The [Serilog repository][serilog] is the location for enhancements and fixes to the core library.  Generally we try to keep the core library lean and performant while attempting to deliver the features of a first class logging library.
 
 If you are interested in contributing to a [sink][sinks] or one of the other [community projects][community_projects] then please create a PR in the respective repository.
 
@@ -52,7 +52,6 @@ Serilog has an active and helpful community who are happy to help point you in t
 
  * [Stack Overflow](http://stackoverflow.com/questions/tagged/serilog) - this is the best place to start if you have a question
  * Our [issue tracker](https://github.com/serilog/serilog/issues) here on GitHub
- * [Gitter chat](https://gitter.im/serilog/serilog)
  * The [#serilog tag on Twitter](https://twitter.com/search?q=%23serilog)
 
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,6 +7,7 @@
     <CheckEolTargetFramework>false</CheckEolTargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
+    <Copyright>Copyright © 2013-23 Serilog Contributors</Copyright>
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
     <Reference Include="System" />

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ catch (Exception ex)
 }
 finally
 {
-    await Log.CloseAndFlushAsync();
+    await Log.CloseAndFlushAsync(); // ensure buffering or async Sinks are flushed before app exits
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -122,4 +122,4 @@ When contributing please keep in mind our [Code of Conduct](CODE_OF_CONDUCT.md).
 | `dev`  | [![Build status](https://ci.appveyor.com/api/projects/status/b9rm3l7kduryjgcj/branch/dev?svg=true)](https://ci.appveyor.com/project/serilog/serilog/branch/dev)       |
 | `main` | [![Build status](https://ci.appveyor.com/api/projects/status/b9rm3l7kduryjgcj/branch/master?svg=true)](https://ci.appveyor.com/project/serilog/serilog/branch/master) |
 
-_Serilog is copyright &copy; 2013-2020 Serilog Contributors - Provided under the [Apache License, Version 2.0](http://apache.org/licenses/LICENSE-2.0.html). Needle and thread logo a derivative of work by [Kenneth Appiah](http://www.kensets.com/)._
+_Serilog is copyright &copy; Serilog Contributors - Provided under the [Apache License, Version 2.0](http://apache.org/licenses/LICENSE-2.0.html). Needle and thread logo a derivative of work by [Kenneth Appiah](http://www.kensets.com/)._

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ catch (Exception ex)
 }
 finally
 {
-    await Log.CloseAndFlushAsync(); // ensure buffering or async Sinks are flushed before app exits
+    await Log.CloseAndFlushAsync(); // ensure all logs written before app exits
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -107,8 +107,6 @@ Serilog has an active and helpful community who are happy to help point you in t
  * The [#serilog tag on Twitter](https://twitter.com/search?q=%23serilog)
  * [Serilog-related courses on Pluralsight](https://www.pluralsight.com/search/?q=serilog)
 
-We welcome bug reports and suggestions through our [issue tracker](https://github.com/serilog/serilog/issues) here on GitHub.
-
 We welcome reproducible bug reports and detailed feature requests through [our GitHub issue tracker](https://github.com/serilog/serilog/issues);
 note the other resource are much better for quick questions or seeking usage help.
 

--- a/README.md
+++ b/README.md
@@ -103,11 +103,14 @@ To learn more about Serilog, check out the [documentation](https://github.com/se
 
 Serilog has an active and helpful community who are happy to help point you in the right direction or work through any issues you might encounter. You can get in touch via:
 
- * [Stack Overflow](http://stackoverflow.com/questions/tagged/serilog) &mdash; this is the best place to start if you have a question
+ * [Stack Overflow](http://stackoverflow.com/questions/tagged/serilog) &mdash; this is the best place to start if you have a question. Many track the `serilog` tag there.
  * The [#serilog tag on Twitter](https://twitter.com/search?q=%23serilog)
  * [Serilog-related courses on Pluralsight](https://www.pluralsight.com/search/?q=serilog)
 
 We welcome bug reports and suggestions through our [issue tracker](https://github.com/serilog/serilog/issues) here on GitHub.
+
+We welcome reproducible bug reports and detailed feature requests through [our GitHub issue tracker](https://github.com/serilog/serilog/issues);
+note the other resource are much better for quick questions or seeking usage help.
 
 ### Contributing
 


### PR DESCRIPTION
related: https://github.com/serilog/serilog/issues/1966
- Remove year (2020) from copyright message on readme (note this propagates to nuget)
- Remove mention of gitter (it's not well-monitored, so better to have people use GitHub issues and/or PRs to to/fro ideas)
- Added NuGet package copyright (see far bottom right of https://www.nuget.org/packages/equinox)

Open issues:
- [ ] Some files are missing copyright headers. Many have incomplete years.
   
   I feel the best answer is to remove them in favor of having one copyright year range in the NOTICE. This seems to be valid based on https://www.apache.org/legal/apply-license.html#copy-per-file and general SO searching. If this is not agreed, perhaps I could remove them from the test files only?
   
   Failing that, I can add the header to all source files.