### PR TITLE
Don't capture properties with private `get` accessors

### DIFF
--- a/src/Serilog/Capturing/PropertyValueConverter.cs
+++ b/src/Serilog/Capturing/PropertyValueConverter.cs
@@ -397,7 +397,7 @@ partial class PropertyValueConverter : ILogEventPropertyFactory, ILogEventProper
         for (var i = 0; i < properties.Length; ++i)
         {
             var property = properties[i];
-            if (!property.CanRead)
+            if (property.GetMethod == null || !property.GetMethod.IsPublic)
             {
                 continue;
             }

--- a/test/Serilog.Tests/Capturing/PropertyValueConverterTests.cs
+++ b/test/Serilog.Tests/Capturing/PropertyValueConverterTests.cs
@@ -488,4 +488,18 @@ public class PropertyValueConverterTests
     {
         public override string Name => "override";
     }
+
+    [Fact]
+    public void PrivateGettersAreIgnoredWhenCapturing()
+    {
+        var structure = _converter.CreateStructureValue(new HasPropertyWithPrivateGetter(), typeof(HasPropertyWithPrivateGetter), false);
+        Assert.Contains(structure.Properties, p => p.Name == "A");
+        Assert.DoesNotContain(structure.Properties, p => p.Name == "B");
+    }
+
+    public class HasPropertyWithPrivateGetter
+    {
+        public string A { get; set; } = "A";
+        public string B { private get; set; } = "B";
+    }
 }


### PR DESCRIPTION
Fixes #2102 

I suspect this is also the cause of #2087 (CC @rcollette).