### PR TITLE
Route optional interfaces through OptionalInterfaceForwardingSink for restricted sinks

### DIFF
--- a/src/Serilog/Configuration/LoggerSinkConfiguration.cs
+++ b/src/Serilog/Configuration/LoggerSinkConfiguration.cs
@@ -74,11 +74,19 @@ public class LoggerSinkConfiguration
             if (restrictedToMinimumLevel != LevelAlias.Minimum)
                 SelfLog.WriteLine("Sink {0} was configured with both a level switch and minimum level '{1}'; the minimum level will be ignored and the switch level used", sink, restrictedToMinimumLevel);
 
-            sink = new RestrictedSink(sink, levelSwitch);
+            sink = new RestrictedSink(logEventSink, levelSwitch);
+            if (!OptionalInterfaceForwardingSink.SupportsAll(sink) && OptionalInterfaceForwardingSink.SupportsAny(logEventSink))
+            {
+                sink = new OptionalInterfaceForwardingSink(sink, logEventSink);
+            }
         }
         else if (restrictedToMinimumLevel > LevelAlias.Minimum)
         {
-            sink = new RestrictedSink(sink, new(restrictedToMinimumLevel));
+            sink = new RestrictedSink(logEventSink, new(restrictedToMinimumLevel));
+            if (!OptionalInterfaceForwardingSink.SupportsAll(sink) && OptionalInterfaceForwardingSink.SupportsAny(logEventSink))
+            {
+                sink = new OptionalInterfaceForwardingSink(sink, logEventSink);
+            }
         }
 
         _addSink(sink);

--- a/src/Serilog/Core/Sinks/RestrictedSink.cs
+++ b/src/Serilog/Core/Sinks/RestrictedSink.cs
@@ -14,7 +14,7 @@
 
 namespace Serilog.Core.Sinks;
 
-sealed class RestrictedSink : ILogEventSink, IDisposable
+sealed class RestrictedSink : ILogEventSink, IDisposable, ISetLoggingFailureListener
 #if FEATURE_ASYNCDISPOSABLE
     , IAsyncDisposable
 #endif
@@ -36,6 +36,14 @@ sealed class RestrictedSink : ILogEventSink, IDisposable
             return;
 
         _sink.Emit(logEvent);
+    }
+
+    public void SetFailureListener(ILoggingFailureListener failureListener)
+    {
+        if (_sink is ISetLoggingFailureListener sfl)
+        {
+            sfl.SetFailureListener(failureListener);
+        }
     }
 
     public void Dispose()

--- a/src/Serilog/Core/Sinks/RestrictedSink.cs
+++ b/src/Serilog/Core/Sinks/RestrictedSink.cs
@@ -14,10 +14,7 @@
 
 namespace Serilog.Core.Sinks;
 
-sealed class RestrictedSink : ILogEventSink, IDisposable, ISetLoggingFailureListener
-#if FEATURE_ASYNCDISPOSABLE
-    , IAsyncDisposable
-#endif
+sealed class RestrictedSink : ILogEventSink
 {
     readonly ILogEventSink _sink;
     readonly LoggingLevelSwitch _levelSwitch;
@@ -37,28 +34,4 @@ sealed class RestrictedSink : ILogEventSink, IDisposable, ISetLoggingFailureList
 
         _sink.Emit(logEvent);
     }
-
-    public void SetFailureListener(ILoggingFailureListener failureListener)
-    {
-        if (_sink is ISetLoggingFailureListener sfl)
-        {
-            sfl.SetFailureListener(failureListener);
-        }
-    }
-
-    public void Dispose()
-    {
-        (_sink as IDisposable)?.Dispose();
-    }
-
-#if FEATURE_ASYNCDISPOSABLE
-    public ValueTask DisposeAsync()
-    {
-        if (_sink is IAsyncDisposable asyncDisposable)
-            return asyncDisposable.DisposeAsync();
-
-        Dispose();
-        return default;
-    }
-#endif
 }

--- a/test/Serilog.Tests/Core/FailureListenerTests.cs
+++ b/test/Serilog.Tests/Core/FailureListenerTests.cs
@@ -28,6 +28,52 @@ public class FailureListenerTests
     }
 
     [Fact]
