### PR TITLE
Add WhenNoOperator for destructuring

### DIFF
--- a/src/Serilog/Capturing/PropertyValueConverter.cs
+++ b/src/Serilog/Capturing/PropertyValueConverter.cs
@@ -40,7 +40,8 @@ partial class PropertyValueConverter : ILogEventPropertyFactory, ILogEventProper
     readonly bool _propagateExceptions;
     readonly IDictionary<Type, Destructuring> _fallbackDestructuring;
 
-    public PropertyValueConverter(int maximumDestructuringDepth,
+    public PropertyValueConverter(
+        int maximumDestructuringDepth,
         int maximumStringLength,
         int maximumCollectionCount,
         IEnumerable<Type> additionalScalarTypes,

--- a/src/Serilog/Configuration/LoggerDestructuringConfiguration.cs
+++ b/src/Serilog/Configuration/LoggerDestructuringConfiguration.cs
@@ -26,7 +26,7 @@ public class LoggerDestructuringConfiguration
     readonly Action<int> _setMaximumDepth;
     readonly Action<int> _setMaximumStringLength;
     readonly Action<int> _setMaximumCollectionCount;
-    readonly Action<Type, Destructuring> _addFallbackDestructuring;
+    readonly Action<Type, DestructuringFallback> _addFallbackDestructuring;
 
     internal LoggerDestructuringConfiguration(
         LoggerConfiguration loggerConfiguration,
@@ -36,7 +36,7 @@ public class LoggerDestructuringConfiguration
         Action<int> setMaximumDepth,
         Action<int> setMaximumStringLength,
         Action<int> setMaximumCollectionCount,
-        Action<Type, Destructuring> addFallbackDestructuring)
+        Action<Type, DestructuringFallback> addFallbackDestructuring)
     {
         _loggerConfiguration = Guard.AgainstNull(loggerConfiguration);
         _addScalar = Guard.AgainstNull(addScalar);
@@ -211,12 +211,12 @@ public class LoggerDestructuringConfiguration
     /// If no explicit destructuring hint was given for the property, use the given
     /// destructuring as fallback.
     /// </summary>
-    /// <param name="destructuring">The fallback destructuring.</param>
+    /// <param name="destructuringFallback">The fallback destructuring.</param>
     /// <param name="type">Type to define the fallback for.</typeparam>
     /// <returns>Configuration object allowing method chaining.</returns>
-    public LoggerConfiguration WhenNoOperator(Type type, Destructuring destructuring)
+    public LoggerConfiguration WhenNoOperator(Type type, DestructuringFallback destructuringFallback)
     {
-        _addFallbackDestructuring(type, destructuring);
+        _addFallbackDestructuring(type, destructuringFallback);
         return _loggerConfiguration;
     }
 
@@ -224,8 +224,8 @@ public class LoggerDestructuringConfiguration
     /// If no explicit destructuring hint was given for the property, use the given
     /// destructuring as fallback.
     /// </summary>
-    /// <param name="destructuring">The fallback destructuring.</param>
+    /// <param name="destructuringFallback">The fallback destructuring.</param>
     /// <typeparam name="T">Type to define the fallback for.</typeparam>
     /// <returns>Configuration object allowing method chaining.</returns>
-    public LoggerConfiguration WhenNoOperator<T>(Destructuring destructuring) => WhenNoOperator(typeof(T), destructuring);
+    public LoggerConfiguration WhenNoOperator<T>(DestructuringFallback destructuringFallback) => WhenNoOperator(typeof(T), destructuringFallback);
 }

--- a/src/Serilog/Configuration/LoggerDestructuringConfiguration.cs
+++ b/src/Serilog/Configuration/LoggerDestructuringConfiguration.cs
@@ -26,6 +26,7 @@ public class LoggerDestructuringConfiguration
     readonly Action<int> _setMaximumDepth;
     readonly Action<int> _setMaximumStringLength;
     readonly Action<int> _setMaximumCollectionCount;
+    readonly Action<Type, Destructuring> _addFallbackDestructuring;
 
     internal LoggerDestructuringConfiguration(
         LoggerConfiguration loggerConfiguration,
@@ -34,7 +35,8 @@ public class LoggerDestructuringConfiguration
         Action<IDestructuringPolicy> addPolicy,
         Action<int> setMaximumDepth,
         Action<int> setMaximumStringLength,
-        Action<int> setMaximumCollectionCount)
+        Action<int> setMaximumCollectionCount,
+        Action<Type, Destructuring> addFallbackDestructuring)
     {
         _loggerConfiguration = Guard.AgainstNull(loggerConfiguration);
         _addScalar = Guard.AgainstNull(addScalar);
@@ -43,6 +45,7 @@ public class LoggerDestructuringConfiguration
         _setMaximumDepth = Guard.AgainstNull(setMaximumDepth);
         _setMaximumStringLength = Guard.AgainstNull(setMaximumStringLength);
         _setMaximumCollectionCount = Guard.AgainstNull(setMaximumCollectionCount);
+        _addFallbackDestructuring = Guard.AgainstNull(addFallbackDestructuring);
     }
 
     /// <summary>
