### PR TITLE
Property factory as AddPropertyIfAbsent parameter

### DIFF
--- a/src/Serilog/Events/LogEvent.cs
+++ b/src/Serilog/Events/LogEvent.cs
@@ -204,8 +204,20 @@ public class LogEvent
 #endif
     }
 
-    internal void AddPropertyIfAbsent(ILogEventPropertyFactory factory, string name, object? value, bool destructureObjects = false)
+    /// <summary>
+    /// Add a property to the event if not already present.
+    /// </summary>
+    /// <param name="factory">Factory for creating the property to add to the event.</param>
+    /// <param name="name">The name of the property.</param>
+    /// <param name="value">The value of the property.</param>
+    /// <param name="destructureObjects">If <see langword="true"/>, and the value is a non-primitive, non-array type,
+    /// then the value will be converted to a structure; otherwise, unknown types will
+    /// be converted to scalars, which are generally stored as strings.</param>
+    /// <exception cref="ArgumentNullException">When <paramref name="factory"/> is <code>null</code></exception>
+    public void AddPropertyIfAbsent(ILogEventPropertyFactory factory, string name, object? value, bool destructureObjects = false)
     {
+        Guard.AgainstNull(factory);
+
         if (!_properties.ContainsKey(name))
         {
             _properties.Add(

--- a/test/Serilog.ApprovalTests/Serilog.approved.txt
+++ b/test/Serilog.ApprovalTests/Serilog.approved.txt
@@ -411,6 +411,7 @@ namespace Serilog.Events
         public System.Diagnostics.ActivityTraceId? TraceId { get; }
         public void AddOrUpdateProperty(Serilog.Events.LogEventProperty property) { }
         public void AddPropertyIfAbsent(Serilog.Events.LogEventProperty property) { }
+        public void AddPropertyIfAbsent(Serilog.Core.ILogEventPropertyFactory factory, string name, object? value, bool destructureObjects = false) { }
         public void RemovePropertyIfPresent(string propertyName) { }
         public string RenderMessage(System.IFormatProvider? formatProvider = null) { }
         public void RenderMessage(System.IO.TextWriter output, System.IFormatProvider? formatProvider = null) { }

--- a/test/Serilog.Tests/Configuration/LoggerConfigurationTests.cs
+++ b/test/Serilog.Tests/Configuration/LoggerConfigurationTests.cs
@@ -254,6 +254,24 @@ public class LoggerConfigurationTests
     }
 
     [Fact]
+    public void EnrichersWithPropertyFactoryExecuteInConfigurationOrder()
+    {
+        var propertyName = Some.String();
+        var propertyValue = Some.String();
+        var enrichedPropertySeen = false;
+
+        var logger = new LoggerConfiguration()
+            .WriteTo.Sink(new StringSink())
+            .Enrich.With(new DelegatingEnricher((e, factory) => e.AddPropertyIfAbsent(factory, propertyName, propertyValue)))
+            .Enrich.With(new DelegatingEnricher((e, _) => enrichedPropertySeen = e.Properties.ContainsKey(propertyName)))
+            .CreateLogger();
+
+        logger.Write(Some.InformationEvent());
+
+        Assert.True(enrichedPropertySeen);
+    }
+
+    [Fact]
     public void MaximumDestructuringDepthDefaultIsEffective()
     {
         var x = new


### PR DESCRIPTION
In this PR I propose to set public this internal method overload:
```
LogEvent.AddPropertyIfAbsent(ILogEventPropertyFactory factory, string name, object? value, bool destructureObjects = false)
```

The goal is allow to write optimised `ILogEventEnricher`classes and also to be able to use `ILogEventPropertyFactory` to create properties.

In therm of performance this solution would be almost the same as the code suggested in https://github.com/serilog/serilog/issues/739 where properties are created only once, but with the benefit of using the property factory as intended by the `ILogEventEnricher` interface. 

Example:
```
class SampleEnricher(Foo foo) : ILogEventEnricher
{
    public void Enrich(LogEvent logEvent, ILogEventPropertyFactory propertyFactory)
    {
        // a LogEventProperty object is created by the factory only if missing
        logEvent.AddPropertyIfAbsent(propertyFactory, nameof(foo.Bar), foo.Bar);
    }
}
```