### PR TITLE
4.3.0 Release

### DIFF
--- a/Directory.Version.props
+++ b/Directory.Version.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <VersionPrefix>4.2.1</VersionPrefix>
+    <VersionPrefix>4.3.0</VersionPrefix>
   </PropertyGroup>
 </Project>

--- a/Directory.Version.props
+++ b/Directory.Version.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <VersionPrefix>4.2.0</VersionPrefix>
+    <VersionPrefix>4.2.1</VersionPrefix>
   </PropertyGroup>
 </Project>

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Serilog&nbsp;[![Build status](https://github.com/serilog/serilog/actions/workflows/ci.yml/badge.svg?branch=dev)](https://github.com/serilog/serilog/actions)&nbsp;[![NuGet Version](http://img.shields.io/nuget/v/Serilog.svg?style=flat)](https://www.nuget.org/packages/Serilog/)&nbsp;[![NuGet Downloads](https://img.shields.io/nuget/dt/serilog.svg)](https://www.nuget.org/packages/Serilog/)&nbsp;[![Stack Overflow](https://img.shields.io/badge/stack%20overflow-serilog-orange.svg)](http://stackoverflow.com/questions/tagged/serilog)
+# Serilog&nbsp;[![Build status](https://github.com/serilog/serilog/actions/workflows/ci.yml/badge.svg?branch=dev)](https://github.com/serilog/serilog/actions)&nbsp;[![NuGet Version](https://img.shields.io/nuget/v/Serilog.svg?style=flat)](https://www.nuget.org/packages/Serilog/)&nbsp;[![NuGet Downloads](https://img.shields.io/nuget/dt/serilog.svg)](https://www.nuget.org/packages/Serilog/)&nbsp;[![Stack Overflow](https://img.shields.io/badge/stack%20overflow-serilog-orange.svg)](https://stackoverflow.com/questions/tagged/serilog)
 
 Serilog is a diagnostic logging library for .NET applications. It is easy to set up, has a clean API, and runs on all recent .NET platforms. While it's useful even in the simplest applications, Serilog's support for structured logging shines when instrumenting complex, distributed, and asynchronous applications and systems.
 
@@ -103,7 +103,7 @@ To learn more about Serilog, check out the [documentation](https://github.com/se
 
 Serilog has an active and helpful community who are happy to help point you in the right direction or work through any issues you might encounter. You can get in touch via:
 
- * [Stack Overflow](http://stackoverflow.com/questions/tagged/serilog) &mdash; this is the best place to start if you have a question. Many track the `serilog` tag there.
+ * [Stack Overflow](https://stackoverflow.com/questions/tagged/serilog) &mdash; this is the best place to start if you have a question. Many track the `serilog` tag there.
  * The [#serilog tag on Twitter](https://twitter.com/search?q=%23serilog)
  * [Serilog-related courses on Pluralsight](https://www.pluralsight.com/search/?q=serilog)
 
@@ -116,4 +116,4 @@ Would you like to help make Serilog even better? We keep a list of issues that a
 
 When contributing please keep in mind our [Code of Conduct](CODE_OF_CONDUCT.md).
 
-_Serilog is copyright &copy; Serilog Contributors - Provided under the [Apache License, Version 2.0](http://apache.org/licenses/LICENSE-2.0.html). Needle and thread logo a derivative of work by [Kenneth Appiah](http://www.kensets.com/)._
+_Serilog is copyright &copy; Serilog Contributors - Provided under the [Apache License, Version 2.0](https://apache.org/licenses/LICENSE-2.0.html). Needle and thread logo a derivative of work by [Kenneth Appiah](https://www.kensets.com/)._

--- a/Serilog.sln
+++ b/Serilog.sln
@@ -1,3 +1,4 @@
+﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.5.33424.131
@@ -42,6 +43,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "workflows", "workflows", "{
 	ProjectSection(SolutionItems) = preProject
 		.github\workflows\ci.yml = .github\workflows\ci.yml
 	EndProjectSection
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AotTestApp", "test\AotTestApp\AotTestApp.csproj", "{445C4888-6DA3-411B-8284-7CFB0E5768A9}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -113,6 +116,18 @@ Global
 		{7669BB99-A118-436B-8C58-1D8E8989A775}.Release|x64.Build.0 = Release|Any CPU
 		{7669BB99-A118-436B-8C58-1D8E8989A775}.Release|x86.ActiveCfg = Release|Any CPU
 		{7669BB99-A118-436B-8C58-1D8E8989A775}.Release|x86.Build.0 = Release|Any CPU
+		{445C4888-6DA3-411B-8284-7CFB0E5768A9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{445C4888-6DA3-411B-8284-7CFB0E5768A9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{445C4888-6DA3-411B-8284-7CFB0E5768A9}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{445C4888-6DA3-411B-8284-7CFB0E5768A9}.Debug|x64.Build.0 = Debug|Any CPU
+		{445C4888-6DA3-411B-8284-7CFB0E5768A9}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{445C4888-6DA3-411B-8284-7CFB0E5768A9}.Debug|x86.Build.0 = Debug|Any CPU
+		{445C4888-6DA3-411B-8284-7CFB0E5768A9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{445C4888-6DA3-411B-8284-7CFB0E5768A9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{445C4888-6DA3-411B-8284-7CFB0E5768A9}.Release|x64.ActiveCfg = Release|Any CPU
+		{445C4888-6DA3-411B-8284-7CFB0E5768A9}.Release|x64.Build.0 = Release|Any CPU
+		{445C4888-6DA3-411B-8284-7CFB0E5768A9}.Release|x86.ActiveCfg = Release|Any CPU
+		{445C4888-6DA3-411B-8284-7CFB0E5768A9}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -125,6 +140,7 @@ Global
 		{7669BB99-A118-436B-8C58-1D8E8989A775} = {290A2775-7CA0-4F81-9DDC-32E28C3A7565}
 		{3BFAB570-11C6-4C85-97A6-2740219F5B48} = {17C8775C-0621-438E-81D4-3B9E98A616BD}
 		{D44EC05A-1374-4053-A9A2-41E8EA1CE0D2} = {17C8775C-0621-438E-81D4-3B9E98A616BD}
+		{445C4888-6DA3-411B-8284-7CFB0E5768A9} = {290A2775-7CA0-4F81-9DDC-32E28C3A7565}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {268F5761-DAC2-4ECA-9AEC-59663B84854C}

--- a/src/Serilog/Capturing/TrimConfiguration.cs
+++ b/src/Serilog/Capturing/TrimConfiguration.cs
@@ -4,11 +4,11 @@ namespace Serilog.Capturing;
 static class TrimConfiguration
 {
     /// <summary>
-    /// True if compiler-generated types are treated specially by Serilog during logging. The main example
+    /// True if structure-value types are treated specially by Serilog during logging. The main example
     /// of this would be anonymous types, which have a special compiler-generated form. If this switch is
     /// disabled, Serilog will not be able to destructure anonymous types, but will still be able to log
     /// them as scalar values.
     /// </summary>
-    public static bool IsCompilerGeneratedCodeSupported { get; } =
-        !AppContext.TryGetSwitch("Serilog.Capturing.IsCompilerGeneratedCodeSupported", out var isEnabled) || isEnabled;
+    public static bool IsStructureValueSupported { get; } =
+        !AppContext.TryGetSwitch("Serilog.Capturing.IsStructureValueSupported", out var isEnabled) || isEnabled;
 }

--- a/src/Serilog/Events/LogEvent.cs
+++ b/src/Serilog/Events/LogEvent.cs
@@ -204,8 +204,20 @@ public class LogEvent
 #endif
     }
 
-    internal void AddPropertyIfAbsent(ILogEventPropertyFactory factory, string name, object? value, bool destructureObjects = false)
+    /// <summary>
+    /// Add a property to the event if not already present.
+    /// </summary>
+    /// <param name="factory">Factory for creating the property to add to the event.</param>
+    /// <param name="name">The name of the property.</param>
+    /// <param name="value">The value of the property.</param>
+    /// <param name="destructureObjects">If <see langword="true"/>, and the value is a non-primitive, non-array type,
+    /// then the value will be converted to a structure; otherwise, unknown types will
+    /// be converted to scalars, which are generally stored as strings.</param>
+    /// <exception cref="ArgumentNullException">When <paramref name="factory"/> is <code>null</code></exception>
+    public void AddPropertyIfAbsent(ILogEventPropertyFactory factory, string name, object? value, bool destructureObjects = false)
     {
+        Guard.AgainstNull(factory);
+
         if (!_properties.ContainsKey(name))
         {
             _properties.Add(

--- a/src/Serilog/ILLink.Substitutions.xml
+++ b/src/Serilog/ILLink.Substitutions.xml
@@ -1,8 +1,8 @@
 <linker>
   <assembly fullname="Serilog">
     <type fullname="Serilog.Capturing.TrimConfiguration" >
-      <method signature="System.Boolean get_IsCompilerGeneratedCodeSupported()" body="stub" value="false"
-              feature="Serilog.Capturing.IsCompilerGeneratedCodeSupported" featurevalue="false" />
+      <method signature="System.Boolean get_IsStructureValueSupported()" body="stub" value="false"
+              feature="Serilog.Capturing.IsStructureValueSupported" featurevalue="false" />
     </type>
   </assembly>
 </linker>

--- a/src/Serilog/Serilog.csproj
+++ b/src/Serilog/Serilog.csproj
@@ -14,7 +14,7 @@
     <PackageIcon>icon.png</PackageIcon>
     <PackageProjectUrl>https://serilog.net/</PackageProjectUrl>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
-    <IsTrimmable>true</IsTrimmable>
+    <IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net7.0'))">true</IsAotCompatible>
     <NoWarn>$(NoWarn);CS1437;CS1570</NoWarn>
     <PolySharpIncludeRuntimeSupportedAttributes>true</PolySharpIncludeRuntimeSupportedAttributes>
     <PackageReadmeFile>README.md</PackageReadmeFile>
@@ -48,6 +48,7 @@
   <ItemGroup>
     <None Include="../../assets/icon.png" Pack="true" Visible="false" PackagePath="/" />
     <None Include="../../README.md" Pack="true" Visible="false" PackagePath="/" />
+    <None Include="Serilog.props" Pack="true" Visible="false" PackagePath="/build" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
     <PackageReference Include="PolySharp" Version="1.15.0" PrivateAssets="All" />
     <EmbeddedResource Include="ILLink.Substitutions.xml">

--- a/src/Serilog/Serilog.csproj
+++ b/src/Serilog/Serilog.csproj
@@ -49,7 +49,7 @@
     <None Include="../../assets/icon.png" Pack="true" Visible="false" PackagePath="/" />
     <None Include="../../README.md" Pack="true" Visible="false" PackagePath="/" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-    <PackageReference Include="PolySharp" Version="1.14.1" PrivateAssets="All" />
+    <PackageReference Include="PolySharp" Version="1.15.0" PrivateAssets="All" />
     <EmbeddedResource Include="ILLink.Substitutions.xml">
       <LogicalName>ILLink.Substitutions.xml</LogicalName>
     </EmbeddedResource>

--- a/src/Serilog/Serilog.csproj
+++ b/src/Serilog/Serilog.csproj
@@ -48,7 +48,7 @@
   <ItemGroup>
     <None Include="../../assets/icon.png" Pack="true" Visible="false" PackagePath="/" />
     <None Include="../../README.md" Pack="true" Visible="false" PackagePath="/" />
-    <None Include="Serilog.props" Pack="true" Visible="false" PackagePath="/build" />
+    <None Include="Serilog.targets" Pack="true" Visible="false" PackagePath="/build" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
     <PackageReference Include="PolySharp" Version="1.15.0" PrivateAssets="All" />
     <EmbeddedResource Include="ILLink.Substitutions.xml">

--- a/src/Serilog/Serilog.props
+++ b/src/Serilog/Serilog.props
@@ -1,0 +1,7 @@
+<Project>
+    <ItemGroup>
+        <RuntimeHostConfigurationOption
+        Include="Serilog.Capturing.IsStructureValueSupported"
+        Value="false" Trim="true" />
+    </ItemGroup>
+</Project>

--- a/src/Serilog/Serilog.targets
+++ b/src/Serilog/Serilog.targets
@@ -1,6 +1,7 @@
 <Project>
     <ItemGroup>
         <RuntimeHostConfigurationOption
+        Condition="'$(PublishTrimmed)' == 'true'"
         Include="Serilog.Capturing.IsStructureValueSupported"
         Value="false" Trim="true" />
     </ItemGroup>

--- a/src/Serilog/Settings/KeyValuePairs/SettingValueConversions.cs
+++ b/src/Serilog/Settings/KeyValuePairs/SettingValueConversions.cs
@@ -27,8 +27,10 @@ class SettingValueConversions
         { typeof(TimeSpan), s => TimeSpan.Parse(s) },
         { typeof(Type),
             // Suppress this trimming warning. We'll annotate all the users of this dictionary instead
+            [UnconditionalSuppressMessage("Trimming", "IL2057",
+                Justification = "All users of this dictionary should be annotated with RequiresUnreferencedCode/RequiresDynamicCode")]
 #pragma warning disable IL2057
-            s => Type.GetType(s, throwOnError: true)!
+            (s) => Type.GetType(s, throwOnError: true)!
 #pragma warning restore IL2057
         },
     };

--- a/test/AotTestApp/AotTestApp.csproj
+++ b/test/AotTestApp/AotTestApp.csproj
@@ -6,14 +6,16 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <PublishAot>true</PublishAot>
+    <UseCurrentRuntimeIdentifier>true</UseCurrentRuntimeIdentifier>
   </PropertyGroup>
+
+  <Import Project="..\..\src\Serilog\Serilog.props" />
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Serilog\Serilog.csproj" />
     <TrimmerRootAssembly Include="Serilog" />
-    <RuntimeHostConfigurationOption
-      Include="Serilog.IsCompilerGeneratedCodeSupported"
-      Value="false" Trim="true" />
   </ItemGroup>
+
+  <Target Name="PublishOnBuild" AfterTargets="Build" DependsOnTargets="Publish" />
 
 </Project>

--- a/test/AotTestApp/AotTestApp.csproj
+++ b/test/AotTestApp/AotTestApp.csproj
@@ -9,13 +9,13 @@
     <UseCurrentRuntimeIdentifier>true</UseCurrentRuntimeIdentifier>
   </PropertyGroup>
 
-  <Import Project="..\..\src\Serilog\Serilog.props" />
-
   <ItemGroup>
     <ProjectReference Include="..\..\src\Serilog\Serilog.csproj" />
     <TrimmerRootAssembly Include="Serilog" />
   </ItemGroup>
 
   <Target Name="PublishOnBuild" AfterTargets="Build" DependsOnTargets="Publish" />
+
+  <Import Project="..\..\src\Serilog\Serilog.targets" />
 
 </Project>

--- a/test/Serilog.ApprovalTests/Serilog.ApprovalTests.csproj
+++ b/test/Serilog.ApprovalTests/Serilog.ApprovalTests.csproj
@@ -18,4 +18,6 @@
     <ProjectReference Include="..\..\src\Serilog\Serilog.csproj" />
   </ItemGroup>
 
+  <Import Project="..\..\src\Serilog\Serilog.targets" />
+
 </Project>

--- a/test/Serilog.ApprovalTests/Serilog.approved.txt
+++ b/test/Serilog.ApprovalTests/Serilog.approved.txt
@@ -105,8 +105,14 @@ namespace Serilog.Context
     public static class LogContext
     {
         public static Serilog.Core.ILogEventEnricher Clone() { }
+        [System.Runtime.CompilerServices.OverloadResolutionPriority(3)]
         public static System.IDisposable Push(Serilog.Core.ILogEventEnricher enricher) { }
+        [System.Runtime.CompilerServices.OverloadResolutionPriority(0)]
         public static System.IDisposable Push(params Serilog.Core.ILogEventEnricher[] enrichers) { }
+        [System.Runtime.CompilerServices.OverloadResolutionPriority(1)]
+        public static System.IDisposable Push([System.Runtime.CompilerServices.ParamCollection] System.Collections.Generic.IEnumerable<Serilog.Core.ILogEventEnricher> enrichers) { }
+        [System.Runtime.CompilerServices.OverloadResolutionPriority(2)]
+        public static System.IDisposable Push([System.Runtime.CompilerServices.ParamCollection] [System.Runtime.CompilerServices.ScopedRef] System.ReadOnlySpan<Serilog.Core.ILogEventEnricher> enrichers) { }
         public static System.IDisposable PushProperty(string name, object? value, bool destructureObjects = false) { }
         public static void Reset() { }
         public static System.IDisposable Suspend() { }

--- a/test/Serilog.ApprovalTests/Serilog.approved.txt
+++ b/test/Serilog.ApprovalTests/Serilog.approved.txt
@@ -411,6 +411,7 @@ namespace Serilog.Events
         public System.Diagnostics.ActivityTraceId? TraceId { get; }
         public void AddOrUpdateProperty(Serilog.Events.LogEventProperty property) { }
         public void AddPropertyIfAbsent(Serilog.Events.LogEventProperty property) { }
+        public void AddPropertyIfAbsent(Serilog.Core.ILogEventPropertyFactory factory, string name, object? value, bool destructureObjects = false) { }
         public void RemovePropertyIfPresent(string propertyName) { }
         public string RenderMessage(System.IFormatProvider? formatProvider = null) { }
         public void RenderMessage(System.IO.TextWriter output, System.IFormatProvider? formatProvider = null) { }

--- a/test/Serilog.PerformanceTests/Serilog.PerformanceTests.csproj
+++ b/test/Serilog.PerformanceTests/Serilog.PerformanceTests.csproj
@@ -19,4 +19,6 @@
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="BenchmarkDotNet" Version="0.14.0" />
   </ItemGroup>
+
+  <Import Project="..\..\src\Serilog\Serilog.targets" />
 </Project>

--- a/test/Serilog.Tests/Configuration/LoggerConfigurationTests.cs
+++ b/test/Serilog.Tests/Configuration/LoggerConfigurationTests.cs
@@ -254,6 +254,24 @@ public class LoggerConfigurationTests
     }
 
     [Fact]
+    public void EnrichersWithPropertyFactoryExecuteInConfigurationOrder()
+    {
+        var propertyName = Some.String();
+        var propertyValue = Some.String();
+        var enrichedPropertySeen = false;
+
+        var logger = new LoggerConfiguration()
+            .WriteTo.Sink(new StringSink())
+            .Enrich.With(new DelegatingEnricher((e, factory) => e.AddPropertyIfAbsent(factory, propertyName, propertyValue)))
+            .Enrich.With(new DelegatingEnricher((e, _) => enrichedPropertySeen = e.Properties.ContainsKey(propertyName)))
+            .CreateLogger();
+
+        logger.Write(Some.InformationEvent());
+
+        Assert.True(enrichedPropertySeen);
+    }
+
+    [Fact]
     public void MaximumDestructuringDepthDefaultIsEffective()
     {
         var x = new

--- a/test/Serilog.Tests/Context/LogContextTests.cs
+++ b/test/Serilog.Tests/Context/LogContextTests.cs
@@ -3,6 +3,63 @@ namespace Serilog.Tests.Context;
 public class LogContextTests
 {
     [Fact]
+    public void PushedSpanPropertiesAreAvailableToLoggers()
+    {
+        LogEvent? lastEvent = null;
+
+        var log = new LoggerConfiguration()
+            .Enrich.FromLogContext()
+            .WriteTo.Sink(new DelegatingSink(e => lastEvent = e))
+            .CreateLogger();
+        ReadOnlySpan<ILogEventEnricher> enrichers = [new PropertyEnricher("A", 1), new PropertyEnricher("B", 2)];
+        using (LogContext.Push(enrichers))
+        {
+            log.Write(Some.InformationEvent());
+            Assert.NotNull(lastEvent);
+            Assert.Equal(1, lastEvent!.Properties["A"].LiteralValue());
+            Assert.Equal(2, lastEvent.Properties["B"].LiteralValue());
+        }
+    }
+
+    [Fact]
+    public void PushedArrayPropertiesAreAvailableToLoggers()
+    {
+        LogEvent? lastEvent = null;
+
+        var log = new LoggerConfiguration()
+            .Enrich.FromLogContext()
+            .WriteTo.Sink(new DelegatingSink(e => lastEvent = e))
+            .CreateLogger();
+        PropertyEnricher[] enrichers = [new("A", 1), new("B", 2)];
+        using (LogContext.Push(enrichers))
+        {
+            log.Write(Some.InformationEvent());
+            Assert.NotNull(lastEvent);
+            Assert.Equal(1, lastEvent!.Properties["A"].LiteralValue());
+            Assert.Equal(2, lastEvent.Properties["B"].LiteralValue());
+        }
+    }
+
+    [Fact]
+    public void PushedEnumerablePropertiesAreAvailableToLoggers()
+    {
+        LogEvent? lastEvent = null;
+
+        var log = new LoggerConfiguration()
+            .Enrich.FromLogContext()
+            .WriteTo.Sink(new DelegatingSink(e => lastEvent = e))
+            .CreateLogger();
+        IEnumerable<PropertyEnricher> enrichers = [new("A", 1), new("B", 2)];
+        using (LogContext.Push(enrichers))
+        {
+            log.Write(Some.InformationEvent());
+            Assert.NotNull(lastEvent);
+            Assert.Equal(1, lastEvent!.Properties["A"].LiteralValue());
+            Assert.Equal(2, lastEvent.Properties["B"].LiteralValue());
+        }
+    }
+
+    [Fact]
     public void PushedPropertiesAreAvailableToLoggers()
     {
         LogEvent? lastEvent = null;

--- a/test/Serilog.Tests/Serilog.Tests.csproj
+++ b/test/Serilog.Tests/Serilog.Tests.csproj
@@ -62,4 +62,6 @@
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net9.0' ">
     <DefineConstants>$(DefineConstants);FEATURE_DEFAULT_INTERFACE;FEATURE_SPAN;FEATURE_DATE_AND_TIME_ONLY;FEATURE_ITUPLE;FEATURE_ASYNCDISPOSABLE</DefineConstants>
   </PropertyGroup>
+
+  <Import Project="..\..\src\Serilog\Serilog.targets" />
 </Project>


### PR DESCRIPTION
 * #2149 - `LogEvent.AddPropertyIfAbsent(ILogEventPropertyFactory, ...)` overload that helps avoid allocations (@vanni-giachin)
 * #2158 - use HTTPS in all README.md images and links (@TimHess)
 * #2163 - `LogContext.Push()` overloads accepting `IEnumerable<ILogEventEnricher>` and `ReadOnlySpan<ILogEventEnricher>` (@SimonCropp)
 * #2175, #2178, #2179 - fix AOT compatibility (@agocke)