### PR TITLE
`MessageTemplateParser` refactor incl. experiemental `.` support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -331,3 +331,5 @@ ASALocalRun/
 *.orig
 
 *.received.txt
+
+.DS_Store

--- a/src/Serilog/Parsing/MessageTemplateParser.cs
+++ b/src/Serilog/Parsing/MessageTemplateParser.cs
@@ -91,13 +91,12 @@ public class MessageTemplateParser : IMessageTemplateParser
     {
         var first = startAt;
         startAt++;
-        while (startAt < messageTemplate.Length && IsValidInPropertyTag(messageTemplate[startAt]))
-            startAt++;
 
-        if (startAt == messageTemplate.Length || messageTemplate[startAt] != '}')
+        startAt = messageTemplate.IndexOf('}', startAt);
+        if (startAt == -1)
         {
-            next = startAt;
-            return new TextToken(messageTemplate.Substring(first, next - first));
+            next = messageTemplate.Length;
+            return new TextToken(messageTemplate.Substring(first));
         }
 
         next = startAt + 1;

--- a/src/Serilog/Parsing/MessageTemplateParser.cs
+++ b/src/Serilog/Parsing/MessageTemplateParser.cs
@@ -21,25 +21,25 @@ namespace Serilog.Parsing;
 public class MessageTemplateParser : IMessageTemplateParser
 {
     /// <summary>
-    /// When set, property names in templates may include `.` and `-`.
+    /// When set, property names in templates may include `.`.
     /// </summary>
-    static readonly bool DefaultAcceptExtendedPropertyNames = AppContext.TryGetSwitch("Serilog.Parsing.MessageTemplateParser.AcceptExtendedPropertyNames", out var isEnabled) && isEnabled;
+    static readonly bool DefaultAcceptDottedPropertyNames = AppContext.TryGetSwitch("Serilog.Parsing.MessageTemplateParser.AcceptDottedPropertyNames", out var isEnabled) && isEnabled;
 
     static readonly TextToken EmptyTextToken = new("");
 
-    readonly bool _acceptExtendedPropertyNames;
+    readonly bool _acceptDottedPropertyNames;
 
     /// <summary>
     /// Construct a <see cref="MessageTemplateParser"/>.
     /// </summary>
     public MessageTemplateParser()
-        : this(DefaultAcceptExtendedPropertyNames)
+        : this(DefaultAcceptDottedPropertyNames)
     {
     }
 
-    internal MessageTemplateParser(bool acceptExtendedPropertyNames)
+    internal MessageTemplateParser(bool acceptDottedPropertyNames)
     {
-        _acceptExtendedPropertyNames = acceptExtendedPropertyNames;
+        _acceptDottedPropertyNames = acceptDottedPropertyNames;
     }
 
     /// <summary>
@@ -219,7 +219,7 @@ public class MessageTemplateParser : IMessageTemplateParser
     bool IsValidInPropertyName(char c) =>
         char.IsLetterOrDigit(c) ||
         c is '_' ||
-        _acceptExtendedPropertyNames && c is '.' or '-';
+        _acceptDottedPropertyNames && c is '.';
 
     static bool TryGetDestructuringHint(char c, out Destructuring destructuring)
     {

--- a/src/Serilog/Parsing/MessageTemplateParser.cs
+++ b/src/Serilog/Parsing/MessageTemplateParser.cs
@@ -216,14 +216,6 @@ public class MessageTemplateParser : IMessageTemplateParser
         return true;
     }
 
-    bool IsValidInPropertyTag(char c)
-    {
-        return IsValidInDestructuringHint(c) ||
-               IsValidInPropertyName(c) ||
-               IsValidInFormat(c) ||
-               c == ':';
-    }
-
     bool IsValidInPropertyName(char c) =>
         char.IsLetterOrDigit(c) ||
         c is '_' ||

--- a/src/Serilog/Parsing/MessageTemplateParser.cs
+++ b/src/Serilog/Parsing/MessageTemplateParser.cs
@@ -304,7 +304,7 @@ public class MessageTemplateParser : IMessageTemplateParser
         }
 
         // We must have encountered an escaped character sequence: finish the text token, using the
-        // accumulator. This is relatively uncommon so we just to it char-by-char.
+        // accumulator. This is relatively uncommon so we just do it char-by-char.
         while (i < messageTemplate.Length)
         {
             ch = messageTemplate[i];

--- a/src/Serilog/Parsing/MessageTemplateParser.cs
+++ b/src/Serilog/Parsing/MessageTemplateParser.cs
@@ -21,6 +21,28 @@ namespace Serilog.Parsing;
 public class MessageTemplateParser : IMessageTemplateParser
 {
     /// <summary>
+    /// When set, property names in templates may include `.` and `-`.
+    /// </summary>
+    static readonly bool DefaultAcceptExtendedPropertyNames = AppContext.TryGetSwitch("Serilog.Parsing.MessageTemplateParser.AcceptExtendedPropertyNames", out var isEnabled) && isEnabled;
+
+    static readonly TextToken EmptyTextToken = new("");
+
+    readonly bool _acceptExtendedPropertyNames;
+
+    /// <summary>
+    /// Construct a <see cref="MessageTemplateParser"/>.
+    /// </summary>
+    public MessageTemplateParser()
+        : this(DefaultAcceptExtendedPropertyNames)
+    {
+    }
+
+    internal MessageTemplateParser(bool acceptExtendedPropertyNames)
+    {
+        _acceptExtendedPropertyNames = acceptExtendedPropertyNames;
+    }
+
+    /// <summary>
     /// Parse the supplied message template.
     /// </summary>
     /// <param name="messageTemplate">The message template to parse.</param>
@@ -36,13 +58,11 @@ public class MessageTemplateParser : IMessageTemplateParser
         return new(messageTemplate, Tokenize(messageTemplate));
     }
 
-    static TextToken emptyTextToken = new("");
-
-    static IEnumerable<MessageTemplateToken> Tokenize(string messageTemplate)
+    IEnumerable<MessageTemplateToken> Tokenize(string messageTemplate)
     {
         if (messageTemplate.Length == 0)
         {
-            yield return emptyTextToken;
+            yield return EmptyTextToken;
             yield break;
         }
 
@@ -67,7 +87,7 @@ public class MessageTemplateParser : IMessageTemplateParser
         }
     }
 
-    static MessageTemplateToken ParsePropertyToken(int startAt, string messageTemplate, out int next)
+    MessageTemplateToken ParsePropertyToken(int startAt, string messageTemplate, out int next)
     {
         var first = startAt;
         startAt++;
@@ -197,7 +217,7 @@ public class MessageTemplateParser : IMessageTemplateParser
         return true;
     }
 
-    static bool IsValidInPropertyTag(char c)
+    bool IsValidInPropertyTag(char c)
     {
         return IsValidInDestructuringHint(c) ||
                IsValidInPropertyName(c) ||
@@ -205,7 +225,10 @@ public class MessageTemplateParser : IMessageTemplateParser
                c == ':';
     }
 
-    static bool IsValidInPropertyName(char c) => char.IsLetterOrDigit(c) || c == '_';
+    bool IsValidInPropertyName(char c) =>
+        char.IsLetterOrDigit(c) ||
+        c is '_' ||
+        _acceptExtendedPropertyNames && c is '.' or '-';
 
     static bool TryGetDestructuringHint(char c, out Destructuring destructuring)
     {

--- a/test/Serilog.PerformanceTests/MessageTemplateParsingBenchmark.cs
+++ b/test/Serilog.PerformanceTests/MessageTemplateParsingBenchmark.cs
@@ -6,14 +6,7 @@ namespace Serilog.PerformanceTests;
 [MemoryDiagnoser]
 public class MessageTemplateParsingBenchmark
 {
-    MessageTemplateParser _parser = null!;
-    const string _DefaultConsoleOutputTemplate = "{Timestamp:yyyy-MM-dd HH:mm:ss} [{Level}] {Message}{NewLine}{Exception}";
-
-    [GlobalSetup]
-    public void Setup()
-    {
-        _parser = new MessageTemplateParser();
-    }
+    MessageTemplateParser _parser = new();
 
     [Benchmark(Baseline = true)]
     public void EmptyTemplate()
@@ -24,6 +17,12 @@ public class MessageTemplateParsingBenchmark
     [Benchmark]
     public void DefaultConsoleOutputTemplate()
     {
-        _parser.Parse(_DefaultConsoleOutputTemplate);
+        _parser.Parse("{Timestamp:yyyy-MM-dd HH:mm:ss} [{Level}] {Message}{NewLine}{Exception}");
+    }
+
+    [Benchmark]
+    public void LiteralTextOnly()
+    {
+        _parser.Parse("Token validated for claims principal with identifier `HJdfshjka678-HJK68SFHJKhjkfsdhjsd456`");
     }
 }

--- a/test/Serilog.Tests/Parsing/MessageTemplateParserTests.cs
+++ b/test/Serilog.Tests/Parsing/MessageTemplateParserTests.cs
@@ -107,8 +107,8 @@ public class MessageTemplateParserTests
     [Theory]
     [InlineData("{test.name}")]
     [InlineData("{test-name}")]
-    // Questionable cases
     [InlineData("{te.st.na.me}")]
+    // Questionable syntax but permitted by the experimental flag.
     [InlineData("{.te.st.na.me-}")]
     public void DashedAndDottedNamesAreAcceptedWhenFeatureFlaggedIn(string template)
     {

--- a/test/Serilog.Tests/Parsing/MessageTemplateParserTests.cs
+++ b/test/Serilog.Tests/Parsing/MessageTemplateParserTests.cs
@@ -106,13 +106,17 @@ public class MessageTemplateParserTests
 
     [Theory]
     [InlineData("{test.name}")]
-    [InlineData("{test-name}")]
     [InlineData("{te.st.na.me}")]
-    // Questionable syntax but permitted by the experimental flag.
-    [InlineData("{.te.st.na.me-}")]
+    // Questionable syntax but permitted by the experimental flag. These are documented here so that if the
+    // feature progresses to first-class support, they can be detected and dealt with accordingly.
+    [InlineData("{.testname}")]
+    [InlineData("{testname.}")]
+    [InlineData("{.}")]
+    [InlineData("{..}")]
+    [InlineData("{test..name}")]
     public void DashedAndDottedNamesAreAcceptedWhenFeatureFlaggedIn(string template)
     {
-        var parser = new MessageTemplateParser(acceptExtendedPropertyNames: true);
+        var parser = new MessageTemplateParser(acceptDottedPropertyNames: true);
         var token = Assert.Single(parser.Parse(template).Tokens);
         var propertyToken = Assert.IsType<PropertyToken>(token);
         var expected = template.Trim('{', '}');

--- a/test/Serilog.Tests/Parsing/MessageTemplateParserTests.cs
+++ b/test/Serilog.Tests/Parsing/MessageTemplateParserTests.cs
@@ -14,8 +14,8 @@ public class MessageTemplateParserTests
     {
         var parsed = Parse(message);
         Assert.Equal(
-            parsed,
-            messageTemplateTokens);
+            messageTemplateTokens,
+            parsed);
     }
 
     [Fact]


### PR DESCRIPTION
This PR came out of, and includes, #1384. You can read about the reasons for considering `.` in message template property names, and the various caveats/disadvantages on that thread. The PR enables wider investigation and experimentation, and there is currently no guarantee that this will ever become a first-class, supported Serilog feature.

By setting the experimental and **unsupported** `AppContext` switch at program start-up:

```csharp
AppContext.SetSwitch("Serilog.Parsing.MessageTemplateParser.AcceptDottedPropertyNames", true)
```

Placeholders such as `{http.request.method}` will (should!) be accepted in message and output templates. Previously, these templates would have been regarded as invalid.

Dotted placeholders will be interpreted as literal property names, e.g. `"http.request.method"`, and not structured object paths like `{http: {request: {method: ...}}}`.

In the process of investigating this I cleaned up some message template parsing tests; these are _so old_ and could use a lot more work, especially translating long multi-assert tests into data-driven `[Theory]`s.

`MessageTemplateParser` itself has also been unchanged for a long time. It could benefit from porting to a `Span<T>`-based model, but even improving our use of vanilla `string` methods yielded a significant performance boost. Long runs of literal text (very common in real-world logs) now allocate dramatically less temporary memory during parsing.

**Before:**

```
BenchmarkDotNet=v0.13.5, OS=macOS 14.4.1 (23E224) [Darwin 23.4.0]
Apple M3 Pro, 1 CPU, 11 logical and 11 physical cores
.NET SDK=8.0.204
  [Host]     : .NET 8.0.4 (8.0.424.16909), Arm64 RyuJIT AdvSIMD
  DefaultJob : .NET 8.0.4 (8.0.424.16909), Arm64 RyuJIT AdvSIMD

|                       Method |      Mean |    Error |   StdDev | Ratio | RatioSD |   Gen0 | Allocated | Alloc Ratio |
|----------------------------- |----------:|---------:|---------:|------:|--------:|-------:|----------:|------------:|
|                EmptyTemplate |  46.98 ns | 0.175 ns | 0.164 ns |  1.00 |    0.00 | 0.0268 |     224 B |        1.00 |
| DefaultConsoleOutputTemplate | 475.56 ns | 3.038 ns | 2.842 ns | 10.12 |    0.08 | 0.2575 |    2160 B |        9.64 |
|              LiteralTextOnly | 171.53 ns | 0.223 ns | 0.209 ns |  3.65 |    0.01 | 0.1194 |    1000 B |        4.46 |
```

**After:**

```
BenchmarkDotNet=v0.13.5, OS=macOS 14.4.1 (23E224) [Darwin 23.4.0]
Apple M3 Pro, 1 CPU, 11 logical and 11 physical cores
.NET SDK=8.0.204
  [Host]     : .NET 8.0.4 (8.0.424.16909), Arm64 RyuJIT AdvSIMD
  DefaultJob : .NET 8.0.4 (8.0.424.16909), Arm64 RyuJIT AdvSIMD


|                       Method |      Mean |    Error |   StdDev | Ratio | RatioSD |   Gen0 |   Gen1 | Allocated | Alloc Ratio |
|----------------------------- |----------:|---------:|---------:|------:|--------:|-------:|-------:|----------:|------------:|
|                EmptyTemplate |  48.35 ns | 0.245 ns | 0.229 ns |  1.00 |    0.00 | 0.0277 |      - |     232 B |        1.00 |
| DefaultConsoleOutputTemplate | 432.28 ns | 2.591 ns | 2.423 ns |  8.94 |    0.06 | 0.2074 | 0.0005 |    1736 B |        7.48 |
|              LiteralTextOnly |  59.97 ns | 0.099 ns | 0.088 ns |  1.24 |    0.01 | 0.0343 |      - |     288 B |        1.24 |
```

Results were similar on .NET 6 on ARM, though much slower across the board.

The additional eight-byte allocation in the baseline `EmptyTemplate` case is the change in `MessageTemplate` memory layout due to the additional `bool _acceptDottedPropertyNames` member.