### PR TITLE
Finish trim annotation

### DIFF
--- a/src/Serilog/Capturing/PropertyValueConverter.cs
+++ b/src/Serilog/Capturing/PropertyValueConverter.cs
@@ -163,8 +163,10 @@ partial class PropertyValueConverter : ILogEventPropertyFactory, ILogEventProper
         if (TryConvertValueTuple(value, type, destructuring, out var tupleResult))
             return tupleResult;
 
-        if (TryConvertCompilerGeneratedType(value, type, destructuring, out var compilerGeneratedResult))
+#pragma warning disable IL2072 // analyzer doesn't support feature switches yet
+        if (TrimConfiguration.IsCompilerGeneratedCodeSupported && TryConvertCompilerGeneratedType(value, type, destructuring, out var compilerGeneratedResult))
             return compilerGeneratedResult;
+#pragma warning restore IL2072
 
         return new ScalarValue(value.ToString() ?? "");
     }

--- a/src/Serilog/Configuration/LoggerSettingsConfiguration.cs
+++ b/src/Serilog/Configuration/LoggerSettingsConfiguration.cs
@@ -47,6 +47,7 @@ public class LoggerSettingsConfiguration
     /// <remarks>In case of duplicate keys, the last value for the key is kept and the previous ones are ignored.</remarks>
     /// <exception cref="ArgumentNullException">When <paramref name="settings"/> is <code>null</code></exception>
     [RequiresUnreferencedCode("KeyValuePair scans for configuration assemblies at run time and is not compatible with trimming.")]
+    [RequiresDynamicCode("KeyValuePair may need to create arrays, which requires dynamic code generation and is not compatible with AOT.")]
     public LoggerConfiguration KeyValuePairs(IEnumerable<KeyValuePair<string, string>> settings)
     {
         Guard.AgainstNull(settings);
@@ -60,6 +61,7 @@ public class LoggerSettingsConfiguration
     }
 
     [RequiresUnreferencedCode("KeyValuePair scans for configuration settings at run time.")]