@@ -203,4 +206,26 @@ public class LoggerDestructuringConfiguration
         _setMaximumCollectionCount(maximumCollectionCount);
         return _loggerConfiguration;
     }
+
+    /// <summary>
+    /// If no explicit destructuring hint was given for the property, use the given
+    /// destructuring as fallback.
+    /// </summary>
+    /// <param name="destructuring">The fallback destructuring.</param>
+    /// <param name="type">Type to define the fallback for.</typeparam>
+    /// <returns>Configuration object allowing method chaining.</returns>
+    public LoggerConfiguration WhenNoOperator(Type type, Destructuring destructuring)
+    {
+        _addFallbackDestructuring(type, destructuring);
+        return _loggerConfiguration;
+    }
+
+    /// <summary>
+    /// If no explicit destructuring hint was given for the property, use the given
+    /// destructuring as fallback.
+    /// </summary>
+    /// <param name="destructuring">The fallback destructuring.</param>
+    /// <typeparam name="T">Type to define the fallback for.</typeparam>
+    /// <returns>Configuration object allowing method chaining.</returns>
+    public LoggerConfiguration WhenNoOperator<T>(Destructuring destructuring) => WhenNoOperator(typeof(T), destructuring);
 }

--- a/src/Serilog/LoggerConfiguration.cs
+++ b/src/Serilog/LoggerConfiguration.cs
@@ -26,6 +26,7 @@ public class LoggerConfiguration
     readonly List<Type> _additionalScalarTypes = new();
     readonly HashSet<Type> _additionalDictionaryTypes = new();
     readonly List<IDestructuringPolicy> _additionalDestructuringPolicies = new();
+    readonly Dictionary<Type, Destructuring> _fallbackDestructuring = new();
     readonly Dictionary<string, LoggingLevelSwitch> _overrides = new();
     LogEventLevel _minimumLevel = LogEventLevel.Information;
     LoggingLevelSwitch? _levelSwitch;
@@ -107,7 +108,8 @@ public class LoggerConfiguration
                 _additionalDestructuringPolicies.Add,
                 depth => _maximumDestructuringDepth = depth,
                 length => _maximumStringLength = length,
-                count => _maximumCollectionCount = count);
+                count => _maximumCollectionCount = count,
+                _fallbackDestructuring.Add);
         }
     }
 
@@ -156,7 +158,8 @@ public class LoggerConfiguration
             _additionalScalarTypes,
             _additionalDictionaryTypes,
             _additionalDestructuringPolicies,
-            auditing);
+            auditing,
+            _fallbackDestructuring);
         var processor = new MessageTemplateProcessor(converter);
 
         var enricher = _enrichers.Count switch

