### PR TITLE
Redesign `LoggerSinkConfiguration.Wrap()`, and introduce `LoggerSinkConfiguration.CreateSink()`

### DIFF
--- a/src/Serilog/Configuration/LoggerSinkConfiguration.cs
+++ b/src/Serilog/Configuration/LoggerSinkConfiguration.cs
@@ -340,7 +340,7 @@ public class LoggerSinkConfiguration
         configure(capturingLoggerSinkConfiguration);
 
         return sinksToWrap.Count == 1 ?
-            sinksToWrap.Single() :
+            sinksToWrap[0] :
             new DisposingAggregateSink(sinksToWrap);
     }
 }

--- a/test/Serilog.ApprovalTests/Serilog.approved.txt
+++ b/test/Serilog.ApprovalTests/Serilog.approved.txt
@@ -90,6 +90,10 @@ namespace Serilog.Configuration
             where TSink : Serilog.Core.ILogEventSink, new () { }
         public Serilog.LoggerConfiguration Sink<TSink>(Serilog.Configuration.BatchingOptions batchingOptions, Serilog.Events.LogEventLevel restrictedToMinimumLevel = 0, Serilog.Core.LoggingLevelSwitch? levelSwitch = null)
             where TSink : Serilog.Core.IBatchedLogEventSink, new () { }
+        public static Serilog.Core.ILogEventSink CreateSink(System.Action<Serilog.Configuration.LoggerSinkConfiguration> configure) { }
+        public static Serilog.Core.ILogEventSink Wrap(System.Func<Serilog.Core.ILogEventSink, Serilog.Core.ILogEventSink> wrapSink, System.Action<Serilog.Configuration.LoggerSinkConfiguration> configureWrappedSink) { }
+        [System.Obsolete("Use the two-argument `Wrap()` overload to construct a wrapper, then use `WriteTo." +
+            "Sink()` to add it to the configuration.")]
         public static Serilog.LoggerConfiguration Wrap(Serilog.Configuration.LoggerSinkConfiguration loggerSinkConfiguration, System.Func<Serilog.Core.ILogEventSink, Serilog.Core.ILogEventSink> wrapSink, System.Action<Serilog.Configuration.LoggerSinkConfiguration> configureWrappedSink, Serilog.Events.LogEventLevel restrictedToMinimumLevel = 0, Serilog.Core.LoggingLevelSwitch? levelSwitch = null) { }
     }
 }

--- a/test/Serilog.Tests/Configuration/LoggerConfigurationTests.cs
+++ b/test/Serilog.Tests/Configuration/LoggerConfigurationTests.cs
@@ -1,6 +1,6 @@
 // ReSharper disable PossibleNullReferenceException
 
