### PR TITLE
Stabilize and fully-implement dotted property names in message templates

### DIFF
--- a/appveyor-perftest.yml
+++ b/appveyor-perftest.yml
@@ -1,7 +1,0 @@
-version: '{build}'
-skip_tags: true
-image: Visual Studio 2019
-configuration: Release
-test: off
-build_script:
-- ps: ./RunPerfTests.ps1

--- a/src/Serilog/Parsing/MessageTemplateParser.cs
+++ b/src/Serilog/Parsing/MessageTemplateParser.cs
@@ -20,26 +20,13 @@ namespace Serilog.Parsing;
 /// </summary>
 public class MessageTemplateParser : IMessageTemplateParser
 {
-    /// <summary>
-    /// When set, property names in templates may include `.`.
-    /// </summary>
-    static readonly bool DefaultAcceptDottedPropertyNames = AppContext.TryGetSwitch("Serilog.Parsing.MessageTemplateParser.AcceptDottedPropertyNames", out var isEnabled) && isEnabled;
-
     static readonly TextToken EmptyTextToken = new("");
-
-    readonly bool _acceptDottedPropertyNames;
 
     /// <summary>
     /// Construct a <see cref="MessageTemplateParser"/>.
     /// </summary>
     public MessageTemplateParser()
-        : this(DefaultAcceptDottedPropertyNames)
     {
-    }
-
-    internal MessageTemplateParser(bool acceptDottedPropertyNames)
-    {
-        _acceptDottedPropertyNames = acceptDottedPropertyNames;
     }
 
     /// <summary>
@@ -96,7 +83,7 @@ public class MessageTemplateParser : IMessageTemplateParser
         if (startAt == -1)
         {
             next = messageTemplate.Length;
-            return new TextToken(messageTemplate.Substring(first));
+            return new TextToken(messageTemplate[first..]);
         }
 
         next = startAt + 1;
@@ -112,16 +99,19 @@ public class MessageTemplateParser : IMessageTemplateParser
         var propertyName = propertyNameAndDestructuring;
         var destructuring = Destructuring.Default;
         if (propertyName.Length != 0 && TryGetDestructuringHint(propertyName[0], out destructuring))
-            propertyName = propertyName.Substring(1);
+            propertyName = propertyName[1..];
 
-        if (propertyName.Length == 0)
-            return new TextToken(rawText);
-
+        var beginIdent = true;
         for (var i = 0; i < propertyName.Length; ++i)
         {
             var c = propertyName[i];
-            if (!IsValidInPropertyName(c))
+            if (!TryContinuePropertyName(c, i == 0, ref beginIdent))
                 return new TextToken(rawText);
+        }
+
+        if (beginIdent)
+        {
+            return new TextToken(rawText);
         }
 
         if (format != null)
@@ -171,7 +161,7 @@ public class MessageTemplateParser : IMessageTemplateParser
 
         if (alignmentDelim == -1 || (formatDelim != -1 && alignmentDelim > formatDelim))
         {
-            propertyNameAndDestructuring = tagContent.Substring(0, formatDelim);
+            propertyNameAndDestructuring = tagContent[..formatDelim];
             format = formatDelim == tagContent.Length - 1 ?
                 null :
                 tagContent.Substring(formatDelim + 1);
@@ -179,7 +169,7 @@ public class MessageTemplateParser : IMessageTemplateParser
             return true;
         }
 
-        propertyNameAndDestructuring = tagContent.Substring(0, alignmentDelim);
+        propertyNameAndDestructuring = tagContent[..alignmentDelim];
         if (formatDelim == -1)
         {
             if (alignmentDelim == tagContent.Length - 1)
@@ -189,7 +179,7 @@ public class MessageTemplateParser : IMessageTemplateParser
             }
 
             format = null;
-            alignment = tagContent.Substring(alignmentDelim + 1);
+            alignment = tagContent[(alignmentDelim + 1)..];
             return true;
         }
 
@@ -202,15 +192,32 @@ public class MessageTemplateParser : IMessageTemplateParser
         alignment = tagContent.Substring(alignmentDelim + 1, formatDelim - alignmentDelim - 1);
         format = formatDelim == tagContent.Length - 1 ?
             null :
-            tagContent.Substring(formatDelim + 1);
+            tagContent[(formatDelim + 1)..];
 
         return true;
     }
 
