### PR TITLE
3.1.1 Release

### DIFF
--- a/src/Serilog/Rendering/ReusableStringWriter.cs
+++ b/src/Serilog/Rendering/ReusableStringWriter.cs
@@ -39,10 +39,16 @@ class ReusableStringWriter : StringWriter
     /// </summary>
     protected override void Dispose(bool disposing)
     {
+        if (!disposing)
+        {
+            base.Dispose(disposing);
+            return;
+        }
+
         var sb = GetStringBuilder();
         if (sb.Capacity > StringBuilderCapacityThreshold)
         {
-            base.Dispose();
+            base.Dispose(disposing);
             return;
         }
         // We don't call base.Dispose because all it does is mark the writer as closed so it can't be

--- a/src/Serilog/Serilog.csproj
+++ b/src/Serilog/Serilog.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>Simple .NET logging with fully-structured events</Description>
-    <VersionPrefix>3.1.0</VersionPrefix>
+    <VersionPrefix>3.1.1</VersionPrefix>
     <Authors>Serilog Contributors</Authors>
     <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT'">net462;net471</TargetFrameworks>
     <TargetFrameworks>$(TargetFrameworks);netstandard2.1;netstandard2.0;net5.0;net6.0;net7.0</TargetFrameworks>


### PR DESCRIPTION
 * #1977 - don't stack overflow when disposing `ReusableStringWriter` with large renderings (@nblumhardt)
