### PR TITLE
Move "missing named property" self log to respect enrichment

### DIFF
--- a/src/Serilog/Capturing/PropertyBinder.cs
+++ b/src/Serilog/Capturing/PropertyBinder.cs
@@ -42,9 +42,6 @@ class PropertyBinder
     {
         if (messageTemplateParameters.Length == 0)
         {
-            if (messageTemplate.NamedProperties != null || messageTemplate.PositionalProperties != null)
-                SelfLog.WriteLine("Required properties not provided for: {0}", messageTemplate);
-
             return NoProperties;
         }
 

--- a/src/Serilog/Core/Logger.cs
+++ b/src/Serilog/Core/Logger.cs
@@ -478,6 +478,19 @@ public sealed class Logger : ILogger, ILogEventSink, IDisposable
             SelfLog.WriteLine("Exception {0} caught while enriching {1} with {2}.", ex, logEvent, _enricher);
         }
 
+        var eventProperties = logEvent.Properties;
+        var namedProperties = logEvent.MessageTemplate.NamedProperties;
+        if(namedProperties != null)
+        {
+            foreach (var property in namedProperties)
+            {
+                if (!eventProperties.ContainsKey(property.PropertyName))
+                {
+                    SelfLog.WriteLine("Could not find named property: {0}", property.PropertyName);
+                }
+            }
+        }
+
         _sink.Emit(logEvent);
     }
 

--- a/test/Serilog.Tests/Debugging/SelfLogTests.cs
+++ b/test/Serilog.Tests/Debugging/SelfLogTests.cs
@@ -26,6 +26,33 @@ public class SelfLogTests
     }
 
     [Fact]
+    public void EnsureNoSelfLogForEnriched()
+    {
+        Messages = new();
+        SelfLog.Enable(m =>
+        {
+            Messages.Add(m);
+        });
+
+        var sink = new CollectingSink();
+        var configuration = new LoggerConfiguration();
+
+        var enrich = configuration.Enrich;
+        enrich.WithProperty("property", "Value");
+        var logger = configuration
+            .WriteTo.Dummy(w => w.Sink(sink))
+            .CreateLogger();
+
+        logger.Warning("Message: {property}");
+
+        var writer = new StringWriter();
+        sink.SingleEvent.RenderMessage(writer);
+        Assert.Equal("Message: \"Value\"", writer.ToString());
+        Assert.Empty(Messages);
+        SelfLog.Disable();
+    }
+
+    [Fact]
     public void SelfLogReportsErrorWhenPositionalParameterCountIsMismatched()
     {
         Messages = new();


### PR DESCRIPTION
The current location where named properties are checked is too early. it does not respect properties provided via enrichment.
Hence it incorrectly writes `Required properties not provided for:` to the selflog on every log call