### PR TITLE
Add selective destructuring policy for logging specific properties

### DIFF
--- a/src/Serilog/Configuration/LoggerDestructuringConfiguration.cs
+++ b/src/Serilog/Configuration/LoggerDestructuringConfiguration.cs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace Serilog.Configuration;
 
 /// <summary>
@@ -202,5 +204,21 @@ public class LoggerDestructuringConfiguration
 
         _setMaximumCollectionCount(maximumCollectionCount);
         return _loggerConfiguration;
+    }
+
+    /// <summary>
+    /// When destructuring objects of the specified type, only include the selected properties
+    /// in the log output. This is useful for logging only relevant parts of complex objects.
+    /// </summary>
+    /// <typeparam name="T">Type of objects to apply selective destructuring to.</typeparam>
+    /// <param name="propertyNames">Names of the properties to include when destructuring.</param>
+    /// <returns>Configuration object allowing method chaining.</returns>
+    /// <exception cref="ArgumentNullException">When <paramref name="propertyNames"/> is <code>null</code></exception>
+    public LoggerConfiguration BySelecting<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] T>(params string[] propertyNames)
+    {
+        Guard.AgainstNull(propertyNames);
+
+        var policy = new SelectiveDestructuringPolicy<T>(propertyNames);
+        return With(policy);
     }
 }

--- a/src/Serilog/Policies/SelectiveDestructuringPolicy.cs
+++ b/src/Serilog/Policies/SelectiveDestructuringPolicy.cs
@@ -1,0 +1,81 @@
+// Copyright 2013-2015 Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
+
+namespace Serilog.Policies;
+
+/// <summary>
+/// A destructuring policy that only includes specified properties when destructuring objects of type <typeparamref name="T"/>.
+/// </summary>
+/// <typeparam name="T">The type of objects this policy applies to.</typeparam>
+public class SelectiveDestructuringPolicy<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] T> : IDestructuringPolicy
+{
+  readonly HashSet<string> _selectedProperties;
+  [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)]
+  readonly Type _targetType;
+
+  /// <summary>
+  /// Creates a new selective destructuring policy.
+  /// </summary>
+  /// <param name="propertyNames">The names of the properties to include when destructuring.</param>
+  public SelectiveDestructuringPolicy(params string[] propertyNames)
+  {
+    _targetType = typeof(T);
+    _selectedProperties = new HashSet<string>(propertyNames ?? Array.Empty<string>(), StringComparer.Ordinal);
+  }
+
+  /// <summary>
+  /// Try to destructure the provided object using selective property inclusion.
+  /// </summary>
+  /// <param name="value">The value to destructure.</param>
+  /// <param name="propertyValueFactory">Factory to use for creating property values.</param>
+  /// <param name="result">The destructured value if successful.</param>
+  /// <returns>True if the value could be destructured by this policy, otherwise false.</returns>
+  public bool TryDestructure(object value, ILogEventPropertyValueFactory propertyValueFactory, [NotNullWhen(true)] out LogEventPropertyValue? result)
+  {
+    Guard.AgainstNull(value);
+
+    if (value.GetType() != _targetType)
+    {
+      result = null;
+      return false;
+    }
+
+    var properties = new List<LogEventProperty>();
+    var typeInfo = _targetType.GetTypeInfo();
+
+    foreach (var propertyName in _selectedProperties)
+    {
+      var property = typeInfo.GetProperty(propertyName, BindingFlags.Public | BindingFlags.Instance);
+      if (property != null && property.CanRead)
+      {
+        try
+        {
+          var propertyValue = property.GetValue(value);
+          var logEventPropertyValue = propertyValueFactory.CreatePropertyValue(propertyValue, destructureObjects: true);
+          properties.Add(new LogEventProperty(property.Name, logEventPropertyValue));
+        }
+        catch (TargetInvocationException)
+        {
+          // Skip properties that throw exceptions when accessed
+        }
+      }
+    }
+
+    result = new StructureValue(properties);
+    return true;
+  }
+}