-    bool IsValidInPropertyName(char c) =>
-        char.IsLetterOrDigit(c) ||
-        c is '_' ||
-        _acceptDottedPropertyNames && c is '.';
+    static bool TryContinuePropertyName(char c, bool first, ref bool beginIdent)
+    {
+        if (beginIdent && !first && char.IsDigit(c))
+        {
+            return false;
+        }
+
+        if (char.IsLetterOrDigit(c) || c is '_')
+        {
+            beginIdent = false;
+            return true;
+        }
+
+        if (!beginIdent && c is '.')
+        {
+            beginIdent = true;
+            return true;
+        }
+
+        return false;
+    }
 
     static bool TryGetDestructuringHint(char c, out Destructuring destructuring)
     {

--- a/test/Serilog.Tests/Core/LoggerTests.cs
+++ b/test/Serilog.Tests/Core/LoggerTests.cs
@@ -323,7 +323,7 @@ public class LoggerTests
     {
         var evt = DelegatingSink.GetLogEvent(l =>
         {
-            var a = new object[3, 2] { { "a", "b" }, { "c", "d" }, { "e", "f" } };
+            var a = new object[,] { { "a", "b" }, { "c", "d" }, { "e", "f" } };
             l.Error("{@Value}", a);
         });
 
@@ -339,7 +339,7 @@ public class LoggerTests
     {
         var evt = DelegatingSink.GetLogEvent(l =>
         {
-            var a = new object[3, 2, 1] { { { "a" }, { "b" } }, { { "c" }, { "d" } }, { { "e" }, { "f" } } };
+            var a = new object[,,] { { { "a" }, { "b" } }, { { "c" }, { "d" } }, { { "e" }, { "f" } } };
             l.Error("{@Value}", a);
         });
 
@@ -355,7 +355,7 @@ public class LoggerTests
     {
         var evt = DelegatingSink.GetLogEvent(l =>
         {
-            var a = new object[2, 2, 2, 2]
+            var a = new object[,,,]
             {
                 {
                     {
@@ -419,11 +419,11 @@ public class LoggerTests
             .WriteTo.Sink(collectingSink)
             .CreateLogger();
 
-        var array = new int[3][]
+        var array = new int[][]
         {
-            new int[] { 1, 2, 3 },
-            new int[] { 4, 5, 6 },
-            new int[] { 7, 8, 9, 10 }
+            [1, 2, 3],
+            [4, 5, 6],
+            [7, 8, 9, 10]
         };
 
         // Act
@@ -458,7 +458,7 @@ public class LoggerTests
             .WriteTo.Sink(collectingSink)
             .CreateLogger();
 
-        var array = new int[3, 3]
+        var array = new[,]
         {
             { 1, 2, 3 },
             { 4, 5, 6 },

--- a/test/Serilog.Tests/Parsing/MessageTemplateParserTests.cs
+++ b/test/Serilog.Tests/Parsing/MessageTemplateParserTests.cs
@@ -107,16 +107,9 @@ public class MessageTemplateParserTests
     [Theory]
     [InlineData("{test.name}")]
     [InlineData("{te.st.na.me}")]
-    // Questionable syntax but permitted by the experimental flag. These are documented here so that if the
-    // feature progresses to first-class support, they can be detected and dealt with accordingly.
-    [InlineData("{.testname}")]
-    [InlineData("{testname.}")]
-    [InlineData("{.}")]
-    [InlineData("{..}")]
-    [InlineData("{test..name}")]
-    public void DashedAndDottedNamesAreAcceptedWhenFeatureFlaggedIn(string template)
+    public void DashedAndDottedNamesAreAccepted(string template)
     {
-        var parser = new MessageTemplateParser(acceptDottedPropertyNames: true);
+        var parser = new MessageTemplateParser();
         var token = Assert.Single(parser.Parse(template).Tokens);
         var propertyToken = Assert.IsType<PropertyToken>(token);
         var expected = template.Trim('{', '}');
@@ -127,14 +120,19 @@ public class MessageTemplateParserTests
     }
 
     [Theory]
-    [InlineData("{0 space}",   "{0 space}")]
-    [InlineData("{0 space",    "{0 space")]
-    [InlineData("{0_space",    "{0_space")]
-    [InlineData("{0_{{space}", "{0_{{space}")]
-    [InlineData("{0_{{space",  "{0_{{space")]
-    public void AMalformedPropertyTagIsParsedAsText(string template, string expected)
+    [InlineData("{0 space}")]
+    [InlineData("{0 space")]
+    [InlineData("{0_space")]
+    [InlineData("{0_{{space}")]
+    [InlineData("{0_{{space")]
+    [InlineData("{.testname}")]
+    [InlineData("{testname.}")]
+    [InlineData("{.}")]
+    [InlineData("{..}")]
+    [InlineData("{test..name}")]
+    public void AMalformedPropertyTagIsParsedAsText(string template)
     {
-        AssertParsedAs(template, new TextToken(expected));
+        AssertParsedAs(template, new TextToken(template));
     }
 
     [Fact]

--- a/test/Serilog.Tests/Parsing/MessageTemplateParserTests.cs
+++ b/test/Serilog.Tests/Parsing/MessageTemplateParserTests.cs
@@ -130,6 +130,9 @@ public class MessageTemplateParserTests
     [InlineData("{.}")]
     [InlineData("{..}")]
     [InlineData("{test..name}")]
+    [InlineData("{10.name}")]
+    [InlineData("{0_}")]
+    [InlineData("{0a}")]
     public void AMalformedPropertyTagIsParsedAsText(string template)
     {
         AssertParsedAs(template, new TextToken(template));
@@ -138,7 +141,7 @@ public class MessageTemplateParserTests
     [Fact]
     public void ATrailingUnmatchedBracketIsParsedAsText()
     {
-        AssertParsedAs("{0_}}space}", new PropertyToken("0_", "{0_}"), new TextToken("}space}"));
+        AssertParsedAs("{0}}space}", new PropertyToken("0", "{0}"), new TextToken("}space}"));
     }
 
     [Fact]


### PR DESCRIPTION
This PR continues on from #2063, which enables `{a.b}`-style placeholders in message templates. The major benefit of this is to support environments that have standardized on [OpenTelemetry](https://opentelemetry.io/docs/specs/semconv/), [DataDog](https://docs.datadoghq.com/standard-attributes/), or [ECS-style](https://www.elastic.co/guide/en/ecs/current/ecs-field-reference.html) naming schemes.

Dotted names, which are captured as _flat_ property names by Serilog, are compatible with a good slice of the Serilog ecosystem, but not all of it. Enough Serilog-based sinks, libraries and tooling will work with dotted names that these should be immediately usable by a majority of users. The process of finding and fixing problems when dots appear in property names may take some time, but can proceed incrementally with this enabling work done.

There's a small behavioral change here: in message templates, property names beginning with a number must now be completely numeric, so `{0_}` and `{0a}`, which were previously accepted, are now rejected. I'd expect the number of users that this might impact to be vanishingly small, but in the unlikely case someone is capturing data with these names, fallback capturing behavior will at still collect the events and properties.
