### PR TITLE
Give up on skipping sync builds for now

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,6 @@ on:
 env:
   CI_BUILD_NUMBER_BASE: ${{ github.run_number }}
   CI_TARGET_BRANCH: ${{ github.head_ref || github.ref_name }}
-  CI_IS_PULL_REQUEST_SYNC: $${{ github.event.pull_request.action == 'synchronize' }}
 
 jobs:
   build:

--- a/Build.ps1
+++ b/Build.ps1
@@ -46,10 +46,6 @@ try {
         Pop-Location
     }
 
-    Write-Output "build: Checking complete solution builds"
-    & dotnet build
-    if($LASTEXITCODE -ne 0) { throw "Solution build failed" }
-
     foreach ($test in Get-ChildItem test/*.Tests) {
         Push-Location $test
 
@@ -61,7 +57,7 @@ try {
         Pop-Location
     }
 
-    if ($env:NUGET_API_KEY -and -not $env:CI_IS_PULL_REQUEST_SYNC) {
+    if ($env:NUGET_API_KEY) {
         # GitHub Actions will only supply this to branch builds and not PRs. We publish
         # builds from any branch this action targets (i.e. main and dev).
 


### PR DESCRIPTION
Reverts #2130 and #2129 - both prevented regular branch builds.

Will revisit.