### PR TITLE
Remove char[] allocation

### DIFF
--- a/src/Serilog/Parsing/MessageTemplateParser.cs
+++ b/src/Serilog/Parsing/MessageTemplateParser.cs
@@ -258,6 +258,7 @@ public class MessageTemplateParser : IMessageTemplateParser
     }
 
     static bool IsValidInFormat(char c) => c != '}';
+    static readonly char[] CurlyBraceChars = ['{', '}'];
 
     static TextToken ParseTextToken(int startAt, string messageTemplate, out int next)
     {
@@ -267,7 +268,7 @@ public class MessageTemplateParser : IMessageTemplateParser
         // Most of the time we won't hit escapes, so we can get away with just a single Substring() allocation at
         // the end.
 
-        var i = messageTemplate.IndexOfAny(['{', '}'], startAt);
+        var i = messageTemplate.IndexOfAny(CurlyBraceChars, startAt);
         if (i == -1)
         {
             // No more interesting characters in the template, everything left is text.

--- a/test/Serilog.PerformanceTests/Serilog.PerformanceTests.csproj
+++ b/test/Serilog.PerformanceTests/Serilog.PerformanceTests.csproj
@@ -17,7 +17,8 @@
     <PackageReference Include="PolySharp" Version="1.14.1" PrivateAssets="All" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" PrivateAssets="all" />
     <PackageReference Include="xunit" Version="2.9.2" />
-    <PackageReference Include="BenchmarkDotNet" Version="0.14.0" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.15.2" />
+    <PackageReference Include="Microsoft.VisualStudio.DiagnosticsHub.BenchmarkDotNetDiagnosers" Version="18.0.36421.1" />
   </ItemGroup>
 
   <Import Project="..\..\src\Serilog\Serilog.targets" />


### PR DESCRIPTION
This PR contributes a performance fix to remove some char[] allocations that are occurring in MessageTemplateParser. This trims ~10% of Gen0 memory usage in the MessageTemplateParsingBenchmark.DefaultConsoleOutputTemplate benchmark.

This fix was found by our new Copilot Profiler Agent as it was profiling and looking for different optimizations in the available benchmarks.

# Before - 1776 Bytes
<img width="804" height="176" alt="BeforeViaTests" src="https://github.com/user-attachments/assets/59a04ab9-d5aa-4cef-bc3f-f4d5c44f9628" />
<img width="1277" height="323" alt="BeforeAllocations" src="https://github.com/user-attachments/assets/33966e96-e195-4c43-85e1-c9a6c547d1d9" />
Note: the allocation trace was done having the Parse run 1000 times in the benchmark and only running the benchmark workload 5 times to keep the allocations consistent between runs.

# After - 1616 Bytes
<img width="587" height="134" alt="AfterViaTests" src="https://github.com/user-attachments/assets/ca6c3ffe-ce34-483f-8ebd-2cc885bcb8c6" />
<img width="621" height="315" alt="AfterAllocation" src="https://github.com/user-attachments/assets/4230576d-4542-4d9b-90f7-017990352b15" />

