### PR TITLE
Add a UtcTimestamp token and a small unit test

### DIFF
--- a/src/Serilog/Formatting/Display/MessageTemplateTextFormatter.cs
+++ b/src/Serilog/Formatting/Display/MessageTemplateTextFormatter.cs
@@ -40,7 +40,7 @@ public class MessageTemplateTextFormatter : ITextFormatter
     public MessageTemplateTextFormatter(string outputTemplate, IFormatProvider? formatProvider = null)
     {
         Guard.AgainstNull(outputTemplate);
-
+          
         _outputTemplate = new MessageTemplateParser().Parse(outputTemplate);
         _formatProvider = formatProvider;
     }
@@ -101,6 +101,10 @@ public class MessageTemplateTextFormatter : ITextFormatter
                 else if (pt.PropertyName == OutputProperties.TimestampPropertyName)
                 {
                     ScalarValue.Render(logEvent.Timestamp, writer, pt.Format, _formatProvider);
+                }
+                else if (pt.PropertyName == OutputProperties.UTCTimestampPropertyName)
+                {
+                    ScalarValue.Render(logEvent.Timestamp.ToUniversalTime(), writer, pt.Format, _formatProvider);
                 }
                 else if (pt.PropertyName == OutputProperties.PropertiesPropertyName)
                 {

--- a/src/Serilog/Formatting/Display/MessageTemplateTextFormatter.cs
+++ b/src/Serilog/Formatting/Display/MessageTemplateTextFormatter.cs
@@ -104,7 +104,7 @@ public class MessageTemplateTextFormatter : ITextFormatter
                 }
                 else if (pt.PropertyName == OutputProperties.UtcTimestampPropertyName)
                 {
-                    ScalarValue.Render(logEvent.Timestamp.ToUniversalTime(), writer, pt.Format, _formatProvider);
+                    ScalarValue.Render(logEvent.Timestamp.UtcDateTime, writer, pt.Format, _formatProvider);
                 }
                 else if (pt.PropertyName == OutputProperties.PropertiesPropertyName)
                 {

--- a/src/Serilog/Formatting/Display/MessageTemplateTextFormatter.cs
+++ b/src/Serilog/Formatting/Display/MessageTemplateTextFormatter.cs
@@ -40,7 +40,7 @@ public class MessageTemplateTextFormatter : ITextFormatter
     public MessageTemplateTextFormatter(string outputTemplate, IFormatProvider? formatProvider = null)
     {
         Guard.AgainstNull(outputTemplate);
-          
+
         _outputTemplate = new MessageTemplateParser().Parse(outputTemplate);
         _formatProvider = formatProvider;
     }
@@ -102,7 +102,7 @@ public class MessageTemplateTextFormatter : ITextFormatter
                 {
                     ScalarValue.Render(logEvent.Timestamp, writer, pt.Format, _formatProvider);
                 }
-                else if (pt.PropertyName == OutputProperties.UTCTimestampPropertyName)
+                else if (pt.PropertyName == OutputProperties.UtcTimestampPropertyName)
                 {
                     ScalarValue.Render(logEvent.Timestamp.ToUniversalTime(), writer, pt.Format, _formatProvider);
                 }

--- a/src/Serilog/Formatting/Display/OutputProperties.cs
+++ b/src/Serilog/Formatting/Display/OutputProperties.cs
@@ -33,7 +33,7 @@ public static class OutputProperties
     /// <summary>
     /// The timestamp of the log event in UTC.
     /// </summary>
-    public const string UTCTimestampPropertyName = "UTCTimestamp";
+    public const string UtcTimestampPropertyName = "UtcTimestamp";
 
     /// <summary>
     /// The level of the log event.

--- a/src/Serilog/Formatting/Display/OutputProperties.cs
+++ b/src/Serilog/Formatting/Display/OutputProperties.cs
@@ -31,6 +31,11 @@ public static class OutputProperties
     public const string TimestampPropertyName = "Timestamp";
 
     /// <summary>
+    /// The timestamp of the log event in UTC.
+    /// </summary>
+    public const string UTCTimestampPropertyName = "UTCTimestamp";
+
+    /// <summary>
     /// The level of the log event.
     /// </summary>
     public const string LevelPropertyName = "Level";

--- a/test/Serilog.ApprovalTests/Serilog.approved.txt
+++ b/test/Serilog.ApprovalTests/Serilog.approved.txt
@@ -463,6 +463,7 @@ namespace Serilog.Formatting.Display
         public const string SpanIdPropertyName = "SpanId";
         public const string TimestampPropertyName = "Timestamp";
         public const string TraceIdPropertyName = "TraceId";
+        public const string UTCTimestampPropertyName = "UTCTimestamp";
     }
 }
 namespace Serilog.Formatting

--- a/test/Serilog.ApprovalTests/Serilog.approved.txt
+++ b/test/Serilog.ApprovalTests/Serilog.approved.txt
@@ -463,7 +463,7 @@ namespace Serilog.Formatting.Display
         public const string SpanIdPropertyName = "SpanId";
         public const string TimestampPropertyName = "Timestamp";
         public const string TraceIdPropertyName = "TraceId";
