### PR TITLE
Removed boxing and string allocations in MessageTemplateTextFormatter

### DIFF
--- a/src/Serilog/Events/ScalarValue.cs
+++ b/src/Serilog/Events/ScalarValue.cs
@@ -95,6 +95,43 @@ public class ScalarValue : LogEventPropertyValue
         }
     }
 
+#if FEATURE_SPAN
+    internal static void Render<T>(T value, TextWriter output, string? format = null, IFormatProvider? formatProvider = null) where T : struct, IFormattable, ISpanFormattable
+    {
+        Guard.AgainstNull(output);
+
+        var custom = (ICustomFormatter?)formatProvider?.GetFormat(typeof(ICustomFormatter));
+        if (custom != null)
+        {
+            WriteWithCustomFormatter(value, output, format, formatProvider, custom);
+            return;
+        }
+
+        formatProvider ??= CultureInfo.InvariantCulture;
+        if (TryWriteSpanFormattable(value, output, format, formatProvider))
+            return;
+
+        output.Write(value.ToString(format, formatProvider));
+    }
+
+    static void WriteWithCustomFormatter<T>(T value, TextWriter output, string? format, IFormatProvider? formatProvider, ICustomFormatter custom) where T : struct, IFormattable
+    {
+        output.Write(custom.Format(format, value, formatProvider));
+    }
+
+    static bool TryWriteSpanFormattable<T>(T value, TextWriter output, string? format, IFormatProvider formatProvider) where T : struct, ISpanFormattable
+    {
+        Span<char> buffer = stackalloc char[36]; // large enough to fit ISO 8601 timestamp (DateTimeOffset.ToString("O"))
+        if (value.TryFormat(buffer, out var charsWritten, format, formatProvider))
+        {
+            output.Write(buffer[..charsWritten]);
+            return true;
+        }
+
+        return false;
+    }
+#endif
+
     /// <summary>
     /// Determine if this instance is equal to <paramref name="obj"/>.
     /// </summary>

--- a/test/Serilog.Tests/Formatting/Display/MessageTemplateTextFormatterTests.cs
+++ b/test/Serilog.Tests/Formatting/Display/MessageTemplateTextFormatterTests.cs
@@ -49,6 +49,19 @@ public class MessageTemplateTextFormatterTests
     }
 
     [Theory]
+    [InlineData(16)]
+    [InlineData(100)]
+    public void RendersTimestampFormatsOfDifferentLengths(int length)
+    {
+        var longFormatString = new string('-', length);
+        var formatter = new MessageTemplateTextFormatter($"{{Timestamp:{longFormatString}}}", CultureInfo.InvariantCulture);
+        var evt = DelegatingSink.GetLogEvent(l => l.Information("{Name}", "Nick"));
+        var sw = new StringWriter();
+        formatter.Format(evt, sw);
+        Assert.Contains(longFormatString, sw.ToString());
+    }
+
+    [Theory]
     [InlineData(Verbose, 1, "V")]
     [InlineData(Verbose, 2, "Vb")]
     [InlineData(Verbose, 3, "Vrb")]


### PR DESCRIPTION
This PR removes allocations from legacy (but still not deprecated in Console/File sinks) `MessageTemplateTextFormatter`. This may still be useful, since the timestamp is serialized for each log event.

Allocations:
 - `DateTimeOffset` boxing, by adding `ScalarValue.Render<T>` overload with constraint for `IFormattable`
 - `DateTimeOffset.ToString()` allocation, by using `ISpanFormattable.TryFormat` API

## OutputTemplateRenderingBenchmark.FormatToOutput

### Before

| Method         | Job      | Runtime  | Mean     | Error   | StdDev  | Gen0   | Allocated |
|--------------- |--------- |--------- |---------:|--------:|--------:|-------:|----------:|
| FormatToOutput | .NET 8.0 | .NET 8.0 | 184.9 ns | 1.93 ns | 1.81 ns | 0.0143 |     120 B |
| FormatToOutput | .NET 9.0 | .NET 9.0 | 141.3 ns | 1.50 ns | 1.40 ns | 0.0143 |     120 B |

### After

| Method         | Job      | Runtime  | Mean     | Error   | StdDev  | Allocated |
|--------------- |--------- |--------- |---------:|--------:|--------:|----------:|
| FormatToOutput | .NET 8.0 | .NET 8.0 | 190.2 ns | 1.70 ns | 1.59 ns |         - |
| FormatToOutput | .NET 9.0 | .NET 9.0 | 135.6 ns | 1.02 ns | 0.95 ns |         - |
```
