### PR TITLE
Use HTTPS in README.md images and links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Serilog&nbsp;[![Build status](https://github.com/serilog/serilog/actions/workflows/ci.yml/badge.svg?branch=dev)](https://github.com/serilog/serilog/actions)&nbsp;[![NuGet Version](http://img.shields.io/nuget/v/Serilog.svg?style=flat)](https://www.nuget.org/packages/Serilog/)&nbsp;[![NuGet Downloads](https://img.shields.io/nuget/dt/serilog.svg)](https://www.nuget.org/packages/Serilog/)&nbsp;[![Stack Overflow](https://img.shields.io/badge/stack%20overflow-serilog-orange.svg)](http://stackoverflow.com/questions/tagged/serilog)
+# Serilog&nbsp;[![Build status](https://github.com/serilog/serilog/actions/workflows/ci.yml/badge.svg?branch=dev)](https://github.com/serilog/serilog/actions)&nbsp;[![NuGet Version](https://img.shields.io/nuget/v/Serilog.svg?style=flat)](https://www.nuget.org/packages/Serilog/)&nbsp;[![NuGet Downloads](https://img.shields.io/nuget/dt/serilog.svg)](https://www.nuget.org/packages/Serilog/)&nbsp;[![Stack Overflow](https://img.shields.io/badge/stack%20overflow-serilog-orange.svg)](https://stackoverflow.com/questions/tagged/serilog)
 
 Serilog is a diagnostic logging library for .NET applications. It is easy to set up, has a clean API, and runs on all recent .NET platforms. While it's useful even in the simplest applications, Serilog's support for structured logging shines when instrumenting complex, distributed, and asynchronous applications and systems.
 
@@ -103,7 +103,7 @@ To learn more about Serilog, check out the [documentation](https://github.com/se
 
 Serilog has an active and helpful community who are happy to help point you in the right direction or work through any issues you might encounter. You can get in touch via:
 
- * [Stack Overflow](http://stackoverflow.com/questions/tagged/serilog) &mdash; this is the best place to start if you have a question. Many track the `serilog` tag there.
+ * [Stack Overflow](https://stackoverflow.com/questions/tagged/serilog) &mdash; this is the best place to start if you have a question. Many track the `serilog` tag there.
  * The [#serilog tag on Twitter](https://twitter.com/search?q=%23serilog)
  * [Serilog-related courses on Pluralsight](https://www.pluralsight.com/search/?q=serilog)
 
@@ -116,4 +116,4 @@ Would you like to help make Serilog even better? We keep a list of issues that a
 
 When contributing please keep in mind our [Code of Conduct](CODE_OF_CONDUCT.md).
 
-_Serilog is copyright &copy; Serilog Contributors - Provided under the [Apache License, Version 2.0](http://apache.org/licenses/LICENSE-2.0.html). Needle and thread logo a derivative of work by [Kenneth Appiah](http://www.kensets.com/)._
+_Serilog is copyright &copy; Serilog Contributors - Provided under the [Apache License, Version 2.0](https://apache.org/licenses/LICENSE-2.0.html). Needle and thread logo a derivative of work by [Kenneth Appiah](https://www.kensets.com/)._


### PR DESCRIPTION
Avoid mixed content issues and unnecessary redirects with https links and image tags