### PR TITLE
Update ILogEventSink.cs

### DIFF
--- a/src/Serilog/Core/ILogEventSink.cs
+++ b/src/Serilog/Core/ILogEventSink.cs
@@ -26,6 +26,6 @@ public interface ILogEventSink
     /// <param name="logEvent">The log event to write.</param>
     /// <seealso cref="IBatchedLogEventSink"/>
     /// <remarks>Implementers should allow exceptions to propagate when event emission fails. The logger will handle
-    /// exceptions and produce diagnostics appropriately.
+    /// exceptions and produce diagnostics appropriately.</remarks>
     void Emit(LogEvent logEvent);
 }


### PR DESCRIPTION
XML Documentation fix (closed <remarks> tag) For `ILogEventSink.Emit()`

Fix for ***ILogEventSink.Emit() is missing the closing </remarks> tag in the XML Docs.*** #2135