### PR TITLE
Cast a custom dictionary inheritance class MyDictionary : Dictionary<…

### DIFF
--- a/src/Serilog/Capturing/PropertyValueConverter.cs
+++ b/src/Serilog/Capturing/PropertyValueConverter.cs
@@ -38,6 +38,7 @@ partial class PropertyValueConverter : ILogEventPropertyFactory, ILogEventProper
     readonly int _maximumStringLength;
     readonly int _maximumCollectionCount;
     readonly bool _propagateExceptions;
+    readonly List<string> _dictionaryFullNames;
 
     public PropertyValueConverter(
         int maximumDestructuringDepth,
@@ -46,7 +47,8 @@ partial class PropertyValueConverter : ILogEventPropertyFactory, ILogEventProper
         IEnumerable<Type> additionalScalarTypes,
         IEnumerable<Type> additionalDictionaryTypes,
         IEnumerable<IDestructuringPolicy> additionalDestructuringPolicies,
-        bool propagateExceptions)
+        bool propagateExceptions,
+        List<string> dictionaryFullNames)
     {
         Guard.AgainstNull(additionalScalarTypes);
         Guard.AgainstNull(additionalDestructuringPolicies);
@@ -55,6 +57,7 @@ partial class PropertyValueConverter : ILogEventPropertyFactory, ILogEventProper
         if (maximumCollectionCount < 1) throw new ArgumentOutOfRangeException(nameof(maximumCollectionCount));
 
         _propagateExceptions = propagateExceptions;
+        _dictionaryFullNames = dictionaryFullNames;
         _maximumStringLength = maximumStringLength;
         _maximumCollectionCount = maximumCollectionCount;
 
@@ -354,7 +357,6 @@ partial class PropertyValueConverter : ILogEventPropertyFactory, ILogEventProper
                 dictionary = idictionary;
                 return true;
             }
-
             if (valueType.IsConstructedGenericType)
             {
                 var definition = valueType.GetGenericTypeDefinition();
@@ -364,6 +366,11 @@ partial class PropertyValueConverter : ILogEventPropertyFactory, ILogEventProper
                     dictionary = idictionary;
                     return true;
                 }
+            }
+            if (value is Dictionary<string, object> && valueType?.FullName != null && _dictionaryFullNames.Contains(valueType.FullName))
+            {
+                dictionary = idictionary;
+                return true;
             }
         }
 

--- a/src/Serilog/LoggerConfiguration.cs
+++ b/src/Serilog/LoggerConfiguration.cs
@@ -41,6 +41,7 @@ public class LoggerConfiguration
     {
         WriteTo = new(this, s => _logEventSinks.Add(s));
         Enrich = new(this, e => _enrichers.Add(e));
+        DictionaryFullNames = new List<string>();
     }
 
     /// <summary>
@@ -87,6 +88,20 @@ public class LoggerConfiguration
     /// modify the properties associated with events.
     /// </summary>
     public LoggerEnrichmentConfiguration Enrich { get; internal set; }
+
+    /// <summary>
+    /// Cast a custom dictionary inheritance class <see cref="Dictionary{String, Object}"/>
+    /// </summary>
+    public List<string> DictionaryFullNames { get; internal set; }
+
+    /// <summary>
+    /// Cast a custom dictionary inheritance class <see cref="Dictionary{String, Object}"/>
+    /// </summary>
+    public LoggerConfiguration SetDictionaryFullNames(List<string> names)
+    {
+        DictionaryFullNames = names;
+        return this;
+    }
 
     /// <summary>
     /// Configures global filtering of <see cref="LogEvent"/>s.
@@ -156,7 +171,8 @@ public class LoggerConfiguration
             _additionalScalarTypes,
             _additionalDictionaryTypes,
             _additionalDestructuringPolicies,
-            auditing);
+            auditing,
+            DictionaryFullNames);
         var processor = new MessageTemplateProcessor(converter);
 
         var enricher = _enrichers.Count switch


### PR DESCRIPTION
[1994](https://github.com/serilog/serilog/issues/1994)
I just want to solve some custom extension dictionary types that can be successfully serialized according to the dictionary.
To prevent the problem from spreading, I added a field that lets users decide for themselves which classes can be successfully identified as dictionaries