--- a/test/Serilog.Tests/Policies/SelectiveDestructuringPolicyTests.cs
+++ b/test/Serilog.Tests/Policies/SelectiveDestructuringPolicyTests.cs
@@ -1,0 +1,189 @@
+using Serilog.Policies;
+
+namespace Serilog.Tests.Policies;
+
+public class SelectiveDestructuringPolicyTests
+{
+  class ComplexObject
+  {
+    public string? Name { get; set; }
+    public int Id { get; set; }
+    public string? Status { get; set; }
+    public string? Description { get; set; }
+    public DateTime CreatedAt { get; set; }
+    public string? InternalData { get; set; }
+  }
+
+  class NonMatchingType
+  {
+    public string? Value { get; set; }
+  }
+
+  [Fact]
+  public void SelectiveDestructuringPolicyOnlyDestructuresSpecifiedType()
+  {
+    var policy = new SelectiveDestructuringPolicy<ComplexObject>("Name", "Id");
+
+    var complexObject = new ComplexObject { Name = "Test", Id = 1, Status = "Active" };
+    var nonMatchingObject = new NonMatchingType { Value = "test" };
+
+    // Test that our policy returns true for ComplexObject
+    var factory = new PropertyValueConverter(10, 1000, 1000, [], [], [], false);
+    LogEventPropertyValue? result;
+    var handled = policy.TryDestructure(complexObject, factory, out result);
+    Assert.True(handled);
+    Assert.NotNull(result);
+
+    // Test that our policy returns false for NonMatchingType
+    handled = policy.TryDestructure(nonMatchingObject, factory, out result);
+    Assert.False(handled);
+    Assert.Null(result);
+  }
+
+  [Fact]
+  public void SelectiveDestructuringPolicyOnlyIncludesSelectedProperties()
+  {
+    var policy = new SelectiveDestructuringPolicy<ComplexObject>("Name", "Id", "Status");
+    var factory = new PropertyValueConverter(10, 1000, 1000, [], [], [policy], false);
+
+    var testObject = new ComplexObject
+    {
+      Name = "TestObject",
+      Id = 123,
+      Status = "Active",
+      Description = "This should not be included",
+      CreatedAt = new DateTime(2024, 1, 1),
+      InternalData = "Secret data"
+    };
+
+    var result = factory.CreatePropertyValue(testObject, destructureObjects: true);
+
+    Assert.IsType<StructureValue>(result);
+    var structure = (StructureValue)result;
+
+    // Should only contain the selected properties
+    Assert.Equal(3, structure.Properties.Count);
+
+    var propertyNames = structure.Properties.Select(p => p.Name).ToHashSet();
+    Assert.Contains("Name", propertyNames);
+    Assert.Contains("Id", propertyNames);
+    Assert.Contains("Status", propertyNames);
+    Assert.DoesNotContain("Description", propertyNames);
+    Assert.DoesNotContain("CreatedAt", propertyNames);
+    Assert.DoesNotContain("InternalData", propertyNames);
+
+    // Verify property values
+    var nameProperty = structure.Properties.First(p => p.Name == "Name");
+    Assert.Equal("TestObject", ((ScalarValue)nameProperty.Value).Value);
+
+    var idProperty = structure.Properties.First(p => p.Name == "Id");
+    Assert.Equal(123, ((ScalarValue)idProperty.Value).Value);
+
+    var statusProperty = structure.Properties.First(p => p.Name == "Status");
+    Assert.Equal("Active", ((ScalarValue)statusProperty.Value).Value);
+  }
+
+  [Fact]
+  public void SelectiveDestructuringPolicyHandlesNullPropertyValues()
+  {
+    var policy = new SelectiveDestructuringPolicy<ComplexObject>("Name", "Status");
+    var factory = new PropertyValueConverter(10, 1000, 1000, [], [], [policy], false);
+
+    var testObject = new ComplexObject
+    {
+      Name = null,
+      Id = 456,
+      Status = "Inactive"
+    };
+
+    var result = factory.CreatePropertyValue(testObject, destructureObjects: true);
+
+    Assert.IsType<StructureValue>(result);
+    var structure = (StructureValue)result;
+
+    Assert.Equal(2, structure.Properties.Count);
+
+    var nameProperty = structure.Properties.First(p => p.Name == "Name");
+    Assert.IsType<ScalarValue>(nameProperty.Value);
+    Assert.Null(((ScalarValue)nameProperty.Value).Value);
+
+    var statusProperty = structure.Properties.First(p => p.Name == "Status");
+    Assert.Equal("Inactive", ((ScalarValue)statusProperty.Value).Value);
+  }
+
+  [Fact]
+  public void SelectiveDestructuringPolicyIgnoresNonExistentProperties()
+  {
+    var policy = new SelectiveDestructuringPolicy<ComplexObject>("Name", "NonExistentProperty");
+    var factory = new PropertyValueConverter(10, 1000, 1000, [], [], [policy], false);
+
+    var testObject = new ComplexObject
+    {
+      Name = "Test",
+      Id = 789
+    };
+
+    var result = factory.CreatePropertyValue(testObject, destructureObjects: true);
+
+    Assert.IsType<StructureValue>(result);
+    var structure = (StructureValue)result;
+
+    // Should only contain the existing property
+    Assert.Single(structure.Properties);
+    Assert.Equal("Name", structure.Properties.First().Name);
+  }
+
+  [Fact]
+  public void SelectiveDestructuringPolicyWorksWithLoggerConfiguration()
+  {
+    var sink = new CollectingSink();
+    var logger = new LoggerConfiguration()
+      .Destructure.BySelecting<ComplexObject>("Name", "Id")
+      .WriteTo.Sink(sink)
+      .CreateLogger();
+
+    var testObject = new ComplexObject
+    {
+      Name = "ConfigTest",
+      Id = 999,
+      Status = "Active",
+      Description = "Should not appear"
+    };
+
+    logger.Information("Test {@Object}", testObject);
+
+    var logEvent = sink.Events.Single();
+    var objectProperty = logEvent.Properties["Object"];
+
+    Assert.IsType<StructureValue>(objectProperty);
+    var structure = (StructureValue)objectProperty;
+
+    var propertyNames = structure.Properties.Select(p => p.Name).ToHashSet();
+    Assert.Equal(2, propertyNames.Count);
+    Assert.Contains("Name", propertyNames);
+    Assert.Contains("Id", propertyNames);
+    Assert.DoesNotContain("Status", propertyNames);
+    Assert.DoesNotContain("Description", propertyNames);
+  }
+
+  [Fact]
+  public void SelectiveDestructuringPolicyHandlesEmptyPropertyList()
+  {
+    var policy = new SelectiveDestructuringPolicy<ComplexObject>();
+    var factory = new PropertyValueConverter(10, 1000, 1000, [], [], [policy], false);
+
+    var testObject = new ComplexObject
+    {
+      Name = "Test",
+      Id = 123
+    };
+
+    var result = factory.CreatePropertyValue(testObject, destructureObjects: true);
+
+    Assert.IsType<StructureValue>(result);
+    var structure = (StructureValue)result;
+
+    // Should return empty structure when no properties are selected
+    Assert.Empty(structure.Properties);
+  }
+}


