### PR TITLE
Add `BatchingOptions.RetryTimeLimit`

### DIFF
--- a/src/Serilog/Configuration/BatchingOptions.cs
+++ b/src/Serilog/Configuration/BatchingOptions.cs
@@ -45,4 +45,10 @@ public class BatchingOptions
     /// backpressure is applied.
     /// </summary>
     public int? QueueLimit { get; set; } = 100000;
+
+    /// <summary>
+    /// The maximum time that the sink will keep retrying failed batches for. The default is ten minutes. Lower
+    /// this value to reduce buffering and backpressure in high-load scenarios.
+    /// </summary>
+    public TimeSpan RetryTimeLimit { get; set; } = TimeSpan.FromMinutes(10);
 }

--- a/src/Serilog/Core/Sinks/Batching/BatchingSink.cs
+++ b/src/Serilog/Core/Sinks/Batching/BatchingSink.cs
@@ -62,7 +62,7 @@ sealed class BatchingSink : ILogEventSink, IDisposable, ISetLoggingFailureListen
         if (options.BatchSizeLimit <= 0)
             throw new ArgumentOutOfRangeException(nameof(options), "The batch size limit must be greater than zero.");
         if (options.BufferingTimeLimit <= TimeSpan.Zero)
-            throw new ArgumentOutOfRangeException(nameof(options), "The period must be greater than zero.");
+            throw new ArgumentOutOfRangeException(nameof(options), "The buffering time limit must be greater than zero.");
         if (options.RetryTimeLimit < TimeSpan.Zero)
             throw new ArgumentOutOfRangeException(nameof(options), "The retry time limit must not be negative.");
 

--- a/src/Serilog/Core/Sinks/Batching/BatchingSink.cs
+++ b/src/Serilog/Core/Sinks/Batching/BatchingSink.cs
@@ -63,13 +63,15 @@ sealed class BatchingSink : ILogEventSink, IDisposable, ISetLoggingFailureListen
             throw new ArgumentOutOfRangeException(nameof(options), "The batch size limit must be greater than zero.");
         if (options.BufferingTimeLimit <= TimeSpan.Zero)
             throw new ArgumentOutOfRangeException(nameof(options), "The period must be greater than zero.");
+        if (options.RetryTimeLimit < TimeSpan.Zero)
+            throw new ArgumentOutOfRangeException(nameof(options), "The retry time limit must not be negative.");
 
         _targetSink = batchedSink ?? throw new ArgumentNullException(nameof(batchedSink));
         _batchSizeLimit = options.BatchSizeLimit;
         _queue = options.QueueLimit is { } limit
             ? Channel.CreateBounded<LogEvent>(new BoundedChannelOptions(limit) { SingleReader = true })
             : Channel.CreateUnbounded<LogEvent>(new UnboundedChannelOptions { SingleReader = true });
-        _batchScheduler = new FailureAwareBatchScheduler(options.BufferingTimeLimit);
+        _batchScheduler = new FailureAwareBatchScheduler(options.BufferingTimeLimit, options.RetryTimeLimit);
         _eagerlyEmitFirstEvent = options.EagerlyEmitFirstEvent;
         _waitForShutdownSignal = Task.Delay(Timeout.InfiniteTimeSpan, _shutdownSignal.Token)
             .ContinueWith(e => e.Exception, TaskContinuationOptions.OnlyOnFaulted);
