### PR TITLE
remove SourceLink

### DIFF
--- a/src/Serilog/Serilog.csproj
+++ b/src/Serilog/Serilog.csproj
@@ -49,7 +49,6 @@
     <None Include="../../assets/icon.png" Pack="true" Visible="false" PackagePath="/" />
     <None Include="../../README.md" Pack="true" Visible="false" PackagePath="/" />
     <None Include="Serilog.targets" Pack="true" Visible="false" PackagePath="/build" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
     <PackageReference Include="PolySharp" Version="1.15.0" PrivateAssets="All" />
     <EmbeddedResource Include="ILLink.Substitutions.xml">
       <LogicalName>ILLink.Substitutions.xml</LogicalName>


### PR DESCRIPTION
https://github.com/dotnet/sourcelink/releases

> Source Link is now included in .NET SDK 8 and enabled by default. Projects that migrate to .NET SDK 8 do not need to reference Source Link packages explicitly via PackageReference anymore.