-namespace Serilog.Tests;
+namespace Serilog.Tests.Configuration;
 
 public class LoggerConfigurationTests
 {
@@ -600,129 +600,6 @@ public class LoggerConfigurationTests
         logger.Information("{@Value}", new Value());
 
         Assert.True(true, "No exception reached the caller");
-    }
-
-    [Fact]
-    public void WrappingDecoratesTheConfiguredSink()
-    {
-        DummyWrappingSink.Reset();
-        var sink = new CollectingSink();
-        var logger = new LoggerConfiguration()
-            .WriteTo.Dummy(w => w.Sink(sink))
-            .CreateLogger();
-
-        var evt = Some.InformationEvent();
-        logger.Write(evt);
-
-        Assert.Same(evt, DummyWrappingSink.Emitted.Single());
-        Assert.Same(evt, sink.SingleEvent);
-    }
-
-    [Fact]
-    public void WrappingDoesNotPermitEnrichment()
-    {
-        var sink = new CollectingSink();
-        var propertyName = Some.String();
-        var logger = new LoggerConfiguration()
-            .WriteTo.Dummy(w => w.Sink(sink)
-                .Enrich.WithProperty(propertyName, 1))
-            .CreateLogger();
-
-        var evt = Some.InformationEvent();
-        logger.Write(evt);
-
-        Assert.Same(evt, sink.SingleEvent);
-        Assert.False(evt.Properties.ContainsKey(propertyName));
-    }
-
-    [Fact]
-    public void WrappingIsAppliedWhenChaining()
-    {
-        DummyWrappingSink.Reset();
-        var sink1 = new CollectingSink();
-        var sink2 = new CollectingSink();
-        var logger = new LoggerConfiguration()
-            .WriteTo.Dummy(w => w.Sink(sink1)
-                .WriteTo.Sink(sink2))
-            .CreateLogger();
-
-        var evt = Some.InformationEvent();
-        logger.Write(evt);
-
-        Assert.Same(evt, DummyWrappingSink.Emitted.Single());
-        Assert.Same(evt, sink1.SingleEvent);
-        Assert.Same(evt, sink2.SingleEvent);
-    }
-
-    [Fact]
-    public void WrappingIsAppliedWhenCallingMultipleTimes()
-    {
-        DummyWrappingSink.Reset();
-        var sink1 = new CollectingSink();
-        var sink2 = new CollectingSink();
-        var logger = new LoggerConfiguration()
-            .WriteTo.Dummy(w =>
-            {
-                w.Sink(sink1);
-                w.Sink(sink2);
-            })
-            .CreateLogger();
-
-        var evt = Some.InformationEvent();
-        logger.Write(evt);
-
-        Assert.Same(evt, DummyWrappingSink.Emitted.Single());
-        Assert.Same(evt, sink1.SingleEvent);
-        Assert.Same(evt, sink2.SingleEvent);
-    }
-
-    [Fact]
-    public void WrappingSinkRespectsLogEventLevelSetting()
-    {
-        DummyWrappingSink.Reset();
-        var sink = new CollectingSink();
-        var logger = new LoggerConfiguration()
-            .WriteTo.DummyWrap(w => w.Sink(sink), Error, null)
-            .CreateLogger();
-
-        logger.Write(Some.InformationEvent());
-
-        Assert.Empty(DummyWrappingSink.Emitted);
-        Assert.Empty(sink.Events);
-    }
-
-    [Fact]
-    public void WrappingSinkRespectsLevelSwitchSetting()
-    {
-        DummyWrappingSink.Reset();
-        var sink = new CollectingSink();
-        var logger = new LoggerConfiguration()
-            .WriteTo.DummyWrap(
-                w => w.Sink(sink), LogEventLevel.Verbose,
-                new(Error))
-            .CreateLogger();
-
-        logger.Write(Some.InformationEvent());
-
-        Assert.Empty(DummyWrappingSink.Emitted);
-        Assert.Empty(sink.Events);
-    }
-
-    [Fact]
-    public void WrappingSinkReceivesEventsWhenLevelIsAppropriate()
-    {
-        DummyWrappingSink.Reset();
-        var sink = new CollectingSink();
-        var logger = new LoggerConfiguration()
-            .WriteTo.DummyWrap(
-                w => w.Sink(sink), LogEventLevel.Error,
-                new(Verbose))
-            .CreateLogger();
-
-        logger.Write(Some.InformationEvent());
-
-        Assert.NotEmpty(DummyWrappingSink.Emitted);
-        Assert.NotEmpty(sink.Events);
     }
 
     [Fact]

--- a/test/Serilog.Tests/Configuration/LoggerSinkConfigurationTests.cs
+++ b/test/Serilog.Tests/Configuration/LoggerSinkConfigurationTests.cs
@@ -64,7 +64,7 @@ public class LoggerSinkConfigurationTests
         var propertyName = Some.String();
         var wrapper = LoggerSinkConfiguration.Wrap(
             s => new DelegatingSink(s.Emit),
-            w => w
+            wt => wt
                 .Sink(enclosed)
                 .Enrich.WithProperty(propertyName, 1));
 