--- a/src/Serilog/LoggerConfiguration.cs
+++ b/src/Serilog/LoggerConfiguration.cs
@@ -26,7 +26,7 @@ public class LoggerConfiguration
     readonly List<Type> _additionalScalarTypes = new();
     readonly HashSet<Type> _additionalDictionaryTypes = new();
     readonly List<IDestructuringPolicy> _additionalDestructuringPolicies = new();
-    readonly Dictionary<Type, Destructuring> _fallbackDestructuring = new();
+    readonly Dictionary<Type, DestructuringFallback> _fallbackDestructuring = new();
     readonly Dictionary<string, LoggingLevelSwitch> _overrides = new();
     LogEventLevel _minimumLevel = LogEventLevel.Information;
     LoggingLevelSwitch? _levelSwitch;

--- a/src/Serilog/Parsing/DestructuringFallback.cs
+++ b/src/Serilog/Parsing/DestructuringFallback.cs
@@ -1,0 +1,42 @@
+// Copyright 2013-2015 Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Serilog.Parsing;
+
+/// <summary>
+/// A structure representing the fallback settings to apply as fallback on default destructuring.
+/// </summary>
+public readonly struct DestructuringFallback
+{
+    /// <summary>
+    /// Initializes a new instance of <see cref="DestructuringFallback"/>.
+    /// </summary>
+    /// <param name="destructuring">The fallback destructuring.</param>
+    /// <param name="applyToInheritance">If true, also inherited types fill use the fallback. Otherwise, only the specified type.</param>
+    public DestructuringFallback(Destructuring destructuring, bool applyToInheritance = false)
+    {
+        Destructuring = destructuring;
+        ApplyToInheritance = applyToInheritance;
+    }
+
+    /// <summary>
+    /// The fallback destructuring.
+    /// </summary>
+    public Destructuring Destructuring { get; }
+
+    /// <summary>
+    /// If true, also inherited types fill use the fallback. Otherwise, only the specified type.
+    /// </summary>
+    public bool ApplyToInheritance { get; }
+}

--- a/src/Serilog/Serilog.csproj
+++ b/src/Serilog/Serilog.csproj
@@ -4,7 +4,7 @@
     <VersionPrefix>3.1.1</VersionPrefix>
     <Authors>Serilog Contributors</Authors>
     <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT'">net462;net471</TargetFrameworks>
-    <TargetFrameworks>$(TargetFrameworks);netstandard2.1;netstandard2.0;net5.0;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworks);netstandard2.1;netstandard2.0;net6.0;net7.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageTags>serilog;logging;semantic;structured</PackageTags>
     <PackageIcon>icon.png</PackageIcon>

--- a/src/Serilog/Serilog.csproj
+++ b/src/Serilog/Serilog.csproj
@@ -4,7 +4,7 @@
     <VersionPrefix>3.1.1</VersionPrefix>
     <Authors>Serilog Contributors</Authors>
     <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT'">net462;net471</TargetFrameworks>
-    <TargetFrameworks>$(TargetFrameworks);netstandard2.1;netstandard2.0;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworks);netstandard2.1;netstandard2.0;net5.0;net6.0;net7.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageTags>serilog;logging;semantic;structured</PackageTags>
     <PackageIcon>icon.png</PackageIcon>

--- a/src/Serilog/Settings/KeyValuePairs/SurrogateConfigurationMethods.cs
+++ b/src/Serilog/Settings/KeyValuePairs/SurrogateConfigurationMethods.cs
@@ -101,7 +101,7 @@ static class SurrogateConfigurationMethods
     }
 
     internal static LoggerConfiguration WhenNoOperator(LoggerDestructuringConfiguration loggerDestructuringConfiguration,
-        Type type, Destructuring destructuring)
+        Type type, DestructuringFallback destructuring)
     {
         return loggerDestructuringConfiguration.WhenNoOperator(type, destructuring);
     }

--- a/src/Serilog/Settings/KeyValuePairs/SurrogateConfigurationMethods.cs
+++ b/src/Serilog/Settings/KeyValuePairs/SurrogateConfigurationMethods.cs
@@ -99,4 +99,10 @@ static class SurrogateConfigurationMethods
     {
         return loggerFilterConfiguration.With(filter);
     }
