### PR TITLE
Fix: ReusableStringWriter pool leak in MessageTemplateTextFormatter

### DIFF
--- a/src/Serilog/Formatting/Display/MessageTemplateTextFormatter.cs
+++ b/src/Serilog/Formatting/Display/MessageTemplateTextFormatter.cs
@@ -133,7 +133,7 @@ public class MessageTemplateTextFormatter : ITextFormatter
                     if (!logEvent.Properties.TryGetValue(pt.PropertyName, out var propertyValue))
                     {
                         if (pt.Alignment.HasValue)
-                            writer.Dispose();
+                            writer?.Dispose();
                         continue;
                     }
 

--- a/src/Serilog/Formatting/Display/MessageTemplateTextFormatter.cs
+++ b/src/Serilog/Formatting/Display/MessageTemplateTextFormatter.cs
@@ -131,7 +131,11 @@ public class MessageTemplateTextFormatter : ITextFormatter
                 {
                     // If a property is missing, don't render anything (message templates render the raw token here).
                     if (!logEvent.Properties.TryGetValue(pt.PropertyName, out var propertyValue))
+                    {
+                        if (pt.Alignment.HasValue)
+                            writer.Dispose();
                         continue;
+                    }
 
                     // If the value is a scalar string, support some additional formats: 'u' for uppercase
                     // and 'w' for lowercase.


### PR DESCRIPTION
Fixed leak in the `ReusableStringWriter` pool in `MessageTemplateTextFormatter.cs`.

**The Problem:**
When a property has alignment but the property itself is missing, the code calls `continue` to skip it. The problem is that `continue` skips the `writer.Dispose()` call at the end of the loop, so the `writer` is never returned to the pool.

**The Fix:**
Added `writer.Dispose()` before the `continue` statement to make sure the `writer` always goes back to the pool.

Found by Linux Verification Center (linuxtesting.org) with SVACE.