### PR TITLE
Emit SelfLog warning when extra arguments are provided

### DIFF
--- a/src/Serilog/Capturing/PropertyBinder.cs
+++ b/src/Serilog/Capturing/PropertyBinder.cs
@@ -99,7 +99,12 @@ class PropertyBinder
     {
         var namedProperties = template.NamedProperties;
         if (namedProperties == null)
+        {
+            if (messageTemplateParameters.Length > 0)
+                SelfLog.WriteLine("Parameters provided for message template with no properties: {0}", template);
+
             return NoProperties;
+        }
 
         var matchedRun = namedProperties.Length;
         if (namedProperties.Length != messageTemplateParameters.Length)

--- a/test/Serilog.Tests/Core/LogEventPropertyCapturingTests.cs
+++ b/test/Serilog.Tests/Core/LogEventPropertyCapturingTests.cs
@@ -142,6 +142,35 @@ public class LogEventPropertyCapturingTests
     }
 
     [Fact]
+    public void ProvidingMoreParametersThanNamedPropertiesInTheTemplateWillSelfLog()
+    {
+        var selfLogOutput = new List<string>();
+        SelfLog.Enable(selfLogOutput.Add);
+
+        Capture("Hello {who}", "world", "extra").ToList();
+
+        Assert.Single(selfLogOutput,
+            s => s.EndsWith("Named property count does not match parameter count: Hello {who}"));
+
+        SelfLog.Disable();
+    }
+
+    [Fact]
+    public void ProvidingParametersWhenTemplateHasNoPropertiesWillSelfLog()
+    {
+        var selfLogOutput = new List<string>();
+        SelfLog.Enable(selfLogOutput.Add);
+
+        var result = Capture("No properties here", 42).ToList();
+
+        Assert.Empty(result);
+        Assert.Single(selfLogOutput,
+            s => s.EndsWith("Parameters provided for message template with no properties: No properties here"));
+
+        SelfLog.Disable();
+    }
+
+    [Fact]
     public void WillCaptureProvidedPositionalValuesEvenIfSomeAreMissing()
     {
         Assert.Equal(new[]


### PR DESCRIPTION
## Summary

Fixes #1600

When a message template has no properties but arguments are supplied (e.g. `logger.Information("Argument extra", 42)`), no `SelfLog` diagnostic was emitted, making it difficult to detect mismatched log calls at runtime.

## Changes

- **`PropertyBinder.ConstructNamedProperties`**: Added a `SelfLog.WriteLine` call when `NamedProperties` is `null` but `messageTemplateParameters.Length > 0`
- Added two unit tests:
  - `ProvidingMoreParametersThanNamedPropertiesInTheTemplateWillSelfLog` — verifies `SelfLog` fires when more args than named properties
  - `ProvidingParametersWhenTemplateHasNoPropertiesWillSelfLog` — verifies `SelfLog` fires for the exact scenario in #1600

## Performance

The added check (`messageTemplateParameters.Length > 0`) only executes in the early-return path when the template has no properties at all. On the normal hot path (templates with properties), there is zero overhead. This aligns with @jandresleiva's earlier benchmark analysis showing negligible impact.

## Testing

All existing tests pass. Two new tests added covering both the reported scenario and the related "more args than properties" case.