+
+    internal static LoggerConfiguration WhenNoOperator(LoggerDestructuringConfiguration loggerDestructuringConfiguration,
+        Type type, Destructuring destructuring)
+    {
+        return loggerDestructuringConfiguration.WhenNoOperator(type, destructuring);
+    }
 }

--- a/test/Serilog.ApprovalTests/Serilog.approved.txt
+++ b/test/Serilog.ApprovalTests/Serilog.approved.txt
@@ -23,8 +23,8 @@ namespace Serilog.Configuration
         public Serilog.LoggerConfiguration ToMaximumCollectionCount(int maximumCollectionCount) { }
         public Serilog.LoggerConfiguration ToMaximumDepth(int maximumDestructuringDepth) { }
         public Serilog.LoggerConfiguration ToMaximumStringLength(int maximumStringLength) { }
-        public Serilog.LoggerConfiguration WhenNoOperator(System.Type type, Serilog.Parsing.Destructuring destructuring) { }
-        public Serilog.LoggerConfiguration WhenNoOperator<T>(Serilog.Parsing.Destructuring destructuring) { }
+        public Serilog.LoggerConfiguration WhenNoOperator(System.Type type, Serilog.Parsing.DestructuringFallback destructuringFallback) { }
+        public Serilog.LoggerConfiguration WhenNoOperator<T>(Serilog.Parsing.DestructuringFallback destructuringFallback) { }
         public Serilog.LoggerConfiguration With(params Serilog.Core.IDestructuringPolicy[] destructuringPolicies) { }
         public Serilog.LoggerConfiguration With<TDestructuringPolicy>()
             where TDestructuringPolicy : Serilog.Core.IDestructuringPolicy, new () { }
@@ -837,6 +837,12 @@ namespace Serilog.Parsing
         Default = 0,
         Stringify = 1,
         Destructure = 2,
