### PR TITLE
Package Serilog.targets as 'buildTransitive' as well as 'build'

### DIFF
--- a/src/Serilog/Serilog.csproj
+++ b/src/Serilog/Serilog.csproj
@@ -52,7 +52,7 @@
   <ItemGroup>
     <None Include="../../assets/icon.png" Pack="true" Visible="false" PackagePath="/" />
     <None Include="../../README.md" Pack="true" Visible="false" PackagePath="/" />
-    <None Include="Serilog.targets" Pack="true" Visible="false" PackagePath="/build" />
+    <None Include="Serilog.targets" Pack="true" Visible="false" PackagePath="build\;buildTransitive\" />
     <PackageReference Include="PolySharp" Version="1.15.0" PrivateAssets="All" />
     <EmbeddedResource Include="ILLink.Substitutions.xml">
       <LogicalName>ILLink.Substitutions.xml</LogicalName>


### PR DESCRIPTION
refs https://github.com/serilog/serilog/issues/2194

This should result in the targets file being imported when Serilog is either a direct or transitive dependency of the consuming project, rather than only when it's a direct dependency