### PR DESCRIPTION
## Summary

This PR implements issue #2192 by adding a new `SelectiveDestructuringPolicy<T>` class that allows users to specify which properties should be included when destructuring objects in Serilog logs.

## Problem

When logging complex objects, Serilog currently destructures the entire object, which can:
- Make log messages verbose
- Include unnecessary/sensitive details  
- Impact performance with large objects

## Solution

Introduced a new destructuring policy that allows selective property inclusion:

```csharp
Log.Logger = new LoggerConfiguration()
    .Destructure.BySelecting<MyComplicatedObject>("Name", "Id", "Status")
    .WriteTo.Console()
    .CreateLogger();
```

## Implementation Details

- **`SelectiveDestructuringPolicy<T>`**: A generic destructuring policy that accepts property names to include
- **`BySelecting<T>` extension method**: Added to `LoggerDestructuringConfiguration` for easy configuration
- **Trimming/AOT support**: Includes proper `DynamicallyAccessedMembers` annotations for .NET 8+ trimming compatibility
- **Comprehensive tests**: Added unit tests covering various scenarios

## Test Coverage

The implementation includes tests for:
- Type-specific destructuring (only applies to specified type)
- Selective property inclusion
- Null property value handling
- Non-existent property handling
- Integration with LoggerConfiguration
- Edge cases (empty property list)

## Breaking Changes

None - this is purely additive functionality.

## Example Usage

```csharp
public class User
{
    public string Name { get; set; }
    public int Id { get; set; }
    public string Email { get; set; }
    public string PasswordHash { get; set; }
}

// Only log Name and Id, excluding sensitive data
logger
    .Destructure.BySelecting<User>("Name", "Id")
    .Information("User logged in {@User}", user);
// Output: User logged in {Name: "John", Id: 123}
```

Fixes #2192