+    }
+    public readonly struct DestructuringFallback
+    {
+        public DestructuringFallback(Serilog.Parsing.Destructuring destructuring, bool applyToInheritance = false) { }
+        public bool ApplyToInheritance { get; }
+        public Serilog.Parsing.Destructuring Destructuring { get; }
     }
     public class MessageTemplateParser
     {

--- a/test/Serilog.ApprovalTests/Serilog.approved.txt
+++ b/test/Serilog.ApprovalTests/Serilog.approved.txt
@@ -23,6 +23,8 @@ namespace Serilog.Configuration
         public Serilog.LoggerConfiguration ToMaximumCollectionCount(int maximumCollectionCount) { }
         public Serilog.LoggerConfiguration ToMaximumDepth(int maximumDestructuringDepth) { }
         public Serilog.LoggerConfiguration ToMaximumStringLength(int maximumStringLength) { }
+        public Serilog.LoggerConfiguration WhenNoOperator(System.Type type, Serilog.Parsing.Destructuring destructuring) { }
+        public Serilog.LoggerConfiguration WhenNoOperator<T>(Serilog.Parsing.Destructuring destructuring) { }
         public Serilog.LoggerConfiguration With(params Serilog.Core.IDestructuringPolicy[] destructuringPolicies) { }
         public Serilog.LoggerConfiguration With<TDestructuringPolicy>()
             where TDestructuringPolicy : Serilog.Core.IDestructuringPolicy, new () { }

--- a/test/Serilog.Tests/Capturing/PropertyValueConverterTests.cs
+++ b/test/Serilog.Tests/Capturing/PropertyValueConverterTests.cs
@@ -6,12 +6,12 @@ namespace Serilog.Tests.Capturing;
 public class PropertyValueConverterTests
 {
     readonly PropertyValueConverter _converter =
-        new(10, 1000, 1000, Enumerable.Empty<Type>(), Enumerable.Empty<Type>(), Enumerable.Empty<IDestructuringPolicy>(), false, ImmutableDictionary<Type, Destructuring>.Empty);
+        new(10, 1000, 1000, Enumerable.Empty<Type>(), Enumerable.Empty<Type>(), Enumerable.Empty<IDestructuringPolicy>(), false, ImmutableDictionary<Type, DestructuringFallback>.Empty);
 
     [Fact]
     public async Task MaximumDepthIsEffectiveAndThreadSafe()
     {
-        var converter = new PropertyValueConverter(3, 1000, 1000, Enumerable.Empty<Type>(), Enumerable.Empty<Type>(), Enumerable.Empty<IDestructuringPolicy>(), false, ImmutableDictionary<Type, Destructuring>.Empty);
+        var converter = new PropertyValueConverter(3, 1000, 1000, Enumerable.Empty<Type>(), Enumerable.Empty<Type>(), Enumerable.Empty<IDestructuringPolicy>(), false, ImmutableDictionary<Type, DestructuringFallback>.Empty);
 
         var barrier = new Barrier(participantCount: 3);
 

--- a/test/Serilog.Tests/Capturing/PropertyValueConverterTests.cs
+++ b/test/Serilog.Tests/Capturing/PropertyValueConverterTests.cs
@@ -6,12 +6,12 @@ namespace Serilog.Tests.Capturing;
 public class PropertyValueConverterTests
 {
     readonly PropertyValueConverter _converter =
-        new(10, 1000, 1000, Enumerable.Empty<Type>(), Enumerable.Empty<Type>(), Enumerable.Empty<IDestructuringPolicy>(), false);
+        new(10, 1000, 1000, Enumerable.Empty<Type>(), Enumerable.Empty<Type>(), Enumerable.Empty<IDestructuringPolicy>(), false, ImmutableDictionary<Type, Destructuring>.Empty);
 
     [Fact]
     public async Task MaximumDepthIsEffectiveAndThreadSafe()
     {
-        var converter = new PropertyValueConverter(3, 1000, 1000, Enumerable.Empty<Type>(), Enumerable.Empty<Type>(), Enumerable.Empty<IDestructuringPolicy>(), false);
+        var converter = new PropertyValueConverter(3, 1000, 1000, Enumerable.Empty<Type>(), Enumerable.Empty<Type>(), Enumerable.Empty<IDestructuringPolicy>(), false, ImmutableDictionary<Type, Destructuring>.Empty);
 
         var barrier = new Barrier(participantCount: 3);
 

--- a/test/Serilog.Tests/Core/LogEventPropertyCapturingTests.cs
+++ b/test/Serilog.Tests/Core/LogEventPropertyCapturingTests.cs
@@ -167,7 +167,7 @@ public class LogEventPropertyCapturingTests
     {
         var mt = new MessageTemplateParser().Parse(messageTemplate);
         var binder = new PropertyBinder(
-            new PropertyValueConverter(10, 1000, 1000, Enumerable.Empty<Type>(), Enumerable.Empty<Type>(), Enumerable.Empty<IDestructuringPolicy>(), false));
+            new PropertyValueConverter(10, 1000, 1000, Enumerable.Empty<Type>(), Enumerable.Empty<Type>(), Enumerable.Empty<IDestructuringPolicy>(), false, ImmutableDictionary<Type, Destructuring>.Empty));
         return binder.ConstructProperties(mt, properties).Select(p => new LogEventProperty(p.Name, p.Value));
     }
 }

--- a/test/Serilog.Tests/Core/LogEventPropertyCapturingTests.cs
+++ b/test/Serilog.Tests/Core/LogEventPropertyCapturingTests.cs
@@ -167,7 +167,7 @@ public class LogEventPropertyCapturingTests
     {
         var mt = new MessageTemplateParser().Parse(messageTemplate);
         var binder = new PropertyBinder(
-            new PropertyValueConverter(10, 1000, 1000, Enumerable.Empty<Type>(), Enumerable.Empty<Type>(), Enumerable.Empty<IDestructuringPolicy>(), false, ImmutableDictionary<Type, Destructuring>.Empty));
+            new PropertyValueConverter(10, 1000, 1000, Enumerable.Empty<Type>(), Enumerable.Empty<Type>(), Enumerable.Empty<IDestructuringPolicy>(), false, ImmutableDictionary<Type, DestructuringFallback>.Empty));
         return binder.ConstructProperties(mt, properties).Select(p => new LogEventProperty(p.Name, p.Value));
     }
 }

--- a/test/Serilog.Tests/Core/MessageTemplateTests.cs
+++ b/test/Serilog.Tests/Core/MessageTemplateTests.cs
@@ -134,7 +134,7 @@ public class MessageTemplateTests
     static string Render(IFormatProvider? formatProvider, string messageTemplate, params object[] properties)
     {
         var mt = new MessageTemplateParser().Parse(messageTemplate);
-        var binder = new PropertyBinder(new PropertyValueConverter(10, 1000, 1000, Enumerable.Empty<Type>(), Enumerable.Empty<Type>(), Enumerable.Empty<IDestructuringPolicy>(), false, ImmutableDictionary<Type, Destructuring>.Empty));
+        var binder = new PropertyBinder(new PropertyValueConverter(10, 1000, 1000, Enumerable.Empty<Type>(), Enumerable.Empty<Type>(), Enumerable.Empty<IDestructuringPolicy>(), false, ImmutableDictionary<Type, DestructuringFallback>.Empty));
         var props = binder.ConstructProperties(mt, properties);
         var output = new StringBuilder();
         var writer = new StringWriter(output);

--- a/test/Serilog.Tests/Core/MessageTemplateTests.cs
+++ b/test/Serilog.Tests/Core/MessageTemplateTests.cs
@@ -134,7 +134,7 @@ public class MessageTemplateTests
     static string Render(IFormatProvider? formatProvider, string messageTemplate, params object[] properties)
     {
         var mt = new MessageTemplateParser().Parse(messageTemplate);
-        var binder = new PropertyBinder(new PropertyValueConverter(10, 1000, 1000, Enumerable.Empty<Type>(), Enumerable.Empty<Type>(), Enumerable.Empty<IDestructuringPolicy>(), false));
+        var binder = new PropertyBinder(new PropertyValueConverter(10, 1000, 1000, Enumerable.Empty<Type>(), Enumerable.Empty<Type>(), Enumerable.Empty<IDestructuringPolicy>(), false, ImmutableDictionary<Type, Destructuring>.Empty));
         var props = binder.ConstructProperties(mt, properties);
         var output = new StringBuilder();
         var writer = new StringWriter(output);

--- a/test/Serilog.Tests/Events/LogEventPropertyValueTests.cs
+++ b/test/Serilog.Tests/Events/LogEventPropertyValueTests.cs
@@ -17,7 +17,7 @@ namespace Serilog.Tests.Events;
 public class LogEventPropertyValueTests
 {
     readonly PropertyValueConverter _converter =
-        new(10, 1000, 1000, Enumerable.Empty<Type>(), Enumerable.Empty<Type>(), Enumerable.Empty<IDestructuringPolicy>(), false);
+        new(10, 1000, 1000, Enumerable.Empty<Type>(), Enumerable.Empty<Type>(), Enumerable.Empty<IDestructuringPolicy>(), false, ImmutableDictionary<Type, Destructuring>.Empty);
 
     [Fact]
     public void AnEnumIsConvertedToANonStringScalarValue()

--- a/test/Serilog.Tests/Events/LogEventPropertyValueTests.cs
+++ b/test/Serilog.Tests/Events/LogEventPropertyValueTests.cs
@@ -17,7 +17,7 @@ namespace Serilog.Tests.Events;
 public class LogEventPropertyValueTests
 {
     readonly PropertyValueConverter _converter =
-        new(10, 1000, 1000, Enumerable.Empty<Type>(), Enumerable.Empty<Type>(), Enumerable.Empty<IDestructuringPolicy>(), false, ImmutableDictionary<Type, Destructuring>.Empty);
+        new(10, 1000, 1000, Enumerable.Empty<Type>(), Enumerable.Empty<Type>(), Enumerable.Empty<IDestructuringPolicy>(), false, ImmutableDictionary<Type, DestructuringFallback>.Empty);
 
     [Fact]
     public void AnEnumIsConvertedToANonStringScalarValue()

--- a/test/Serilog.Tests/GlobalUsings.cs
+++ b/test/Serilog.Tests/GlobalUsings.cs
@@ -1,4 +1,5 @@
 global using System.Collections;
+global using System.Collections.Immutable;
 global using System.Diagnostics.CodeAnalysis;
 global using System.Globalization;
 global using System.Reflection;

--- a/test/Serilog.Tests/LoggerConfigurationTests.cs
+++ b/test/Serilog.Tests/LoggerConfigurationTests.cs
@@ -115,6 +115,42 @@ public class LoggerConfigurationTests
     }
 
     [Fact]
+    public void SpecifyingThatATypeShouldBeDestructuredCausesItToBeLoggedAsStructureEvenOnDefault()
+    {
+        var events = new List<LogEvent>();
+        var sink = new DelegatingSink(events.Add);
+
+        var logger = new LoggerConfiguration()
+            .WriteTo.Sink(sink)
+            .Destructure.WhenNoOperator(typeof(AB), Destructuring.Destructure)
+            .CreateLogger();
+
+        logger.Information("{AB}", new AB());
+
+        var ev = events.Single();
+        var prop = ev.Properties["AB"];
+        Assert.IsType<StructureValue>(prop);
+    }
+
+    [Fact]
+    public void SpecifyingThatATypeShouldBeDestructuredCausesItToBeLoggedAsScalarWhenStringified()
+    {
+        var events = new List<LogEvent>();
+        var sink = new DelegatingSink(events.Add);
+
+        var logger = new LoggerConfiguration()
+            .WriteTo.Sink(sink)
+            .Destructure.WhenNoOperator(typeof(AB), Destructuring.Destructure)
+            .CreateLogger();
+
+        logger.Information("{$AB}", new AB());
+
+        var ev = events.Single();
+        var prop = ev.Properties["AB"];
+        Assert.IsType<ScalarValue>(prop);
+    }
+
+    [Fact]
     public void DestructuringSystemTypeGivesScalarByDefault()
     {
         var events = new List<LogEvent>();

--- a/test/Serilog.Tests/Serilog.Tests.csproj
+++ b/test/Serilog.Tests/Serilog.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT'">net462;net48</TargetFrameworks>
     <TargetFrameworks>$(TargetFrameworks);net6.0;net7.0</TargetFrameworks>
@@ -18,6 +18,10 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" PrivateAssets="all" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework.TrimEnd(`0123456789`))' == 'net' ">
+    <PackageReference Include="System.Collections.Immutable" Version="8.0.0" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net462' ">

--- a/test/Serilog.Tests/Settings/CallableConfigurationMethodFinderTests.cs
+++ b/test/Serilog.Tests/Settings/CallableConfigurationMethodFinderTests.cs
@@ -74,6 +74,7 @@ public class CallableConfigurationMethodFinderTests
         Assert.Contains(nameof(LoggerDestructuringConfiguration.ToMaximumStringLength), destructuringMethods);
         Assert.Contains(nameof(DummyLoggerConfigurationExtensions.WithDummyHardCodedString), destructuringMethods);
         Assert.Contains(nameof(LoggerDestructuringConfiguration.With), destructuringMethods);
+        Assert.Contains(nameof(LoggerDestructuringConfiguration.WhenNoOperator), destructuringMethods);
     }
 
     [Fact]


### PR DESCRIPTION
Fixes #2023

I created a PR to show that it is aligning with the architecture of Serilog quite well and that it only needs minimal changes.

For my use-case, not only the type but also inherited types would need to use the fallback. But I wanted to start with this for discussion to see if it get‘s interest or if it gets declined. This could easily be also given to the call as parameter.