--- a/test/Serilog.Tests/Configuration/LoggerSinkConfigurationTests.cs
+++ b/test/Serilog.Tests/Configuration/LoggerSinkConfigurationTests.cs
@@ -1,0 +1,96 @@
+namespace Serilog.Tests.Configuration;
+
+public class LoggerSinkConfigurationTests
+{
+    [Fact]
+    public void CreateSinkSucceedsWhenNoSinksAreConfigured()
+    {
+        var sink = LoggerSinkConfiguration.CreateSink(_ => { });
+        Assert.NotNull(sink);
+
+        // Does nothing.
+        sink.Emit(Some.LogEvent());
+    }
+
+    [Fact]
+    public void CreateSinkSucceedsWhenOneSinkIsConfigured()
+    {
+        var single = new CollectingSink();
+        var sink = LoggerSinkConfiguration.CreateSink(wt => wt.Sink(single));
+        Assert.Same(single, sink);
+    }
+
+    [Fact]
+    public void CreateSinkSucceedsWhenManySinksConfigured()
+    {
+        var first = new CollectingSink();
+        var second = new CollectingSink();
+        var sink = LoggerSinkConfiguration.CreateSink(wt => wt.Sink(first).WriteTo.Sink(second));
+        var evt = Some.LogEvent();
+        sink.Emit(evt);
+        Assert.Same(evt, first.SingleEvent);
+        Assert.Same(evt, second.SingleEvent);
+    }
+
+    [Fact]
+    public void WrapDelegatesToTheEnclosedSink()
+    {
+        var enclosed = new CollectingSink();
+        var wrapper = LoggerSinkConfiguration.Wrap(s => new DelegatingSink(s.Emit), wt => wt.Sink(enclosed));
+        Assert.IsType<DelegatingSink>(wrapper);
+        var evt = Some.LogEvent();
+        wrapper.Emit(evt);
+        Assert.Same(evt, enclosed.SingleEvent);
+    }
+
+    [Fact]
+    public void WrapPropagatesDisposalToTheEnclosedSink()
+    {
+        var enclosed = new DisposeTrackingSink();
+        var wrapper = LoggerSinkConfiguration.Wrap(s => new DelegatingSink(s.Emit), wt => wt.Sink(enclosed));
+
+        // DelegatingSink is not IDisposable, but DisposeTrackingSink is, so a proxy is returned.
+        Assert.IsNotType<DelegatingSink>(wrapper);
+
+        var disposable = Assert.IsAssignableFrom<IDisposable>(wrapper);
+        disposable.Dispose();
+        Assert.True(enclosed.IsDisposed);
+    }
+
+    [Fact]
+    public void WrappingDoesNotPermitEnrichment()
+    {
+        var enclosed = new CollectingSink();
+        var propertyName = Some.String();
+        var wrapper = LoggerSinkConfiguration.Wrap(
+            s => new DelegatingSink(s.Emit),
+            w => w
+                .Sink(enclosed)
+                .Enrich.WithProperty(propertyName, 1));
+
+        var evt = Some.InformationEvent();
+        wrapper.Emit(evt);
+
+        Assert.Same(evt, enclosed.SingleEvent);
+        Assert.False(evt.Properties.ContainsKey(propertyName));
+    }
+
+    [Fact]
+    public void WrappingIsAppliedWhenChaining()
+    {
+        DummyWrappingSink.Reset();
+        var sink1 = new CollectingSink();
+        var sink2 = new CollectingSink();
+        var logger = new LoggerConfiguration()
+            .WriteTo.DummyWrapper(w => w.Sink(sink1)
+                .WriteTo.Sink(sink2))
+            .CreateLogger();
+
+        var evt = Some.InformationEvent();
+        logger.Write(evt);
+
+        Assert.Same(evt, DummyWrappingSink.Emitted.Single());
+        Assert.Same(evt, sink1.SingleEvent);
+        Assert.Same(evt, sink2.SingleEvent);
+    }
+}

--- a/test/Serilog.Tests/Configuration/LoggerSinkConfigurationTests.cs
+++ b/test/Serilog.Tests/Configuration/LoggerSinkConfigurationTests.cs
@@ -74,23 +74,4 @@ public class LoggerSinkConfigurationTests
         Assert.Same(evt, enclosed.SingleEvent);
         Assert.False(evt.Properties.ContainsKey(propertyName));
     }
