### PR TITLE
Level override check is case-insensitive.

### DIFF
--- a/src/Serilog/Core/LevelOverrideMap.cs
+++ b/src/Serilog/Core/LevelOverrideMap.cs
@@ -68,7 +68,7 @@ class LevelOverrideMap
     {
         foreach (var levelOverride in _overrides)
         {
-            if (context.StartsWith(levelOverride.Context) &&
+            if (context.StartsWith(levelOverride.Context, StringComparison.OrdinalIgnoreCase) &&
                 (context.Length == levelOverride.Context.Length || context[levelOverride.Context.Length] == '.'))
             {
                 minimumLevel = LevelAlias.Minimum;

--- a/src/Serilog/Core/LevelOverrideMap.cs
+++ b/src/Serilog/Core/LevelOverrideMap.cs
@@ -68,7 +68,11 @@ class LevelOverrideMap
     {
         foreach (var levelOverride in _overrides)
         {
-            if ((context.Length == levelOverride.Context.Length || context[levelOverride.Context.Length] == '.') &&
+            if (
+                (
+                    context.Length == levelOverride.Context.Length ||
+                    (context.Length > levelOverride.Context.Length && context[levelOverride.Context.Length] == '.')
+                ) &&
                 context.StartsWith(levelOverride.Context, StringComparison.OrdinalIgnoreCase))
             {
                 minimumLevel = LevelAlias.Minimum;

--- a/src/Serilog/Core/LevelOverrideMap.cs
+++ b/src/Serilog/Core/LevelOverrideMap.cs
@@ -68,8 +68,8 @@ class LevelOverrideMap
     {
         foreach (var levelOverride in _overrides)
         {
-            if (context.StartsWith(levelOverride.Context, StringComparison.OrdinalIgnoreCase) &&
-                (context.Length == levelOverride.Context.Length || context[levelOverride.Context.Length] == '.'))
+            if ((context.Length == levelOverride.Context.Length || context[levelOverride.Context.Length] == '.') &&
+                context.StartsWith(levelOverride.Context, StringComparison.OrdinalIgnoreCase))
             {
                 minimumLevel = LevelAlias.Minimum;
                 levelSwitch = levelOverride.LevelSwitch;

--- a/test/Serilog.Tests/Core/LevelOverrideMapTests.cs
+++ b/test/Serilog.Tests/Core/LevelOverrideMapTests.cs
@@ -12,6 +12,9 @@ public class LevelOverrideMapTests
     [InlineData("MyApp.Api.Controllers.AboutController", true, Information)]
     [InlineData("MyApp.Api.Controllers.HomeController", true, Warning)]
     [InlineData("Api.Controllers.HomeController", false, LevelAlias.Minimum)]
+    [InlineData("serilog", false, LevelAlias.Minimum)]
+    [InlineData("myapp", true, Debug)]
+    [InlineData("myappsomething", false, LevelAlias.Minimum)]
     public void OverrideScenarios(string context, bool overrideExpected, LogEventLevel expected)
     {
         var overrides = new Dictionary<string, LoggingLevelSwitch>


### PR DESCRIPTION
Fix #1944.

Changes `LevelOverrideMap.GetEffectiveLevel()` to use a case-insensitive comparison for context names, correcting some challenges with setting overrides through mechanisms like environment variables where ALL_CAPS may be used.