+    public void RestrictedSinkForwardsFailureListenerToInnerSink()
+    {
+        var trackingSink = new ListenerTrackingSink();
+        var restricted = new RestrictedSink(trackingSink, new LoggingLevelSwitch());
+        var listener = new CollectingFailureListener();
+
+        restricted.SetFailureListener(listener);
+
+        Assert.Same(listener, trackingSink.Listener);
+    }
+
+    [Fact]
+    public void RestrictedToMinimumLevelAllowsFailureListenerPropagation()
+    {
+        var trackingSink = new ListenerTrackingSink();
+
+        using (var logger = new LoggerConfiguration()
+                   .WriteTo.FallbackChain(
+                       wt => wt.Sink(trackingSink, restrictedToMinimumLevel: Information),
+                       wt => wt.Sink(new CollectingSink()))
+                   .CreateLogger())
+        {
+            logger.Write(Some.InformationEvent());
+        }
+
+        Assert.NotNull(trackingSink.Listener);
+    }
+
+    [Fact]
+    public void DefaultLevelAllowsFailureListenerPropagation()
+    {
+        var trackingSink = new ListenerTrackingSink();
+
+        using (var logger = new LoggerConfiguration()
+                   .WriteTo.FallbackChain(
+                       wt => wt.Sink(trackingSink),
+                       wt => wt.Sink(new CollectingSink()))
+                   .CreateLogger())
+        {
+            logger.Write(Some.InformationEvent());
+        }
+
+        Assert.NotNull(trackingSink.Listener);
+    }
+
+    [Fact]
     public void ShallowFallbackChainsAreEffective()
     {
         var disposeTracker1 = new DisposeTrackingSink();

--- a/test/Serilog.Tests/Core/FailureListenerTests.cs
+++ b/test/Serilog.Tests/Core/FailureListenerTests.cs
@@ -28,18 +28,6 @@ public class FailureListenerTests
     }
 
     [Fact]
-    public void RestrictedSinkForwardsFailureListenerToInnerSink()
-    {
-        var trackingSink = new ListenerTrackingSink();
-        var restricted = new RestrictedSink(trackingSink, new LoggingLevelSwitch());
-        var listener = new CollectingFailureListener();
-
-        restricted.SetFailureListener(listener);
-
-        Assert.Same(listener, trackingSink.Listener);
-    }
-
-    [Fact]
     public void RestrictedToMinimumLevelAllowsFailureListenerPropagation()
     {
         var trackingSink = new ListenerTrackingSink();

--- a/test/Serilog.Tests/Support/ListenerTrackingSink.cs
+++ b/test/Serilog.Tests/Support/ListenerTrackingSink.cs
@@ -1,0 +1,13 @@
+namespace Serilog.Tests.Support;
+
+class ListenerTrackingSink : ILogEventSink, ISetLoggingFailureListener
+{
+    public ILoggingFailureListener? Listener { get; private set; }
+
+    public void Emit(LogEvent logEvent) { }
+
+    public void SetFailureListener(ILoggingFailureListener failureListener)
+    {
+        Listener = failureListener;
+    }
+}


### PR DESCRIPTION
Closes #2231.

## Summary

`Serilog.Core.Sinks.RestrictedSink` — the wrapper applied by `LoggerSinkConfiguration.Sink(sink, restrictedToMinimumLevel)` whenever `restrictedToMinimumLevel` is anything other than `LevelAlias.Minimum` — hid the inner sink's optional interfaces (`IDisposable`, `IAsyncDisposable`, `ISetLoggingFailureListener`). The most visible consequence: the failure listener installed by `FailureListenerSink` (used internally by `WriteTo.FallbackChain(...)` and `WriteTo.Fallible(...)`, introduced in #2108) never reached the inner sink.

For synchronous sinks the gap is masked: `FailureListenerSink.Emit(...)` catches exceptions and notifies the listener directly. For **async/batched sinks** that surface failures only through `ILoggingFailureListener` (notably anything built on `BatchingSink`), the listener stayed unset and failed batches were silently dropped via `SelfLog` instead of being routed to the next stage of the fallback chain.

Per maintainer feedback, the fix routes optional interfaces through the existing `OptionalInterfaceForwardingSink` (the canonical mechanism, already used in the chained-sink path) rather than re-implementing forwarding inside each wrapper. Future optional interfaces will only need updates in one place.

## Changes

- `RestrictedSink` is now a plain `ILogEventSink` — its `Dispose`/`DisposeAsync`/`SetFailureListener` shims are removed.
- `LoggerSinkConfiguration.Sink(...)` wraps the resulting `RestrictedSink` in `OptionalInterfaceForwardingSink` whenever the inner sink supports any optional interface, mirroring the existing chained-sink wiring.
- Integration test `RestrictedToMinimumLevelAllowsFailureListenerPropagation` — pins the wiring through `FallbackChain` + `restrictedToMinimumLevel`.
- Companion test `DefaultLevelAllowsFailureListenerPropagation` — pins the un-wrapped baseline.
- Added small `ListenerTrackingSink` helper for the integration tests.

## Test plan

- [x] `dotnet test test/Serilog.Tests --filter "FullyQualifiedName~FailureListenerTests"` — 4/4 passing on `net8.0`, `net9.0`, `net10.0`
- [x] Full `Serilog.Tests` suite — 815/815 passing
- [x] `Serilog.ApprovalTests` passes (no public-API drift; `RestrictedSink` is internal)
- [x] CI on `windows-latest` covers the `net48`/`net462` legs

## Discovered via

Wiring `Serilog.Sinks.RabbitMQ` against the new `WriteTo.FallbackChain` / `WriteTo.Fallible` extensions from #2108. Setting `RestrictedToMinimumLevel = Information` on the primary sink silently broke the whole fallback story, with no compile-time or runtime indication.