### PR TITLE
Remove backpressure from XMLDoc

### DIFF
--- a/src/Serilog/Configuration/BatchingOptions.cs
+++ b/src/Serilog/Configuration/BatchingOptions.cs
@@ -42,13 +42,13 @@ public class BatchingOptions
     /// <summary>
     /// Maximum number of events to hold in the sink's internal queue, or <c>null</c>
     /// for an unbounded queue. The default is <c>100000</c>. When the limit is exceeded,
-    /// backpressure is applied.
+    /// events are discarded.
     /// </summary>
     public int? QueueLimit { get; set; } = 100000;
 
     /// <summary>
     /// The maximum time that the sink will keep retrying failed batches for. The default is ten minutes. Lower
-    /// this value to reduce buffering and backpressure in high-load scenarios.
+    /// this value to reduce buffering in high-load scenarios.
     /// </summary>
     public TimeSpan RetryTimeLimit { get; set; } = TimeSpan.FromMinutes(10);
 }

--- a/src/Serilog/Configuration/LoggerSinkConfiguration.cs
+++ b/src/Serilog/Configuration/LoggerSinkConfiguration.cs
@@ -107,7 +107,7 @@ public class LoggerSinkConfiguration
     /// written to the sink in batches.
     /// </summary>
     /// <param name="batchedLogEventSink">The batched sink to receive events.</param>
-    /// <param name="batchingOptions">Options that control batch sizes, buffering time, and backpressure.</param>
+    /// <param name="batchingOptions">Options that control batch sizes and buffering time.</param>
     /// <param name="restrictedToMinimumLevel">The minimum level for
     /// events passed through the sink. Ignored when <paramref name="levelSwitch"/> is specified.</param>
     /// <param name="levelSwitch">A switch allowing the pass-through minimum level
@@ -131,7 +131,7 @@ public class LoggerSinkConfiguration
     /// </summary>
     /// <typeparam name="TSink">The type of a batched sink to receive events. The sink must provide a public,
     /// parameterless constructor.</param>
-    /// <param name="batchingOptions">Options that control batch sizes, buffering time, and backpressure.</param>
+    /// <param name="batchingOptions">Options that control batch sizes and buffering time.</param>
     /// <param name="restrictedToMinimumLevel">The minimum level for
     /// events passed through the sink. Ignored when <paramref name="levelSwitch"/> is specified.</param>
     /// <param name="levelSwitch">A switch allowing the pass-through minimum level


### PR DESCRIPTION
Because backpressure is not applied, instead events are discarded when the queue is full.

The xmldoc for `BatchingOptions.QueueLimit` says that backpressure is applied when the limit is exceeded.

However, in `BatchingSink.cs` we see that no backpressure is applied

```
_queue.Writer.TryWrite(logEvent);
```

Instead the event is discarded (which is good).

To me it looks like a mistake in the XMLDoc, and this PR adjusts it.