### PR TITLE
Handle Exception.ToString failures in text formatter

### DIFF
--- a/src/Serilog/Formatting/Display/MessageTemplateTextFormatter.cs
+++ b/src/Serilog/Formatting/Display/MessageTemplateTextFormatter.cs
@@ -85,7 +85,16 @@ public class MessageTemplateTextFormatter : ITextFormatter
             }
             else if (pt.PropertyName == OutputProperties.ExceptionPropertyName)
             {
-                var exception = logEvent.Exception == null ? "" : logEvent.Exception + Environment.NewLine;
+                string exception;
+                try
+                {
+                    exception = logEvent.Exception == null ? "" : logEvent.Exception + Environment.NewLine;
+                }
+                catch (Exception e)
+                {
+                    exception = $"[Exception.ToString() failed: {e.Message}] Original exception type: {logEvent.Exception?.GetType().FullName}, message: {logEvent.Exception?.Message}{Environment.NewLine}";
+                }
+
                 Padding.Apply(output, exception, pt.Alignment);
             }
             else


### PR DESCRIPTION
closes #2165.

Wraps Exception.ToString in a try-catch block to prevent logging failures if the method throws. If an error occurs, a fallback message with details is written instead.