### PR TITLE
allow pushing a IEnumerable of ILogEventEnricher

### DIFF
--- a/src/Serilog/Context/LogContext.cs
+++ b/src/Serilog/Context/LogContext.cs
@@ -129,7 +129,7 @@ public static class LogContext
     /// <param name="enrichers">Enrichers to push onto the log context</param>
     /// <returns>A token that must be disposed, in order, to pop properties back off the stack.</returns>
     /// <exception cref="ArgumentNullException">When <paramref name="enrichers"/> is <code>null</code></exception>
-    [OverloadResolutionPriority(1) ]
+    [OverloadResolutionPriority(1)]
     public static IDisposable Push(params IEnumerable<ILogEventEnricher> enrichers)
     {
         Guard.AgainstNull(enrichers);

--- a/src/Serilog/Context/LogContext.cs
+++ b/src/Serilog/Context/LogContext.cs
@@ -66,6 +66,7 @@ public static class LogContext
     /// <param name="enricher">An enricher to push onto the log context</param>
     /// <returns>A token that must be disposed, in order, to pop properties back off the stack.</returns>
     /// <exception cref="ArgumentNullException">When <paramref name="enricher"/> is <code>null</code></exception>
+    [OverloadResolutionPriority(3)]
     public static IDisposable Push(ILogEventEnricher enricher)
     {
         Guard.AgainstNull(enricher);
@@ -88,9 +89,10 @@ public static class LogContext
     /// <param name="enrichers">Enrichers to push onto the log context</param>
     /// <returns>A token that must be disposed, in order, to pop properties back off the stack.</returns>
     /// <exception cref="ArgumentNullException">When <paramref name="enrichers"/> is <code>null</code></exception>
+    [OverloadResolutionPriority(0)]
     public static IDisposable Push(params ILogEventEnricher[] enrichers)
     {
-        return Push(enrichers.AsSpan());
+        return Push(enrichers);
     }
 
     /// <summary>
@@ -102,6 +104,7 @@ public static class LogContext
     /// <seealso cref="PropertyEnricher"/>.
     /// <param name="enrichers">Enrichers to push onto the log context</param>
     /// <returns>A token that must be disposed, in order, to pop properties back off the stack.</returns>
+    [OverloadResolutionPriority(2)]
     public static IDisposable Push(params ReadOnlySpan<ILogEventEnricher> enrichers)
     {
         var stack = GetOrCreateEnricherStack();
@@ -127,6 +130,7 @@ public static class LogContext
     /// <param name="enrichers">Enrichers to push onto the log context</param>
     /// <returns>A token that must be disposed, in order, to pop properties back off the stack.</returns>
     /// <exception cref="ArgumentNullException">When <paramref name="enrichers"/> is <code>null</code></exception>
+    [OverloadResolutionPriority(1)]
     public static IDisposable Push(params IEnumerable<ILogEventEnricher> enrichers)
     {
         Guard.AgainstNull(enrichers);

--- a/src/Serilog/Context/LogContext.cs
+++ b/src/Serilog/Context/LogContext.cs
@@ -66,6 +66,7 @@ public static class LogContext
     /// <param name="enricher">An enricher to push onto the log context</param>
     /// <returns>A token that must be disposed, in order, to pop properties back off the stack.</returns>
     /// <exception cref="ArgumentNullException">When <paramref name="enricher"/> is <code>null</code></exception>
+    [OverloadResolutionPriority(2)]
     public static IDisposable Push(ILogEventEnricher enricher)
     {
         Guard.AgainstNull(enricher);

--- a/src/Serilog/Context/LogContext.cs
+++ b/src/Serilog/Context/LogContext.cs
@@ -92,7 +92,7 @@ public static class LogContext
     [OverloadResolutionPriority(0)]
     public static IDisposable Push(params ILogEventEnricher[] enrichers)
     {
-        return Push(enrichers);
+        return Push(enrichers.AsSpan());
     }
 
     /// <summary>

--- a/src/Serilog/Context/LogContext.cs
+++ b/src/Serilog/Context/LogContext.cs
@@ -92,6 +92,8 @@ public static class LogContext
     [OverloadResolutionPriority(0)]
     public static IDisposable Push(params ILogEventEnricher[] enrichers)
     {
+        Guard.AgainstNull(enrichers);
+        
         return Push(enrichers.AsSpan());
     }
 

--- a/src/Serilog/Context/LogContext.cs
+++ b/src/Serilog/Context/LogContext.cs
@@ -90,7 +90,7 @@ public static class LogContext
     /// <exception cref="ArgumentNullException">When <paramref name="enrichers"/> is <code>null</code></exception>
     public static IDisposable Push(params ILogEventEnricher[] enrichers)
     {
-        return Push(enrichers);
+        return Push(enrichers.AsSpan());
     }
 
     /// <summary>

--- a/src/Serilog/Context/LogContext.cs
+++ b/src/Serilog/Context/LogContext.cs
@@ -88,15 +88,35 @@ public static class LogContext
     /// <param name="enrichers">Enrichers to push onto the log context</param>
     /// <returns>A token that must be disposed, in order, to pop properties back off the stack.</returns>
     /// <exception cref="ArgumentNullException">When <paramref name="enrichers"/> is <code>null</code></exception>
+    [OverloadResolutionPriority(0)]
+    [Obsolete("Use Push(IEnumerable<ILogEventEnricher> enrichers) instead.")]
     public static IDisposable Push(params ILogEventEnricher[] enrichers)
+    {
+        return Push(enrichers);
+    }
+
+    /// <summary>
+    /// Push multiple enrichers onto the context, returning an <see cref="IDisposable"/>
+    /// that must later be used to remove the property, along with any others that
+    /// may have been pushed on top of it and not yet popped. The property must
+    /// be popped from the same thread/logical call context.
+    /// </summary>
+    /// <seealso cref="PropertyEnricher"/>.
+    /// <param name="enrichers">Enrichers to push onto the log context</param>
+    /// <returns>A token that must be disposed, in order, to pop properties back off the stack.</returns>
+    /// <exception cref="ArgumentNullException">When <paramref name="enrichers"/> is <code>null</code></exception>
+    [OverloadResolutionPriority(1) ]
+    public static IDisposable Push(params IEnumerable<ILogEventEnricher> enrichers)
     {
         Guard.AgainstNull(enrichers);
 
         var stack = GetOrCreateEnricherStack();
         var bookmark = new ContextStackBookmark(stack);
 
-        for (var i = 0; i < enrichers.Length; ++i)
-            stack = stack.Push(enrichers[i]);
+        foreach (var enricher in enrichers)
+        {
+            stack = stack.Push(enricher);
+        }
 
         Enrichers = stack;
 

--- a/src/Serilog/Context/LogContext.cs
+++ b/src/Serilog/Context/LogContext.cs
@@ -103,7 +103,6 @@ public static class LogContext
     /// <seealso cref="PropertyEnricher"/>.
     /// <param name="enrichers">Enrichers to push onto the log context</param>
     /// <returns>A token that must be disposed, in order, to pop properties back off the stack.</returns>
-    /// <exception cref="ArgumentNullException">When <paramref name="enrichers"/> is <code>null</code></exception>
     public static IDisposable Push(params ReadOnlySpan<ILogEventEnricher> enrichers)
     {
         var stack = GetOrCreateEnricherStack();

--- a/src/Serilog/Context/LogContext.cs
+++ b/src/Serilog/Context/LogContext.cs
@@ -66,7 +66,6 @@ public static class LogContext
     /// <param name="enricher">An enricher to push onto the log context</param>
     /// <returns>A token that must be disposed, in order, to pop properties back off the stack.</returns>
     /// <exception cref="ArgumentNullException">When <paramref name="enricher"/> is <code>null</code></exception>
-    [OverloadResolutionPriority(3)]
     public static IDisposable Push(ILogEventEnricher enricher)
     {
         Guard.AgainstNull(enricher);
@@ -89,7 +88,6 @@ public static class LogContext
     /// <param name="enrichers">Enrichers to push onto the log context</param>
     /// <returns>A token that must be disposed, in order, to pop properties back off the stack.</returns>
     /// <exception cref="ArgumentNullException">When <paramref name="enrichers"/> is <code>null</code></exception>
-    [OverloadResolutionPriority(0)]
     public static IDisposable Push(params ILogEventEnricher[] enrichers)
     {
         return Push(enrichers);
@@ -104,7 +102,6 @@ public static class LogContext
     /// <seealso cref="PropertyEnricher"/>.
     /// <param name="enrichers">Enrichers to push onto the log context</param>
     /// <returns>A token that must be disposed, in order, to pop properties back off the stack.</returns>
-    [OverloadResolutionPriority(2)]
     public static IDisposable Push(params ReadOnlySpan<ILogEventEnricher> enrichers)
     {
         var stack = GetOrCreateEnricherStack();
@@ -130,7 +127,6 @@ public static class LogContext
     /// <param name="enrichers">Enrichers to push onto the log context</param>
     /// <returns>A token that must be disposed, in order, to pop properties back off the stack.</returns>
     /// <exception cref="ArgumentNullException">When <paramref name="enrichers"/> is <code>null</code></exception>
-    [OverloadResolutionPriority(1)]
     public static IDisposable Push(params IEnumerable<ILogEventEnricher> enrichers)
     {
         Guard.AgainstNull(enrichers);

--- a/src/Serilog/Context/LogContext.cs
+++ b/src/Serilog/Context/LogContext.cs
@@ -66,7 +66,7 @@ public static class LogContext
     /// <param name="enricher">An enricher to push onto the log context</param>
     /// <returns>A token that must be disposed, in order, to pop properties back off the stack.</returns>
     /// <exception cref="ArgumentNullException">When <paramref name="enricher"/> is <code>null</code></exception>
-    [OverloadResolutionPriority(2)]
+    [OverloadResolutionPriority(3)]
     public static IDisposable Push(ILogEventEnricher enricher)
     {
         Guard.AgainstNull(enricher);
@@ -104,6 +104,7 @@ public static class LogContext
     /// <seealso cref="PropertyEnricher"/>.
     /// <param name="enrichers">Enrichers to push onto the log context</param>
     /// <returns>A token that must be disposed, in order, to pop properties back off the stack.</returns>
+    [OverloadResolutionPriority(2)]
     public static IDisposable Push(params ReadOnlySpan<ILogEventEnricher> enrichers)
     {
         var stack = GetOrCreateEnricherStack();

--- a/src/Serilog/Serilog.csproj
+++ b/src/Serilog/Serilog.csproj
@@ -49,7 +49,7 @@
     <None Include="../../assets/icon.png" Pack="true" Visible="false" PackagePath="/" />
     <None Include="../../README.md" Pack="true" Visible="false" PackagePath="/" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-    <PackageReference Include="PolySharp" Version="1.14.1" PrivateAssets="All" />
+    <PackageReference Include="PolySharp" Version="1.15.0" PrivateAssets="All" />
     <EmbeddedResource Include="ILLink.Substitutions.xml">
       <LogicalName>ILLink.Substitutions.xml</LogicalName>
     </EmbeddedResource>

--- a/test/Serilog.ApprovalTests/Serilog.approved.txt
+++ b/test/Serilog.ApprovalTests/Serilog.approved.txt
@@ -105,8 +105,14 @@ namespace Serilog.Context
     public static class LogContext
     {
         public static Serilog.Core.ILogEventEnricher Clone() { }
+        [System.Runtime.CompilerServices.OverloadResolutionPriority(3)]
         public static System.IDisposable Push(Serilog.Core.ILogEventEnricher enricher) { }
+        [System.Runtime.CompilerServices.OverloadResolutionPriority(0)]
         public static System.IDisposable Push(params Serilog.Core.ILogEventEnricher[] enrichers) { }
+        [System.Runtime.CompilerServices.OverloadResolutionPriority(1)]
+        public static System.IDisposable Push([System.Runtime.CompilerServices.ParamCollection] System.Collections.Generic.IEnumerable<Serilog.Core.ILogEventEnricher> enrichers) { }
+        [System.Runtime.CompilerServices.OverloadResolutionPriority(2)]
+        public static System.IDisposable Push([System.Runtime.CompilerServices.ParamCollection] [System.Runtime.CompilerServices.ScopedRef] System.ReadOnlySpan<Serilog.Core.ILogEventEnricher> enrichers) { }
         public static System.IDisposable PushProperty(string name, object? value, bool destructureObjects = false) { }
         public static void Reset() { }
         public static System.IDisposable Suspend() { }

--- a/test/Serilog.Tests/Context/LogContextTests.cs
+++ b/test/Serilog.Tests/Context/LogContextTests.cs
@@ -3,6 +3,63 @@ namespace Serilog.Tests.Context;
 public class LogContextTests
 {
     [Fact]
+    public void PushedSpanPropertiesAreAvailableToLoggers()
+    {
+        LogEvent? lastEvent = null;
+
+        var log = new LoggerConfiguration()
+            .Enrich.FromLogContext()
+            .WriteTo.Sink(new DelegatingSink(e => lastEvent = e))
+            .CreateLogger();
+        ReadOnlySpan<ILogEventEnricher> enrichers = [new PropertyEnricher("A", 1), new PropertyEnricher("B", 2)];
+        using (LogContext.Push(enrichers))
+        {
+            log.Write(Some.InformationEvent());
+            Assert.NotNull(lastEvent);
+            Assert.Equal(1, lastEvent!.Properties["A"].LiteralValue());
+            Assert.Equal(2, lastEvent.Properties["B"].LiteralValue());
+        }
+    }
+
+    [Fact]
+    public void PushedArrayPropertiesAreAvailableToLoggers()
+    {
+        LogEvent? lastEvent = null;
+
+        var log = new LoggerConfiguration()
+            .Enrich.FromLogContext()
+            .WriteTo.Sink(new DelegatingSink(e => lastEvent = e))
+            .CreateLogger();
+        PropertyEnricher[] enrichers = [new("A", 1), new("B", 2)];
+        using (LogContext.Push(enrichers))
+        {
+            log.Write(Some.InformationEvent());
+            Assert.NotNull(lastEvent);
+            Assert.Equal(1, lastEvent!.Properties["A"].LiteralValue());
+            Assert.Equal(2, lastEvent.Properties["B"].LiteralValue());
+        }
+    }
+
+    [Fact]
+    public void PushedEnumerablePropertiesAreAvailableToLoggers()
+    {
+        LogEvent? lastEvent = null;
+
+        var log = new LoggerConfiguration()
+            .Enrich.FromLogContext()
+            .WriteTo.Sink(new DelegatingSink(e => lastEvent = e))
+            .CreateLogger();
+        IEnumerable<PropertyEnricher> enrichers = [new("A", 1), new("B", 2)];
+        using (LogContext.Push(enrichers))
+        {
+            log.Write(Some.InformationEvent());
+            Assert.NotNull(lastEvent);
+            Assert.Equal(1, lastEvent!.Properties["A"].LiteralValue());
+            Assert.Equal(2, lastEvent.Properties["B"].LiteralValue());
+        }
+    }
+
+    [Fact]
     public void PushedPropertiesAreAvailableToLoggers()
     {
         LogEvent? lastEvent = null;


### PR DESCRIPTION
given in some contexts i build up a list of ILogEventEnricher of a (runtime) variable size. So the array nature of push forces a redundant array alloc.

this PR adds a `params IEnumerable` overload.

I am not sure on having the Obsolete? the OverloadResolutionPriority will point the compiler to IEnumerable overload. so it is not a compile time breaking change. and it is not a runtime breaking change. thoughts?

