### PR TITLE
Don't stack overflow when disposing `ReusableStringWriter`

### DIFF
--- a/src/Serilog/Rendering/ReusableStringWriter.cs
+++ b/src/Serilog/Rendering/ReusableStringWriter.cs
@@ -42,7 +42,7 @@ class ReusableStringWriter : StringWriter
         var sb = GetStringBuilder();
         if (sb.Capacity > StringBuilderCapacityThreshold)
         {
-            base.Dispose();
+            base.Dispose(disposing);
             return;
         }
         // We don't call base.Dispose because all it does is mark the writer as closed so it can't be


### PR DESCRIPTION
Fixes https://github.com/serilog/serilog-sinks-console/issues/148