### PR TITLE
Reference targets file from tests

### DIFF
--- a/test/Serilog.ApprovalTests/Serilog.ApprovalTests.csproj
+++ b/test/Serilog.ApprovalTests/Serilog.ApprovalTests.csproj
@@ -18,4 +18,6 @@
     <ProjectReference Include="..\..\src\Serilog\Serilog.csproj" />
   </ItemGroup>
 
+  <Import Project="..\..\src\Serilog\Serilog.targets" />
+
 </Project>

--- a/test/Serilog.PerformanceTests/Serilog.PerformanceTests.csproj
+++ b/test/Serilog.PerformanceTests/Serilog.PerformanceTests.csproj
@@ -19,4 +19,6 @@
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="BenchmarkDotNet" Version="0.14.0" />
   </ItemGroup>
+
+  <Import Project="..\..\src\Serilog\Serilog.targets" />
 </Project>

--- a/test/Serilog.Tests/Serilog.Tests.csproj
+++ b/test/Serilog.Tests/Serilog.Tests.csproj
@@ -62,4 +62,6 @@
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net9.0' ">
     <DefineConstants>$(DefineConstants);FEATURE_DEFAULT_INTERFACE;FEATURE_SPAN;FEATURE_DATE_AND_TIME_ONLY;FEATURE_ITUPLE;FEATURE_ASYNCDISPOSABLE</DefineConstants>
   </PropertyGroup>
+
+  <Import Project="..\..\src\Serilog\Serilog.targets" />
 </Project>


### PR DESCRIPTION
Add the targets file import to the other test projects. This should increase the test coverage to make it look closer to what a NuGet package reference would experience.