### PR TITLE
fix: allows all non-'}' characters as format values

### DIFF
--- a/src/Serilog/Parsing/MessageTemplateParser.cs
+++ b/src/Serilog/Parsing/MessageTemplateParser.cs
@@ -228,11 +228,7 @@ public class MessageTemplateParser : IMessageTemplateParser
         }
     }
 
-    static bool IsValidInFormat(char c)
-    {
-        // This is the entire ascii printable range minus '}' and DEL
-        return (byte)c >= 32 && (byte)c < 127 && c != '}';
-    }
+    static bool IsValidInFormat(char c) => c != (byte)'}';
 
     static TextToken ParseTextToken(int startAt, string messageTemplate, out int next)
     {

--- a/src/Serilog/Parsing/MessageTemplateParser.cs
+++ b/src/Serilog/Parsing/MessageTemplateParser.cs
@@ -228,7 +228,7 @@ public class MessageTemplateParser : IMessageTemplateParser
         }
     }
 
-    static bool IsValidInFormat(char c) => c != (byte)'}';
+    static bool IsValidInFormat(char c) => c != '}';
 
     static TextToken ParseTextToken(int startAt, string messageTemplate, out int next)
     {

--- a/src/Serilog/Parsing/MessageTemplateParser.cs
+++ b/src/Serilog/Parsing/MessageTemplateParser.cs
@@ -228,17 +228,10 @@ public class MessageTemplateParser : IMessageTemplateParser
         }
     }
 
-    static bool IsValidInDestructuringHint(char c)
-    {
-        return c is '@' or '$';
-    }
-
     static bool IsValidInFormat(char c)
     {
-        return c != '}' &&
-               (char.IsLetterOrDigit(c) ||
-                char.IsPunctuation(c) ||
-                c is ' ' or '+');
+        // This is the entire ascii printable range minus '}' and DEL
+        return (byte)c >= 32 && (byte)c < 127 && c != '}';
     }
 
     static TextToken ParseTextToken(int startAt, string messageTemplate, out int next)

--- a/test/Serilog.Tests/Parsing/MessageTemplateParserTests.cs
+++ b/test/Serilog.Tests/Parsing/MessageTemplateParserTests.cs
@@ -243,10 +243,22 @@ public class MessageTemplateParserTests
     }
 
     [Fact]
-    public void APropertyWithValidNameAndInvalidFormatIsParsedAsText()
+    public void FormatsCanContainSymbolsAndOperators()
     {
         AssertParsedAs("{Hello:HH$MM}",
-            new TextToken("{Hello:HH$MM}"));
+            new PropertyToken("Hello", "{Hello:HH$MM}", "HH$MM"));
+
+        AssertParsedAs("{Hello:HH<MM}",
+            new PropertyToken("Hello", "{Hello:HH<MM}", "HH<MM"));
+
+        AssertParsedAs("{Hello:HH#MM}",
+            new PropertyToken("Hello", "{Hello:HH#MM}", "HH#MM"));
+
+        AssertParsedAs("{Hello:HH+MM}",
+            new PropertyToken("Hello", "{Hello:HH+MM}", "HH+MM"));
+
+        AssertParsedAs("{Hello:HH`MM}",
+            new PropertyToken("Hello", "{Hello:HH`MM}", "HH`MM"));
     }
 
     [Fact]


### PR DESCRIPTION
Hey it's me again!

The existing implementation used .IsPunctuation + IsLetterOrDigit with an override for '+' and ' '. That left some conspicuous holes and the spec itself is just "^\}" so basically anything goes in a format string. This allows for them and this does seem to have a reasonably large impact on the DefaultConsoleOutputTemplate parsing method. Everything else was within error bounds and no impact at all on memory allocs.

Some examples of oddities was that `@` was allowed but `$` wasn't and `+` was allowed but `>, <, =` weren't

for posterity this is based on our conversation here: https://github.com/messagetemplates/grammar/pull/6

### BEFORE - Allocs