-
-    [Fact]
-    public void WrappingIsAppliedWhenChaining()
-    {
-        DummyWrappingSink.Reset();
-        var sink1 = new CollectingSink();
-        var sink2 = new CollectingSink();
-        var logger = new LoggerConfiguration()
-            .WriteTo.DummyWrapper(w => w.Sink(sink1)
-                .WriteTo.Sink(sink2))
-            .CreateLogger();
-
-        var evt = Some.InformationEvent();
-        logger.Write(evt);
-
-        Assert.Same(evt, DummyWrappingSink.Emitted.Single());
-        Assert.Same(evt, sink1.SingleEvent);
-        Assert.Same(evt, sink2.SingleEvent);
-    }
 }

--- a/test/Serilog.Tests/Core/AuditSinkTests.cs
+++ b/test/Serilog.Tests/Core/AuditSinkTests.cs
@@ -54,6 +54,7 @@ public class AuditSinkTests
             .CreateLogger();
 
         logger.Information("{@Value}", new ThrowingProperty());
+        // ([implicit] 'assertion' is that the exception is handled and does not propagate)
     }
 
     [Fact]

--- a/test/Serilog.Tests/Core/AuditSinkTests.cs
+++ b/test/Serilog.Tests/Core/AuditSinkTests.cs
@@ -31,7 +31,7 @@ public class AuditSinkTests
             .CreateLogger();
 
         Assert.Throws<AggregateException>(() => logger
-            .ForContext<LoggerConfigurationTests>()
+            .ForContext<AuditSinkTests>()
             .Write(Some.InformationEvent()));
     }
 
@@ -54,8 +54,6 @@ public class AuditSinkTests
             .CreateLogger();
 
         logger.Information("{@Value}", new ThrowingProperty());
-
-        Assert.True(true, "No exception reached the caller");
     }
 
     [Fact]

