### PR TITLE
Version `Serilog.dll` as `Major.Minor.0.0`

### DIFF
--- a/src/Serilog/Serilog.csproj
+++ b/src/Serilog/Serilog.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <Description>Simple .NET logging with fully-structured events</Description>
     <VersionPrefix>4.0.1</VersionPrefix>
+    <AssemblyVersion>$(VersionPrefix.Substring(0, 3)).0.0</AssemblyVersion>
     <Authors>Serilog Contributors</Authors>
     <!-- .NET Framework version targeting is frozen at these two TFMs. -->
     <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT'">net471;net462</TargetFrameworks>

--- a/test/Serilog.Tests/MethodOverloadConventionTests.cs
+++ b/test/Serilog.Tests/MethodOverloadConventionTests.cs
@@ -35,7 +35,7 @@ public class MethodOverloadConventionTests
     /// </para>
     ///
     /// <para>
-    /// A similar <see cref="ReadOnlySpan{T}"/> accepting method does not exists in the <see cref="ILogger"/> interface,
+    /// A similar <see cref="ReadOnlySpan{T}"/> accepting method does not exist in the <see cref="ILogger"/> interface,
     /// and introducing it is a breaking change.
     /// </para>
     /// </remarks>

--- a/test/Serilog.Tests/VersioningTests.cs
+++ b/test/Serilog.Tests/VersioningTests.cs
@@ -1,0 +1,20 @@
+namespace Serilog.Tests;
+
+public class VersioningTests
+{
+    [Fact]
+    public void AssemblyIsExplicitlyVersioned()
+    {
+        var version = typeof(Log).Assembly.GetName().Version;
+        Assert.NotNull(version);
+        Assert.False(version.Major is 0 or 1);
+    }
+
+    [Fact]
+    public void AssemblySubordinateVersionPartsAreZero()
+    {
+        var version = typeof(Log).Assembly.GetName().Version;
+        Assert.True(version?.Build is 0);
+        Assert.True(version.Revision is 0);
+    }
+}


### PR DESCRIPTION
Fixes #2074 

This is essentially a commitment to strong binary backwards/forwards compatibility between all versions in a `Major.Minor` series.