### PR TITLE
Attempt to avoid building PR syncs, number 2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ on:
 env:
   CI_BUILD_NUMBER_BASE: ${{ github.run_number }}
   CI_TARGET_BRANCH: ${{ github.head_ref || github.ref_name }}
-  CI_PULL_REQUEST_NUMBER: $${{ github.event.pull_request.number }}
+  CI_IS_PULL_REQUEST_SYNC: $${{ github.event.pull_request.action == 'synchronize' }}
 
 jobs:
   build:

--- a/Build.ps1
+++ b/Build.ps1
@@ -61,7 +61,7 @@ try {
         Pop-Location
     }
 
-    if ($env:NUGET_API_KEY -and -not $env:CI_PULL_REQUEST_NUMBER) {
+    if ($env:NUGET_API_KEY -and -not $env:CI_IS_PULL_REQUEST_SYNC) {
         # GitHub Actions will only supply this to branch builds and not PRs. We publish
         # builds from any branch this action targets (i.e. main and dev).
 


### PR DESCRIPTION
#2129 was unsuccessful, causing publishing to also be skipped on branch builds that resulted from a PR close.