|               Method |         Mean |      Error |     StdDev |  Ratio | RatioSD |   Gen0 | Allocated | Alloc Ratio |
|--------------------- |-------------:|-----------:|-----------:|-------:|--------:|-------:|----------:|------------:|
|             LogEmpty |     2.527 ns |  0.0247 ns |  0.0231 ns |   1.00 |    0.00 |      - |         - |          NA |
| LogEmptyWithEnricher |    11.869 ns |  0.0309 ns |  0.0258 ns |   4.70 |    0.04 |      - |         - |          NA |
|            LogScalar |   157.863 ns |  3.0242 ns |  3.6001 ns |  62.26 |    1.72 | 0.0215 |     360 B |          NA |
|        LogDictionary | 1,229.274 ns | 24.3282 ns | 31.6336 ns | 489.18 |   14.38 | 0.1297 |    2192 B |          NA |
|          LogSequence |   251.133 ns |  4.8599 ns |  6.3192 ns |  99.78 |    2.60 | 0.0343 |     576 B |          NA |
|         LogAnonymous | 1,630.629 ns | 32.4170 ns | 31.8378 ns | 645.87 |   13.55 | 0.1717 |    2896 B |          NA |
|        FormatMessage |    42.957 ns |  0.2456 ns |  0.2297 ns |  17.00 |    0.18 |      - |         - |          NA |


### BEFORE - Parsing

|                       Method |      Mean |     Error |    StdDev | Ratio | RatioSD |   Gen0 | Allocated | Alloc Ratio |
|----------------------------- |----------:|----------:|----------:|------:|--------:|-------:|----------:|------------:|
|                EmptyTemplate |  56.11 ns |  1.080 ns |  1.110 ns |  1.00 |    0.00 | 0.0138 |     232 B |        1.00 |
| DefaultConsoleOutputTemplate | 534.43 ns | 10.624 ns | 20.468 ns |  9.53 |    0.32 | 0.1030 |    1736 B |        7.48 |
|              LiteralTextOnly |  67.79 ns |  1.381 ns |  2.229 ns |  1.21 |    0.04 | 0.0172 |     288 B |        1.24 |


### AFTER - Allocs

|               Method |         Mean |      Error |     StdDev |  Ratio | RatioSD |   Gen0 | Allocated | Alloc Ratio |
|--------------------- |-------------:|-----------:|-----------:|-------:|--------:|-------:|----------:|------------:|
|             LogEmpty |     2.629 ns |  0.0130 ns |  0.0115 ns |   1.00 |    0.00 |      - |         - |          NA |
| LogEmptyWithEnricher |    14.431 ns |  0.0369 ns |  0.0345 ns |   5.49 |    0.02 |      - |         - |          NA |
|            LogScalar |   152.972 ns |  3.0344 ns |  3.9455 ns |  58.25 |    1.54 | 0.0215 |     360 B |          NA |
|        LogDictionary | 1,215.807 ns | 24.0812 ns | 24.7296 ns | 461.82 |   10.03 | 0.1297 |    2192 B |          NA |
|          LogSequence |   236.164 ns |  4.5692 ns |  4.4876 ns |  89.90 |    1.70 | 0.0343 |     576 B |          NA |
|         LogAnonymous | 1,636.475 ns | 27.9450 ns | 26.1398 ns | 623.24 |   11.09 | 0.1717 |    2896 B |          NA |
|        FormatMessage |    42.094 ns |  0.1604 ns |  0.1340 ns |  16.01 |    0.05 |      - |         - |          NA |

### AFTER - PARSING

|                       Method |      Mean |    Error |    StdDev | Ratio | RatioSD |   Gen0 |   Gen1 | Allocated | Alloc Ratio |
|----------------------------- |----------:|---------:|----------:|------:|--------:|-------:|-------:|----------:|------------:|
|                EmptyTemplate |  55.05 ns | 1.122 ns |  1.292 ns |  1.00 |    0.00 | 0.0138 |      - |     232 B |        1.00 |
| DefaultConsoleOutputTemplate | 475.19 ns | 9.331 ns | 12.457 ns |  8.67 |    0.35 | 0.1035 | 0.0005 |    1736 B |        7.48 |
|              LiteralTextOnly |  66.30 ns | 1.357 ns |  2.447 ns |  1.22 |    0.05 | 0.0172 |      - |     288 B |        1.24 |

Change in allowed printables before and after:

```
$ - Before: False -> After True
< - Before: False -> After True
= - Before: False -> After True
> - Before: False -> After True
^ - Before: False -> After True
` - Before: False -> After True
| - Before: False -> After True
~ - Before: False -> After True
```

