### PR TITLE
Fix AOT compatibility

### DIFF
--- a/Serilog.sln
+++ b/Serilog.sln
@@ -1,3 +1,4 @@
+﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.5.33424.131
@@ -42,6 +43,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "workflows", "workflows", "{
 	ProjectSection(SolutionItems) = preProject
 		.github\workflows\ci.yml = .github\workflows\ci.yml
 	EndProjectSection
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AotTestApp", "test\AotTestApp\AotTestApp.csproj", "{445C4888-6DA3-411B-8284-7CFB0E5768A9}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -113,6 +116,18 @@ Global
 		{7669BB99-A118-436B-8C58-1D8E8989A775}.Release|x64.Build.0 = Release|Any CPU
 		{7669BB99-A118-436B-8C58-1D8E8989A775}.Release|x86.ActiveCfg = Release|Any CPU
 		{7669BB99-A118-436B-8C58-1D8E8989A775}.Release|x86.Build.0 = Release|Any CPU
+		{445C4888-6DA3-411B-8284-7CFB0E5768A9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{445C4888-6DA3-411B-8284-7CFB0E5768A9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{445C4888-6DA3-411B-8284-7CFB0E5768A9}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{445C4888-6DA3-411B-8284-7CFB0E5768A9}.Debug|x64.Build.0 = Debug|Any CPU
+		{445C4888-6DA3-411B-8284-7CFB0E5768A9}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{445C4888-6DA3-411B-8284-7CFB0E5768A9}.Debug|x86.Build.0 = Debug|Any CPU
+		{445C4888-6DA3-411B-8284-7CFB0E5768A9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{445C4888-6DA3-411B-8284-7CFB0E5768A9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{445C4888-6DA3-411B-8284-7CFB0E5768A9}.Release|x64.ActiveCfg = Release|Any CPU
+		{445C4888-6DA3-411B-8284-7CFB0E5768A9}.Release|x64.Build.0 = Release|Any CPU
+		{445C4888-6DA3-411B-8284-7CFB0E5768A9}.Release|x86.ActiveCfg = Release|Any CPU
+		{445C4888-6DA3-411B-8284-7CFB0E5768A9}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -125,6 +140,7 @@ Global
 		{7669BB99-A118-436B-8C58-1D8E8989A775} = {290A2775-7CA0-4F81-9DDC-32E28C3A7565}
 		{3BFAB570-11C6-4C85-97A6-2740219F5B48} = {17C8775C-0621-438E-81D4-3B9E98A616BD}
 		{D44EC05A-1374-4053-A9A2-41E8EA1CE0D2} = {17C8775C-0621-438E-81D4-3B9E98A616BD}
+		{445C4888-6DA3-411B-8284-7CFB0E5768A9} = {290A2775-7CA0-4F81-9DDC-32E28C3A7565}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {268F5761-DAC2-4ECA-9AEC-59663B84854C}

--- a/src/Serilog/Capturing/PropertyValueConverter.cs
+++ b/src/Serilog/Capturing/PropertyValueConverter.cs
@@ -363,14 +363,14 @@ partial class PropertyValueConverter : ILogEventPropertyFactory, ILogEventProper
             {
                 var isCompilerGeneratedType = IsCompilerGeneratedType(type);
                 // !!IMPORTANT!!
-                // This block of code is guarded by the IsStructureValueSupported check,
-                // meaning that it will not be trimmed away if the switch is disabled.
-                // This is important because CreateStructureValue is not trim-compatible, so
-                // the switch must be disabled during trimming to ensure that the code is removed.
-                // We suppress the warning below because the analyzer doesn't understand feature
-                // switch removal (and #pragma warnings are meaningless to the IL trimmer), but
-                // this pragma cannot be expanded outside of the scope of this check, and all
-                // calls to CreateStructureValue must be guarded by this check.
+                // This block of code is guarded by the IsStructureValueSupported check, meaning
+                // that it will be trimmed away if the switch is disabled.  This is important
+                // because CreateStructureValue is not trim-compatible, so the switch must be
+                // disabled during trimming to ensure that the code is removed.  We suppress the
+                // warning below because the analyzer doesn't understand feature switch removal (and
+                // #pragma warnings are meaningless to the IL trimmer), but this pragma cannot be
+                // expanded outside of the scope of this check, and all calls to
+                // CreateStructureValue must be guarded by this check.
 #pragma warning disable IL2067
                 result = CreateStructureValue(value, type, isCompilerGeneratedType);
 #pragma warning restore IL2067

--- a/src/Serilog/Capturing/PropertyValueConverter.cs
+++ b/src/Serilog/Capturing/PropertyValueConverter.cs
@@ -163,11 +163,8 @@ partial class PropertyValueConverter : ILogEventPropertyFactory, ILogEventProper
         if (TryConvertValueTuple(value, type, destructuring, out var tupleResult))
             return tupleResult;
 
-        // This appears to be a hole in analysis prior to .NET 9
-#pragma warning disable IL2072
         if (TryConvertStructure(value, type, destructuring, out var structureResult))
             return structureResult;
-#pragma warning restore IL2072
 
         return new ScalarValue(value.ToString() ?? "");
     }
@@ -356,16 +353,27 @@ partial class PropertyValueConverter : ILogEventPropertyFactory, ILogEventProper
 
     bool TryConvertStructure(
         object value,
-        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] Type type,
+        Type type,
         Destructuring destructuring,
         [NotNullWhen(true)] out StructureValue? result)
     {
         if (destructuring == Destructuring.Destructure)
         {
-            var isCompilerGeneratedType = IsCompilerGeneratedType(type);
-            if (!isCompilerGeneratedType || TrimConfiguration.IsCompilerGeneratedCodeSupported)
+            if (TrimConfiguration.IsStructureValueSupported)
             {
+                var isCompilerGeneratedType = IsCompilerGeneratedType(type);
+                // !!IMPORTANT!!
+                // This block of code is guarded by the IsStructureValueSupported check,
+                // meaning that it will not be trimmed away if the switch is disabled.
+                // This is important because CreateStructureValue is not trim-compatible, so
+                // the switch must be disabled during trimming to ensure that the code is removed.
+                // We suppress the warning below because the analyzer doesn't understand feature
+                // switch removal (and #pragma warnings are meaningless to the IL trimmer), but
+                // this pragma cannot be expanded outside of the scope of this check, and all
+                // calls to CreateStructureValue must be guarded by this check.
+#pragma warning disable IL2067
                 result = CreateStructureValue(value, type, isCompilerGeneratedType);
+#pragma warning restore IL2067
                 return true;
             }
         }

--- a/src/Serilog/Capturing/TrimConfiguration.cs
+++ b/src/Serilog/Capturing/TrimConfiguration.cs
@@ -4,11 +4,11 @@ namespace Serilog.Capturing;
 static class TrimConfiguration
 {
     /// <summary>
-    /// True if compiler-generated types are treated specially by Serilog during logging. The main example
+    /// True if structure-value types are treated specially by Serilog during logging. The main example
     /// of this would be anonymous types, which have a special compiler-generated form. If this switch is
     /// disabled, Serilog will not be able to destructure anonymous types, but will still be able to log
     /// them as scalar values.
     /// </summary>
-    public static bool IsCompilerGeneratedCodeSupported { get; } =
-        !AppContext.TryGetSwitch("Serilog.Capturing.IsCompilerGeneratedCodeSupported", out var isEnabled) || isEnabled;
+    public static bool IsStructureValueSupported { get; } =
+        !AppContext.TryGetSwitch("Serilog.Capturing.IsStructureValueSupported", out var isEnabled) || isEnabled;
 }

--- a/src/Serilog/ILLink.Substitutions.xml
+++ b/src/Serilog/ILLink.Substitutions.xml
@@ -1,8 +1,8 @@
 <linker>
   <assembly fullname="Serilog">
     <type fullname="Serilog.Capturing.TrimConfiguration" >
-      <method signature="System.Boolean get_IsCompilerGeneratedCodeSupported()" body="stub" value="false"
-              feature="Serilog.Capturing.IsCompilerGeneratedCodeSupported" featurevalue="false" />
+      <method signature="System.Boolean get_IsStructureValueSupported()" body="stub" value="false"
+              feature="Serilog.Capturing.IsStructureValueSupported" featurevalue="false" />
     </type>
   </assembly>
 </linker>

--- a/src/Serilog/Serilog.csproj
+++ b/src/Serilog/Serilog.csproj
@@ -14,7 +14,7 @@
     <PackageIcon>icon.png</PackageIcon>
     <PackageProjectUrl>https://serilog.net/</PackageProjectUrl>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
-    <IsTrimmable>true</IsTrimmable>
+    <IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net7.0'))">true</IsAotCompatible>
     <NoWarn>$(NoWarn);CS1437;CS1570</NoWarn>
     <PolySharpIncludeRuntimeSupportedAttributes>true</PolySharpIncludeRuntimeSupportedAttributes>
     <PackageReadmeFile>README.md</PackageReadmeFile>
@@ -48,6 +48,7 @@
   <ItemGroup>
     <None Include="../../assets/icon.png" Pack="true" Visible="false" PackagePath="/" />
     <None Include="../../README.md" Pack="true" Visible="false" PackagePath="/" />
+    <None Include="Serilog.props" Pack="true" Visible="false" PackagePath="/build" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
     <PackageReference Include="PolySharp" Version="1.15.0" PrivateAssets="All" />
     <EmbeddedResource Include="ILLink.Substitutions.xml">

--- a/src/Serilog/Serilog.props
+++ b/src/Serilog/Serilog.props
@@ -1,0 +1,7 @@
+<Project>
+    <ItemGroup>
+        <RuntimeHostConfigurationOption
+        Include="Serilog.Capturing.IsStructureValueSupported"
+        Value="false" Trim="true" />
+    </ItemGroup>
+</Project>

--- a/src/Serilog/Settings/KeyValuePairs/SettingValueConversions.cs
+++ b/src/Serilog/Settings/KeyValuePairs/SettingValueConversions.cs
@@ -27,8 +27,10 @@ class SettingValueConversions
         { typeof(TimeSpan), s => TimeSpan.Parse(s) },
         { typeof(Type),
             // Suppress this trimming warning. We'll annotate all the users of this dictionary instead
+            [UnconditionalSuppressMessage("Trimming", "IL2057",
+                Justification = "All users of this dictionary should be annotated with RequiresUnreferencedCode/RequiresDynamicCode")]
 #pragma warning disable IL2057
-            s => Type.GetType(s, throwOnError: true)!
+            (s) => Type.GetType(s, throwOnError: true)!
 #pragma warning restore IL2057
         },
     };

--- a/test/AotTestApp/AotTestApp.csproj
+++ b/test/AotTestApp/AotTestApp.csproj
@@ -6,14 +6,16 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <PublishAot>true</PublishAot>
+    <UseCurrentRuntimeIdentifier>true</UseCurrentRuntimeIdentifier>
   </PropertyGroup>
+
+  <Import Project="..\..\src\Serilog\Serilog.props" />
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Serilog\Serilog.csproj" />
     <TrimmerRootAssembly Include="Serilog" />
-    <RuntimeHostConfigurationOption
-      Include="Serilog.IsCompilerGeneratedCodeSupported"
-      Value="false" Trim="true" />
   </ItemGroup>
+
+  <Target Name="PublishOnBuild" AfterTargets="Build" DependsOnTargets="Publish" />
 
 </Project>


### PR DESCRIPTION
It looks like the code has drifted a bit and disrupted the feature switch that provided AOT compatibility. I've fixed the feature switch, added the AotTestApp to the solution to ensure that it builds when the solution does, configured the AotTestApp to publish on build so that it runs the IL analysis engine, and added a Serilog.props file to the NuGet package to enable the feature switch automatically whenever trimming is enabled.

This should be much more likely to catch any regressions.

Fixes https://github.com/serilog/serilog/issues/2140