### PR TITLE
Allow non-anonymous-type destructuring when trimmed

### DIFF
--- a/src/Serilog/Capturing/GettablePropertyFinder.cs
+++ b/src/Serilog/Capturing/GettablePropertyFinder.cs
@@ -14,9 +14,9 @@
 
 namespace Serilog.Capturing;
 
-static class GetablePropertyFinder
+static class GettablePropertyFinder
 {
-    internal static IEnumerable<PropertyInfo> GetPropertiesRecursive([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] this Type type)
+    internal static IEnumerable<PropertyInfo> GetPropertiesInHierarchy([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] this Type type)
     {
         var seenNames = new HashSet<string>();
 

--- a/src/Serilog/Capturing/PropertyValueConverter.cs
+++ b/src/Serilog/Capturing/PropertyValueConverter.cs
@@ -163,10 +163,8 @@ partial class PropertyValueConverter : ILogEventPropertyFactory, ILogEventProper
         if (TryConvertValueTuple(value, type, destructuring, out var tupleResult))
             return tupleResult;
 
-#pragma warning disable IL2072 // analyzer doesn't support feature switches yet
-        if (TrimConfiguration.IsCompilerGeneratedCodeSupported && TryConvertCompilerGeneratedType(value, type, destructuring, out var compilerGeneratedResult))
-            return compilerGeneratedResult;
-#pragma warning restore IL2072
+        if (TryConvertStructure(value, type, destructuring, out var structureResult))
+            return structureResult;
 
         return new ScalarValue(value.ToString() ?? "");
     }
@@ -251,6 +249,7 @@ partial class PropertyValueConverter : ILogEventPropertyFactory, ILogEventProper
 
 #if FEATURE_ITUPLE
 
+    // ReSharper disable once UnusedParameter.Local
     bool TryConvertValueTuple(object value, Type type, Destructuring destructuring, [NotNullWhen(true)] out LogEventPropertyValue? result)
     {
         if (value is not ITuple tuple)
@@ -308,16 +307,17 @@ partial class PropertyValueConverter : ILogEventPropertyFactory, ILogEventProper
 
 #endif
 
-    bool TryConvertCompilerGeneratedType(
+    bool TryConvertStructure(
         object value,
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] Type type,
         Destructuring destructuring,
-        [NotNullWhen(true)] out LogEventPropertyValue? result)
+        [NotNullWhen(true)] out StructureValue? result)
     {
-        if (destructuring == Destructuring.Destructure)
+        var isCompilerGeneratedType = IsCompilerGeneratedType(type);
+        if (destructuring == Destructuring.Destructure && (!isCompilerGeneratedType || TrimConfiguration.IsCompilerGeneratedCodeSupported))
         {
             var typeTag = type.Name;
-            if (typeTag.Length <= 0 || IsCompilerGeneratedType(type))
+            if (typeTag.Length <= 0 || isCompilerGeneratedType)
             {
                 typeTag = null;
             }
@@ -330,7 +330,7 @@ partial class PropertyValueConverter : ILogEventPropertyFactory, ILogEventProper
         return false;
     }
 
-    LogEventPropertyValue Stringify(object value)
+    ScalarValue Stringify(object value)
     {
         var stringified = value.ToString();
         var truncated = stringified == null ? "" : TruncateIfNecessary(stringified);
@@ -349,11 +349,11 @@ partial class PropertyValueConverter : ILogEventPropertyFactory, ILogEventProper
 
     bool TryGetDictionary(object value, Type valueType, [NotNullWhen(true)] out IDictionary? dictionary)
     {
-        if (value is IDictionary idictionary)
+        if (value is IDictionary iDictionary)
         {
             if (_dictionaryTypes.Contains(valueType))
             {
-                dictionary = idictionary;
+                dictionary = iDictionary;
                 return true;
             }
 
@@ -363,7 +363,7 @@ partial class PropertyValueConverter : ILogEventPropertyFactory, ILogEventProper
                 if ((definition == typeof(Dictionary<,>) || definition == typeof(System.Collections.ObjectModel.ReadOnlyDictionary<,>)) &&
                     IsValidDictionaryKeyType(valueType.GenericTypeArguments[0]))
                 {
-                    dictionary = idictionary;
+                    dictionary = iDictionary;
                     return true;
                 }
             }
@@ -382,7 +382,7 @@ partial class PropertyValueConverter : ILogEventPropertyFactory, ILogEventProper
 
     IEnumerable<LogEventProperty> GetProperties(object value, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] Type type)
     {
-        foreach (var prop in type.GetPropertiesRecursive())
+        foreach (var prop in type.GetPropertiesInHierarchy())
         {
             object? propValue;
             try

--- a/test/Serilog.Tests/Capturing/GettablePropertyFinderTests.cs
+++ b/test/Serilog.Tests/Capturing/GettablePropertyFinderTests.cs
@@ -5,35 +5,35 @@ public class GettablePropertyFinderTests
     [Fact]
     public void GetPropertiesRecursiveIntegerTypeYieldNoResult()
     {
-        var result = default(int).GetType().GetPropertiesRecursive();
+        var result = default(int).GetType().GetPropertiesInHierarchy();
         Assert.Empty(result);
     }
 
     [Fact]
     public void GetPropertiesRecursiveBooleanTypeYieldNoResult()
     {
-        var result = default(bool).GetType().GetPropertiesRecursive();
+        var result = default(bool).GetType().GetPropertiesInHierarchy();
         Assert.Empty(result);
     }
 
     [Fact]
     public void GetPropertiesRecursiveCharTypeYieldNoResult()
     {
-        var result = default(char).GetType().GetPropertiesRecursive();
+        var result = default(char).GetType().GetPropertiesInHierarchy();
         Assert.Empty(result);
     }
 
     [Fact]
     public void GetPropertiesRecursiveObjectTypeYieldNoResult()
     {
-        var result = new object().GetType().GetPropertiesRecursive();
+        var result = new object().GetType().GetPropertiesInHierarchy();
         Assert.Empty(result);
     }
 
     [Fact]
     public void GetPropertiesRecursiveStringTypeYieldResult()
     {
-        var result = string.Empty.GetType().GetPropertiesRecursive();
+        var result = string.Empty.GetType().GetPropertiesInHierarchy();
         Assert.NotEmpty(result);
     }
 
@@ -47,7 +47,7 @@ public class GettablePropertyFinderTests
         var myFactory = new System.ServiceModel.ChannelFactory<IMyChannel>(binding, remoteAddress);
         var channel = myFactory.CreateChannel();
 
-        var _ = channel.GetType().GetPropertiesRecursive().ToList();
+        var _ = channel.GetType().GetPropertiesInHierarchy().ToList();
     }
 
     [System.ServiceModel.ServiceContract]
@@ -60,7 +60,7 @@ public class GettablePropertyFinderTests
     [Fact]
     public void ShouldOnlyGetInheritedNewProperty()
     {
-        var property = typeof(InheritedNewClass).GetPropertiesRecursive().Single();
+        var property = typeof(InheritedNewClass).GetPropertiesInHierarchy().Single();
 
         Assert.Equal(typeof(InheritedNewClass).GetProperty("Property"), property);
     }
@@ -74,7 +74,7 @@ public class GettablePropertyFinderTests
     [Fact]
     public void ShouldOnlyGetInheritedProperty()
     {
-        var property = typeof(InheritedClass).GetPropertiesRecursive().Single();
+        var property = typeof(InheritedClass).GetPropertiesInHierarchy().Single();
 
         Assert.Equal(typeof(InheritedClass).GetProperty("Property"), property);
     }


### PR DESCRIPTION
An old refactor pulled out structure capturing logic into a method incorrectly named `TryConvertCompilerGeneratedType`; this in fact is the catch-all for non-scalar/dictionary/enumerable types without an explicit `IDestructuringPolicy` configured.

The misleading name led to incorrect logic being implemented for skipping capturing of compiler-generated type properties when not supported: in this situation all structure capturing will be skipped.

This PR fixes the method name - `TryConvertStructure` - and the aforementioned trimming-related logic.