-        public const string UTCTimestampPropertyName = "UTCTimestamp";
+        public const string UtcTimestampPropertyName = "UtcTimestamp";
     }
 }
 namespace Serilog.Formatting

--- a/test/Serilog.Tests/Formatting/Display/MessageTemplateTextFormatterTests.cs
+++ b/test/Serilog.Tests/Formatting/Display/MessageTemplateTextFormatterTests.cs
@@ -1,6 +1,7 @@
 
 // ReSharper disable StringLiteralTypo
 
+using System;
 using System.Diagnostics;
 
 namespace Serilog.Tests.Formatting.Display;
@@ -385,12 +386,8 @@ public class MessageTemplateTextFormatterTests
     public void UTCTimestampOutputsCorrectValue()
     {
         var formatter = new MessageTemplateTextFormatter("{UTCTimestamp:yyyy-MM-dd hh:mm:ss.fffZ}", CultureInfo.InvariantCulture);
-        var evt = new LogEvent(
-            new(2013, 3, 11, 15, 59, 0, 123, TimeSpan.FromHours(10)),
-            Information,
-            null,
-            Some.MessageTemplate(),
-            Array.Empty<LogEventProperty>());
+
+        var evt = Some.LogEvent(timestamp: new(2013, 3, 11, 15, 59, 0, 123, TimeSpan.FromHours(10)));
 
         var sw = new StringWriter();
         formatter.Format(evt, sw);

--- a/test/Serilog.Tests/Formatting/Display/MessageTemplateTextFormatterTests.cs
+++ b/test/Serilog.Tests/Formatting/Display/MessageTemplateTextFormatterTests.cs
@@ -384,7 +384,7 @@ public class MessageTemplateTextFormatterTests
     [Fact]
     public void UTCTimestampOutputsCorrectValue()
     {
-        var formatter = new MessageTemplateTextFormatter("{UTCTimestamp:yyyy-MM-dd hh:mm:ss.fffZ}", CultureInfo.InvariantCulture);
+        var formatter = new MessageTemplateTextFormatter("{UtcTimestamp:yyyy-MM-dd hh:mm:ss.fffZ}", CultureInfo.InvariantCulture);
 
         var evt = Some.LogEvent(timestamp: new(2013, 3, 11, 15, 59, 0, 123, TimeSpan.FromHours(10)));
 

--- a/test/Serilog.Tests/Formatting/Display/MessageTemplateTextFormatterTests.cs
+++ b/test/Serilog.Tests/Formatting/Display/MessageTemplateTextFormatterTests.cs
@@ -382,7 +382,7 @@ public class MessageTemplateTextFormatterTests
     }
 
     [Fact]
-    public void UTCTimestampOutputsCorrectValue()
+    public void UtcTimestampOutputsCorrectValue()
     {
         var formatter = new MessageTemplateTextFormatter("{UtcTimestamp:yyyy-MM-dd hh:mm:ss.fffZ}", CultureInfo.InvariantCulture);
 

--- a/test/Serilog.Tests/Formatting/Display/MessageTemplateTextFormatterTests.cs
+++ b/test/Serilog.Tests/Formatting/Display/MessageTemplateTextFormatterTests.cs
@@ -1,7 +1,6 @@
 
 // ReSharper disable StringLiteralTypo
 
-using System;
 using System.Diagnostics;
 
 namespace Serilog.Tests.Formatting.Display;

--- a/test/Serilog.Tests/Formatting/Display/MessageTemplateTextFormatterTests.cs
+++ b/test/Serilog.Tests/Formatting/Display/MessageTemplateTextFormatterTests.cs
@@ -380,4 +380,20 @@ public class MessageTemplateTextFormatterTests
         formatter.Format(evt, sw);
         Assert.Equal($"{traceId}/{spanId}", sw.ToString());
     }
+
+    [Fact]
+    public void UTCTimestampOutputsCorrectValue()
+    {
+        var formatter = new MessageTemplateTextFormatter("{UTCTimestamp:yyyy-MM-dd hh:mm:ss.fffZ}", CultureInfo.InvariantCulture);
+        var evt = new LogEvent(
+            new(2013, 3, 11, 15, 59, 0, 123, TimeSpan.FromHours(10)),
+            Information,
+            null,
+            Some.MessageTemplate(),
+            Array.Empty<LogEventProperty>());
+
+        var sw = new StringWriter();
+        formatter.Format(evt, sw);
+        Assert.Equal("2013-03-11 05:59:00.123Z", sw.ToString());
+    }
 }


### PR DESCRIPTION
Add the **UtcTimestamp** token to the MesageTemplateFormatter, allowing for built in support of logging timestamps in UTC in custom formats without having to use the various workarounds (expressions/custom properties etc). Also added a small unit test to show that the correct value is output, and with a custom format.