@@ -143,15 +145,15 @@ sealed class BatchingSink : ILogEventSink, IDisposable, ISetLoggingFailureListen
             catch (Exception ex)
             {
                 _failureListener.OnLoggingFailed(this, LoggingFailureKind.Temporary, "failed emitting a batch", _currentBatch, ex);
-                _batchScheduler.MarkFailure();
+                _batchScheduler.MarkFailure(out var shouldDropBatch, out var shouldDropQueue);
 
-                if (_batchScheduler.ShouldDropBatch)
+                if (shouldDropBatch)
                 {
                     _failureListener.OnLoggingFailed(this, LoggingFailureKind.Permanent, "dropping the current batch", _currentBatch, ex);
                     _currentBatch.Clear();
                 }
 
-                if (_batchScheduler.ShouldDropQueue)
+                if (shouldDropQueue)
                 {
                     DrainOnFailure(LoggingFailureKind.Permanent, "dropping all queued events", ex);
                 }

--- a/src/Serilog/Core/Sinks/Batching/FailureAwareBatchScheduler.cs
+++ b/src/Serilog/Core/Sinks/Batching/FailureAwareBatchScheduler.cs
@@ -45,7 +45,7 @@ class FailureAwareBatchScheduler
     internal FailureAwareBatchScheduler(TimeSpan bufferingTimeLimit, TimeSpan retryTimeLimit, TimeProvider timeProvider)
     {
         if (bufferingTimeLimit < TimeSpan.Zero)
-            throw new ArgumentOutOfRangeException(nameof(bufferingTimeLimit), "The batching period must be a positive timespan.");
+            throw new ArgumentOutOfRangeException(nameof(bufferingTimeLimit), "The buffering time limit must be a positive timespan.");
 
         if (retryTimeLimit < TimeSpan.Zero)
             throw new ArgumentOutOfRangeException(nameof(retryTimeLimit), "The retry time limit must be a positive timespan.");

--- a/src/Serilog/Util/TimeProvider.cs
+++ b/src/Serilog/Util/TimeProvider.cs
@@ -1,0 +1,48 @@
+// Copyright © Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#if !NET8_0_OR_GREATER
+
+using System.Diagnostics;
+
+namespace System;
+
+/// <summary>
+/// A super-simple, cut-down subset of `System.TimeProvider` which we use internally to avoid a package dependency
+/// on platforms without it.
+/// </summary>
+abstract class TimeProvider
+{
+    public static TimeProvider System { get; } = new SystemTimeProvider();
+
+    public DateTimeOffset GetLocalNow() => DateTimeOffset.Now;
+
+    public virtual DateTimeOffset GetUtcNow() => DateTimeOffset.UtcNow;
+
+    public virtual long TimestampFrequency => Stopwatch.Frequency;
+
+    public virtual long GetTimestamp() => Stopwatch.GetTimestamp();
+
+    public TimeSpan GetElapsedTime(long startingTimestamp, long endingTimestamp)
+    {
+        // Assumes Stopwatch.Frequency is never zero, safe for our internal usage.
+        return new TimeSpan((long)((endingTimestamp - startingTimestamp) * ((double)TimeSpan.TicksPerSecond / TimestampFrequency)));
+    }
+
+    public TimeSpan GetElapsedTime(long startingTimestamp) => GetElapsedTime(startingTimestamp, GetTimestamp());
+
+    sealed class SystemTimeProvider : TimeProvider;
+}
+
+#endif

--- a/test/Serilog.ApprovalTests/Serilog.approved.txt
+++ b/test/Serilog.ApprovalTests/Serilog.approved.txt
@@ -7,6 +7,7 @@ namespace Serilog.Configuration
         public System.TimeSpan BufferingTimeLimit { get; set; }
         public bool EagerlyEmitFirstEvent { get; set; }
         public int? QueueLimit { get; set; }
+        public System.TimeSpan RetryTimeLimit { get; set; }
     }
     public interface ILoggerSettings
     {

--- a/test/Serilog.Tests/Support/TestTimeProvider.cs
+++ b/test/Serilog.Tests/Support/TestTimeProvider.cs
@@ -1,0 +1,23 @@
+namespace Serilog.Tests.Support;
+
+class TestTimeProvider: TimeProvider
+{
+    DateTimeOffset _utcNow = DateTimeOffset.UtcNow;
+
+    public override long GetTimestamp()
+    {
+        return _utcNow.Ticks;
+    }
+
+    public override DateTimeOffset GetUtcNow()
+    {
+        return _utcNow;
+    }
+
+    public void Advance(TimeSpan distance)
+    {
+        _utcNow = _utcNow.Add(distance);
+    }
+
+    public override long TimestampFrequency => TimeSpan.TicksPerSecond;
+}


### PR DESCRIPTION
This PR improves batching sink behavior by making the retry time for failed batches explicit and configurable, through `BatchingOptions.RetryTimeLimit`. Previously, the retry time was computed from `BufferingTimeLimit` in a fairly opaque manner.

Batching still uses exponential back-off, and checks "expected" retry times against the limit, so the final retry for a batch may happen earlier than the configured maximum. The maximum granularity of retries is now 1 minute, so this puts an upper bound on the difference between the retry time limit and the actual last retry.

The failure sequence is:

 - If no failures have occurred, collect and send batches within BufferingTimeLimit (two seconds by default)
 - When the first failure occurs, retry at max(BufferingTimeLimit, five seconds) later, unless this would exceed RetryTimeLimit (ten minutes by default)
 - Exponentially back off the retry interval until it's no more than one minute, trying each time unless the attempt would exceed RetryTimeLimit
 - Once RetryTimeLimit is hit, drop the current batch
 - Attempt to send another batch at each interval, continuing to use the exponential back-off with intervals no more than one minute apart, dropping failed batches immediately
 - Once ten consecutive batches have failed and been dropped, drain the whole queue
 - Continue at the same progression of intervals, now dropping the batch and draining the queue on each subsequent failure

By default, this process buffers all data for 10 minutes, and drops one batch per minute for at least 10 more; once those two stages have completed, stop buffering and drain as much data as possible to prevent negative impacts on the host application.

The main failure modes are:

 - Backpressure due to queue exhaustion (the queue limit, 100000 by default, needs to last at least 10 minutes); this is not new, and is reasonably mitigated by either increasing queue size, or substantially reducing the retry time
 - Stalls due to "poison" events; these are also not new, and also able to be mitigated by reducing retry time, but it'd be nice to open up some more options (fast failure with some `ILogEventFailureListener` tie-in)
 - Byzantine failures, e.g. where the target sink accepts only one batch per 10 minutes; in this case we'll keep resetting the timer but not be able to work through any significant portion of the queue; also not new, and no current mitigation

There are definitely still opportunities to improve this, but each option we open up narrows down the range of possible improvements to the algorithm. After adding the new setting, I think we'd be wise to leave things as-is for at least a year, just to let the dust settle.

Note that systems with non-default buffering delays might be relying on these to generate very long buffering times. I think it's reasonable to expect these to migrate to the new setting, but we'll need to point the change out prominently in the release notes.