### PR TITLE
Inline TraceId and SpanId JSON string formatting

### DIFF
--- a/src/Serilog/Formatting/Json/JsonFormatter.cs
+++ b/src/Serilog/Formatting/Json/JsonFormatter.cs
@@ -74,13 +74,17 @@ public sealed class JsonFormatter : ITextFormatter
         if (logEvent.TraceId != null)
         {
             output.Write(",\"TraceId\":");
-            JsonValueFormatter.WriteQuotedJsonString(logEvent.TraceId.ToString()!, output);
+            output.Write('\"');
+            output.Write(logEvent.TraceId.ToString()!);
+            output.Write('\"');
         }
 
         if (logEvent.SpanId != null)
         {
             output.Write(",\"SpanId\":");
-            JsonValueFormatter.WriteQuotedJsonString(logEvent.SpanId.ToString()!, output);
+            output.Write('\"');
+            output.Write(logEvent.SpanId.ToString()!);
+            output.Write('\"');
         }
 
         if (logEvent.Exception != null)

--- a/test/Serilog.Tests/Formatting/Json/JsonFormatterTests.cs
+++ b/test/Serilog.Tests/Formatting/Json/JsonFormatterTests.cs
@@ -317,4 +317,62 @@ public class JsonFormatterTests
         Assert.Contains($"\"TraceId\":\"{traceId}\"", formatted);
         Assert.Contains($"\"SpanId\":\"{spanId}\"", formatted);
     }
+
+    [Fact]
+    public void TraceIdIsFormattedAsValidJsonString()
+    {
+        var traceId = ActivityTraceId.CreateFromString("0af7651916cd43dd8448eb211c80319c".AsSpan());
+        var evt = Some.LogEvent(traceId: traceId, spanId: default);
+        var formatted = FormatJson(evt);
+
+        Assert.Equal("0af7651916cd43dd8448eb211c80319c", (string)formatted.TraceId);
+    }
+
+    [Fact]
+    public void SpanIdIsFormattedAsValidJsonString()
+    {
+        var spanId = ActivitySpanId.CreateFromString("00f067aa0ba902b7".AsSpan());
+        var evt = Some.LogEvent(traceId: default, spanId: spanId);
+        var formatted = FormatJson(evt);
+
+        Assert.Equal("00f067aa0ba902b7", (string)formatted.SpanId);
+    }
+
+    [Fact]
+    public void TraceIdAndSpanIdProduceValidJson()
+    {
+        var traceId = ActivityTraceId.CreateRandom();
+        var spanId = ActivitySpanId.CreateRandom();
+        var evt = Some.LogEvent(traceId: traceId, spanId: spanId);
+
+        // FormatJson uses Newtonsoft.Json to parse - will throw if invalid JSON
+        var formatted = FormatJson(evt);
+
+        Assert.NotNull(formatted.TraceId);
+        Assert.NotNull(formatted.SpanId);
+        Assert.Equal(32, ((string)formatted.TraceId).Length);
+        Assert.Equal(16, ((string)formatted.SpanId).Length);
+    }
+
+    [Fact]
+    public void TraceIdContainsOnlyHexCharacters()
+    {
+        var traceId = ActivityTraceId.CreateRandom();
+        var evt = Some.LogEvent(traceId: traceId, spanId: default);
+        var formatted = FormatJson(evt);
+
+        var traceIdString = (string)formatted.TraceId;
+        Assert.Matches("^[0-9a-f]{32}$", traceIdString);
+    }
+
+    [Fact]
+    public void SpanIdContainsOnlyHexCharacters()
+    {
+        var spanId = ActivitySpanId.CreateRandom();
+        var evt = Some.LogEvent(traceId: default, spanId: spanId);
+        var formatted = FormatJson(evt);
+
+        var spanIdString = (string)formatted.SpanId;
+        Assert.Matches("^[0-9a-f]{16}$", spanIdString);
+    }
 }


### PR DESCRIPTION
Replaces usage of JsonValueFormatter.WriteQuotedJsonString for TraceId and SpanId with direct writing of quoted string values.

activitytraceid is only either numbers or lower-case hexadecimal https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.activitytraceid.createfromstring?view=net-8.0#exceptions

same for activityspanid
https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.activityspanid.createfromstring?view=net-8.0#exceptions