### PR TITLE
Fall back to `IDisposable` in `Log.CloseAndFlushAsync()` when the target logger is not `IAsyncDisposable`

### DIFF
--- a/src/Serilog/Log.cs
+++ b/src/Serilog/Log.cs
@@ -59,11 +59,18 @@ public static class Log
     /// <summary>
     /// Resets <see cref="Logger"/> to the default and disposes the original if possible
     /// </summary>
-    public static ValueTask CloseAndFlushAsync()
+    public static async ValueTask CloseAndFlushAsync()
     {
         var logger = Interlocked.Exchange(ref _logger, Serilog.Core.Logger.None);
 
-        return (logger as IAsyncDisposable)?.DisposeAsync() ?? default;
+        if (logger is IAsyncDisposable asyncDisposable)
+        {
+            await asyncDisposable.DisposeAsync();
+        }
+        else
+        {
+            (logger as IDisposable)?.Dispose();
+        }
     }
 #endif
 

--- a/test/Serilog.Tests/Core/BatchingSinkTests.cs
+++ b/test/Serilog.Tests/Core/BatchingSinkTests.cs
@@ -15,9 +15,9 @@ public class BatchingSinkTests
         var evt = Some.InformationEvent();
         pbs.Emit(evt);
         pbs.Dispose();
-        Assert.Single(bs.Batches);
-        Assert.Single(bs.Batches[0]);
-        Assert.Same(evt, bs.Batches[0][0]);
+        var batch = Assert.Single(bs.Batches);
+        var actual = Assert.Single(batch);
+        Assert.Same(evt, actual);
         Assert.True(bs.IsDisposed);
         Assert.False(bs.WasCalledAfterDisposal);
     }
@@ -35,9 +35,9 @@ public class BatchingSinkTests
             var evt = Some.InformationEvent();
             pbs.Emit(evt);
             await pbs.DisposeAsync();
-            Assert.Single(bs.Batches);
-            Assert.Single(bs.Batches[0]);
-            Assert.Same(evt, bs.Batches[0][0]);
+            var batch = Assert.Single(bs.Batches);
+            var actual = Assert.Single(batch);
+            Assert.Same(evt, actual);
             Assert.True(bs.IsDisposed);
             Assert.True(bs.IsDisposedAsync);
             Assert.False(bs.WasCalledAfterDisposal);

--- a/test/Serilog.Tests/LogTests.cs
+++ b/test/Serilog.Tests/LogTests.cs
@@ -40,6 +40,15 @@ public class LogTests
     }
 
     [Fact]
+    public async Task CloseAndFlushAsyncDisposesTheLoggerEvenWhenItIsNotAsyncDisposable()
+    {
+        var disposableLogger = new SyncDisposableLogger();
+        Log.Logger = disposableLogger;
+        await Log.CloseAndFlushAsync();
+        Assert.True(disposableLogger.IsDisposed);
+    }
+
+    [Fact]
     public async Task CloseAndFlushAsyncResetsLoggerToSilentLogger()
     {
         Log.Logger = new DisposableLogger();

--- a/test/Serilog.Tests/LogTests.cs
+++ b/test/Serilog.Tests/LogTests.cs
@@ -43,6 +43,7 @@ public class LogTests
     public async Task CloseAndFlushAsyncDisposesTheLoggerEvenWhenItIsNotAsyncDisposable()
     {
         var disposableLogger = new SyncDisposableLogger();
+        Assert.IsNotAssignableFrom<IAsyncDisposable>(disposableLogger);
         Log.Logger = disposableLogger;
         await Log.CloseAndFlushAsync();
         Assert.True(disposableLogger.IsDisposed);

--- a/test/Serilog.Tests/Support/DisposableLogger.cs
+++ b/test/Serilog.Tests/Support/DisposableLogger.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 namespace Serilog.Tests.Support;
 
 public class DisposableLogger : ILogger, IDisposable

--- a/test/Serilog.Tests/Support/SyncDisposableLogger.cs
+++ b/test/Serilog.Tests/Support/SyncDisposableLogger.cs
@@ -1,0 +1,19 @@
+#if FEATURE_ASYNCDISPOSABLE && FEATURE_DEFAULT_INTERFACE
+
+namespace Serilog.Tests.Support;
+
+public class SyncDisposableLogger: ILogger, IDisposable
+{
+    public bool IsDisposed { get; private set; }
+
+    public void Write(LogEvent logEvent)
+    {
+    }
+
+    public void Dispose()
+    {
+        IsDisposed = true;
+    }
+}
+
+#endif


### PR DESCRIPTION
This fixes #2115.

We've missed spotting this previously because the default `Logger` type _is_ `IAsyncDisposable`, and handles the fallback to `IDisposable` for sinks that don't implement it.