+    [RequiresDynamicCode("Creates arrays of unknown element type")]
     LoggerConfiguration KeyValuePairs(IReadOnlyDictionary<string, string> settings)
     {
         return Settings(new KeyValuePairSettings(settings));

--- a/src/Serilog/Configuration/TrimConfiguration.cs
+++ b/src/Serilog/Configuration/TrimConfiguration.cs
@@ -1,0 +1,13 @@
+
+namespace Serilog.Configuration;
+
+internal static class TrimConfiguration
+{
+    /// <summary>
+    /// True if compiler-generated types is treated specially by Serilog during logging. The main example
+    /// of this would be anonymous types, which have a special compiler-generated form. If this switch is
+    /// disabled, Serilog will not be able to destructure anonymous types, but will still be able to log
+    /// them as scalar values.
+    /// </summary>
+    public static bool IsCompilerGeneratedCodeSupported { get; } = !AppContext.TryGetSwitch("Serilog.IsCompilerGeneratedCodeSupported", out var isEnabled) || isEnabled;
+}

--- a/src/Serilog/ILLink.Substitutions.xml
+++ b/src/Serilog/ILLink.Substitutions.xml
@@ -1,0 +1,8 @@
+<linker>
+  <assembly fullname="Serilog">
+    <type fullname="Serilog.Configuration.TrimConfiguration" >
+      <method signature="System.Boolean get_IsCompilerGeneratedCodeSupported()" body="stub" value="false"
+              feature="Serilog.IsCompilerGeneratedCodeSupported" featurevalue="false" />
+    </type>
+  </assembly>
+</linker>

--- a/src/Serilog/Serilog.csproj
+++ b/src/Serilog/Serilog.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>Simple .NET logging with fully-structured events</Description>
     <VersionPrefix>4.0.0</VersionPrefix>
@@ -51,6 +51,9 @@
     <None Include="../../README.md" Pack="true" Visible="false" PackagePath="/" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
     <PackageReference Include="PolySharp" Version="1.12.1" PrivateAssets="All" />
+    <EmbeddedResource Include="ILLink.Substitutions.xml">
+      <LogicalName>ILLink.Substitutions.xml</LogicalName>
+    </EmbeddedResource>
   </ItemGroup>
 
   <!-- Per-TFM `ItemGroup` for exceptions only: -->

--- a/src/Serilog/Settings/KeyValuePairs/KeyValuePairSettings.cs
+++ b/src/Serilog/Settings/KeyValuePairs/KeyValuePairSettings.cs
@@ -15,6 +15,7 @@
 namespace Serilog.Settings.KeyValuePairs;
 
 [RequiresUnreferencedCode("Scans assemblies at runtime")] // RequiresUnreferencedCode couldn't be applied to types in .NET 5.
+[RequiresDynamicCode("Creates arrays of unknown element type")]
 class KeyValuePairSettings : ILoggerSettings
 {
     const string UsingDirective = "using";
@@ -211,6 +212,7 @@ class KeyValuePairSettings : ILoggerSettings
     }
 
     [RequiresUnreferencedCode("Finds accessors by name")]
+    [RequiresDynamicCode("Creates arrays of unknown element type")]
     static object ConvertOrLookupByName(string valueOrSwitchName, Type type, IReadOnlyDictionary<string, LoggingLevelSwitch> declaredSwitches)
     {
         if (type == typeof(LoggingLevelSwitch))
@@ -221,6 +223,7 @@ class KeyValuePairSettings : ILoggerSettings
     }
 
     [RequiresUnreferencedCode("Finds accessors by name")]
+    [RequiresDynamicCode("Creates arrays of unknown element type")]
     static void ApplyDirectives(List<IGrouping<string, ConfigurationMethodCall>> directives, IList<MethodInfo> configurationMethods, object loggerConfigMethod, IReadOnlyDictionary<string, LoggingLevelSwitch> declaredSwitches)
     {
         foreach (var directiveInfo in directives)
@@ -240,6 +243,7 @@ class KeyValuePairSettings : ILoggerSettings
 
                 // Work around inability to annotate lambdas in query expressions. The parent *must* have RUC for safety.
                 [UnconditionalSuppressMessage("Trimming", "IL2026")]
+                [UnconditionalSuppressMessage("AOT", "IL3050")]
                 object? SuppressConvertCall(ConfigurationMethodCall? directive, ParameterInfo p)
                     => directive == null ? p.DefaultValue : ConvertOrLookupByName(directive.Value, p.ParameterType, declaredSwitches);
 

--- a/src/Serilog/Settings/KeyValuePairs/SettingValueConversions.cs
+++ b/src/Serilog/Settings/KeyValuePairs/SettingValueConversions.cs
@@ -33,6 +33,7 @@ class SettingValueConversions
     };
 
     [RequiresUnreferencedCode("Finds accessors by name")]
+    [RequiresDynamicCode("Creates arrays of unknown element type")]
     public static object? ConvertToType(string value, Type toType)
     {
         if (toType.IsGenericType && toType.GetGenericTypeDefinition() == typeof(Nullable<>))

--- a/test/AotTestApp/AotTestApp.csproj
+++ b/test/AotTestApp/AotTestApp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <PublishAot>true</PublishAot>
@@ -11,6 +11,9 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\Serilog\Serilog.csproj" />
     <TrimmerRootAssembly Include="Serilog" />
+    <RuntimeHostConfigurationOption
+      Include="Serilog.IsCompilerGeneratedCodeSupported"
+      Value="false" Trim="true" />
   </ItemGroup>
 
 </Project>

--- a/test/AotTestApp/AotTestApp.csproj
+++ b/test/AotTestApp/AotTestApp.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net7.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <PublishAot>true</PublishAot>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Serilog\Serilog.csproj" />
+    <TrimmerRootAssembly Include="Serilog" />
+  </ItemGroup>
+
+</Project>

--- a/test/AotTestApp/Program.cs
+++ b/test/AotTestApp/Program.cs
@@ -1,0 +1,2 @@
+// See https://aka.ms/new-console-template for more information
+Console.WriteLine("Hello, World!");

--- a/test/AotTestApp/README.md
+++ b/test/AotTestApp/README.md
@@ -1,0 +1,2 @@
+
+This is a test app to produce AOT warnings. To see all trim warnings, run `dotnet publish` on the current project.

--- a/test/Serilog.ApprovalTests/Serilog.approved.txt
+++ b/test/Serilog.ApprovalTests/Serilog.approved.txt
@@ -62,6 +62,8 @@ namespace Serilog.Configuration
     }
     public class LoggerSettingsConfiguration
     {
+        [System.Diagnostics.CodeAnalysis.RequiresDynamicCode("KeyValuePair may need to create arrays, which requires dynamic code generation an" +
+            "d is not compatible with AOT.")]
         [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("KeyValuePair scans for configuration assemblies at run time and is not compatible" +
             " with trimming.")]
         public Serilog.LoggerConfiguration KeyValuePairs(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, string>> settings) { }


### PR DESCRIPTION
There's one trim warning that the analyzer didn't catch (bug) that the
AOT compiler does. Unfortunately, the warning isn't easily resolvable --
it implies that you can no longer use deconstructed compiler-generated
types (like anonymous types) through the various logging calls.

There's unfortunately no way to perfectly resolve this. This PR proposes
a behavioral change for trimming -- when trimming, compiler-generated
types will be logged like scalars, instead of being deconstructed. This
is not ideal. Libraries should not have significantly different behavior
when trimming without a warning or some other diagnostic being produced.

Unfortunately, the contract implied by the existing code is much too
complicated to be encoded in the trimmer. The contract is that types do
not need to preserve reflection metadata, except for compiler-generated
types, which need public properties. However, the definition of
compiler-generated types is not well-defined. Encoding a heuristic in
Serilog is one thing -- encoding the heuristic in the .NET runtime is
another.

Given the constraints, this seems like the best option.