--- a/test/Serilog.Tests/Core/LoggerTests.cs
+++ b/test/Serilog.Tests/Core/LoggerTests.cs
@@ -252,7 +252,7 @@ public class LoggerTests
     {
         var sink = new DisposeTrackingSink();
         var log = new LoggerConfiguration()
-            .WriteTo.Dummy(wrapped => wrapped.Sink(sink))
+            .WriteTo.DummyWrapper(wrapped => wrapped.Sink(sink))
             .CreateLogger();
 
         log.Dispose();
@@ -266,7 +266,7 @@ public class LoggerTests
         var sinkA = new DisposeTrackingSink();
         var sinkB = new DisposeTrackingSink();
         var log = new LoggerConfiguration()
-            .WriteTo.Dummy(wrapped => wrapped.Sink(sinkA).WriteTo.Sink(sinkB))
+            .WriteTo.DummyWrapper(wrapped => wrapped.Sink(sinkA).WriteTo.Sink(sinkB))
             .CreateLogger();
 
         log.Dispose();
@@ -395,7 +395,7 @@ public class LoggerTests
     {
         var sink = new DisposeTrackingSink();
         var log = new LoggerConfiguration()
-            .WriteTo.Dummy(wrapped => wrapped.Sink(sink))
+            .WriteTo.DummyWrapper(wrapped => wrapped.Sink(sink))
             .CreateLogger();
 
         await log.DisposeAsync();
@@ -408,7 +408,7 @@ public class LoggerTests
     {
         var sink = new AsyncDisposeTrackingSink();
         var log = new LoggerConfiguration()
-            .WriteTo.Dummy(wrapped => wrapped.Sink(sink))
+            .WriteTo.DummyWrapper(wrapped => wrapped.Sink(sink))
             .CreateLogger();
 
         await log.DisposeAsync();
@@ -422,7 +422,7 @@ public class LoggerTests
         var sinkA = new DisposeTrackingSink();
         var sinkB = new AsyncDisposeTrackingSink();
         var log = new LoggerConfiguration()
-            .WriteTo.Dummy(wrapped => wrapped.Sink(sinkA).WriteTo.Sink(sinkB))
+            .WriteTo.DummyWrapper(wrapped => wrapped.Sink(sinkA).WriteTo.Sink(sinkB))
             .CreateLogger();
 
         await log.DisposeAsync();

--- a/test/TestDummies/DummyLoggerConfigurationExtensions.cs
+++ b/test/TestDummies/DummyLoggerConfigurationExtensions.cs
@@ -49,28 +49,24 @@ public static class DummyLoggerConfigurationExtensions
         return loggerSinkConfiguration.Sink(new DummyConsoleSink(theme), restrictedToMinimumLevel);
     }
 
-    public static LoggerConfiguration Dummy(
+    public static LoggerConfiguration DummyWrapper(
         this LoggerSinkConfiguration loggerSinkConfiguration,
         Action<LoggerSinkConfiguration> wrappedSinkAction)
     {
-        return LoggerSinkConfiguration.Wrap(
-            loggerSinkConfiguration,
+        return loggerSinkConfiguration.Sink(LoggerSinkConfiguration.Wrap(
             s => new DummyWrappingSink(s),
-            wrappedSinkAction,
-            LevelAlias.Minimum,
-            null);
+            wrappedSinkAction));
     }
 
-    public static LoggerConfiguration DummyWrap(
+    public static LoggerConfiguration DummyWrapper(
         this LoggerSinkConfiguration loggerSinkConfiguration,
         Action<LoggerSinkConfiguration> wrappedSinkAction,
         LogEventLevel logEventLevel,
         LoggingLevelSwitch? levelSwitch)
     {
-        return LoggerSinkConfiguration.Wrap(
-            loggerSinkConfiguration,
+        return loggerSinkConfiguration.Sink(LoggerSinkConfiguration.Wrap(
             s => new DummyWrappingSink(s),
-            wrappedSinkAction,
+            wrappedSinkAction),
             logEventLevel,
             levelSwitch);
     }


### PR DESCRIPTION
Serilog sinks push for factory methods for sink construction and composition (`WriteTo.File()`), rather than an "OO" style of public sink types and constructors (`new FileSink(...)`).

The existing `LoggerSinkConfiguration.Wrap()` method is a helper used by wrapping sink implementations, such as _Serilog.Sinks.Async_, and the core `WriteTo.Conditional()` method, to enclose one or more sinks in a "wrapper" that modifies their behavior in some way.

The existing `Wrap()` method has three roles: providing access to the enclosed sinks created via their factory methods, delegating `IDisposable.Dispose()` to the enclosed sinks so that wrappers don't need to implement it explicitly, and applying a `LoggingLevelSwitch`/minimum level to the completed result.

This PR pulls out the two main responsibilities, so that it's now possible to create an `ILogEventSink` without constructing the full logger pipeline (previously only possible using a hack based on the `Wrap()` call), and it's separately possible to wrap a given sink instance.

Creating sinks is performed using `LoggerSinkConfiguration.CreateSink()`:

```csharp
var sink = new LoggerSinkConfiguration.CreateSink(wt => wt.File(...));
// `sink` is now a `FileSink` or similar
```

Wrapping uses a new overload of `LoggerSinkConfiguration.Wrap()`:

```csharp
var wrapper = LoggerSinkConfiguration.Wrap(
    enclosed => new Wrapper(enclosed),
    wt => wt.File(...));
```

Although it would be possible to simplify this further into `Wrap(sink, wrapper)`, i.e. fully-construct both sink and wrapper, and then just perform disposal delegation in `Wrap()`:

 * the equal types of the two sink arguments would make usage error-prone,
 * almost all usage needs to apply a `WriteTo` callback anyway, and
 * it's possible to use pre-constructed sinks and wrappers with this API if necessary.

Finally, the `LoggingLevelSwitch` and minimum level responsibilities are now handed off to `WriteTo.Sink()`. Since `CreateSink()` and `Wrap()` just return `ILogEventSink`, there's no need for either of those to have any interaction with levelling.

Why make these changes now? With the introduction of `WriteTo.Batched()`, code that previously relied on constructing `PeriodicBatchingSink` will be ported over to it. Unlike the older API, no sink class is exposed - batching is only available through the factory method. This makes porting nontrivial usage of PBS harder. `CreateSink()` fixes this.