### PR TITLE
4.4.0 Release

### DIFF
--- a/Directory.Version.props
+++ b/Directory.Version.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <VersionPrefix>4.3.1</VersionPrefix>
+    <VersionPrefix>4.3.2</VersionPrefix>
   </PropertyGroup>
 </Project>

--- a/Directory.Version.props
+++ b/Directory.Version.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <VersionPrefix>4.3.2</VersionPrefix>
+    <VersionPrefix>4.4.0</VersionPrefix>
   </PropertyGroup>
 </Project>

--- a/src/Serilog/Capturing/PropertyBinder.cs
+++ b/src/Serilog/Capturing/PropertyBinder.cs
@@ -99,7 +99,12 @@ class PropertyBinder
     {
         var namedProperties = template.NamedProperties;
         if (namedProperties == null)
+        {
+            if (messageTemplateParameters.Length > 0)
+                SelfLog.WriteLine("Parameters provided for message template with no properties: {0}", template);
+
             return NoProperties;
+        }
 
         var matchedRun = namedProperties.Length;
         if (namedProperties.Length != messageTemplateParameters.Length)

--- a/src/Serilog/Configuration/LoggerSinkConfiguration.cs
+++ b/src/Serilog/Configuration/LoggerSinkConfiguration.cs
@@ -74,11 +74,19 @@ public class LoggerSinkConfiguration
             if (restrictedToMinimumLevel != LevelAlias.Minimum)
                 SelfLog.WriteLine("Sink {0} was configured with both a level switch and minimum level '{1}'; the minimum level will be ignored and the switch level used", sink, restrictedToMinimumLevel);
 
-            sink = new RestrictedSink(sink, levelSwitch);
+            sink = new RestrictedSink(logEventSink, levelSwitch);
+            if (!OptionalInterfaceForwardingSink.SupportsAll(sink) && OptionalInterfaceForwardingSink.SupportsAny(logEventSink))
+            {
+                sink = new OptionalInterfaceForwardingSink(sink, logEventSink);
+            }
         }
         else if (restrictedToMinimumLevel > LevelAlias.Minimum)
         {
-            sink = new RestrictedSink(sink, new(restrictedToMinimumLevel));
+            sink = new RestrictedSink(logEventSink, new(restrictedToMinimumLevel));
+            if (!OptionalInterfaceForwardingSink.SupportsAll(sink) && OptionalInterfaceForwardingSink.SupportsAny(logEventSink))
+            {
+                sink = new OptionalInterfaceForwardingSink(sink, logEventSink);
+            }
         }
 
         _addSink(sink);

--- a/src/Serilog/Core/Logger.cs
+++ b/src/Serilog/Core/Logger.cs
@@ -426,7 +426,8 @@ public sealed class Logger : ILogger, ILogEventSink, IDisposable
 
         var currentActivity = Activity.Current;
         var logEvent = new LogEvent(logTimestamp, level, exception, parsedTemplate, boundProperties, currentActivity?.TraceId ?? default, currentActivity?.SpanId ?? default);
-        Dispatch(logEvent);
+        PostLevelCheckEmit(logEvent);
+        SelfMetrics.PipelineEventEmitted.Add(1);
     }
 
 #if FEATURE_SPAN
@@ -441,7 +442,8 @@ public sealed class Logger : ILogger, ILogEventSink, IDisposable
 
         var currentActivity = Activity.Current;
         var logEvent = new LogEvent(logTimestamp, level, exception, parsedTemplate, boundProperties, currentActivity?.TraceId ?? default, currentActivity?.SpanId ?? default);
-        Dispatch(logEvent);
+        PostLevelCheckEmit(logEvent);
+        SelfMetrics.PipelineEventEmitted.Add(1);
     }
 #endif
 
@@ -453,7 +455,8 @@ public sealed class Logger : ILogger, ILogEventSink, IDisposable
     {
         if (logEvent == null!) return;
         if (!IsEnabled(logEvent.Level)) return;
-        Dispatch(logEvent);
+        PostLevelCheckEmit(logEvent);
+        SelfMetrics.PipelineEventEmitted.Add(1);
     }
 
     void ILogEventSink.Emit(LogEvent logEvent)
@@ -462,10 +465,13 @@ public sealed class Logger : ILogger, ILogEventSink, IDisposable
 
         // Bypasses the level check so that child loggers
         // using this one as a sink can increase verbosity.
-        Dispatch(logEvent);
+        PostLevelCheckEmit(logEvent);
+
+        // No metric increment, here. If the event arrives via `ILogEventSink.Emit()`, it's already been
+        // written through a `Logger` (or logger-like thing), which would be responsible for metrics recording.
     }
 
-    void Dispatch(LogEvent logEvent)
+    void PostLevelCheckEmit(LogEvent logEvent)
     {
         // The enricher may be a "safe" aggregate one, but is most commonly bare and so
         // the exception handling from SafeAggregateEnricher is duplicated here.
@@ -479,8 +485,6 @@ public sealed class Logger : ILogger, ILogEventSink, IDisposable
         }
 
         _sink.Emit(logEvent);
-
-        SelfMetrics.PipelineEventEmitted.Add(1);
     }
 
     /// <summary>

--- a/src/Serilog/Core/Logger.cs
+++ b/src/Serilog/Core/Logger.cs
@@ -479,6 +479,8 @@ public sealed class Logger : ILogger, ILogEventSink, IDisposable
         }
 
         _sink.Emit(logEvent);
+
+        SelfMetrics.PipelineEventEmitted.Add(1);
     }
 
     /// <summary>

--- a/src/Serilog/Core/Sinks/RestrictedSink.cs
+++ b/src/Serilog/Core/Sinks/RestrictedSink.cs
@@ -14,7 +14,7 @@
 
 namespace Serilog.Core.Sinks;
 
-sealed class RestrictedSink : ILogEventSink, IDisposable
+sealed class RestrictedSink : ILogEventSink, IDisposable, ISetLoggingFailureListener
 #if FEATURE_ASYNCDISPOSABLE
     , IAsyncDisposable
 #endif
@@ -36,6 +36,14 @@ sealed class RestrictedSink : ILogEventSink, IDisposable
             return;
 
         _sink.Emit(logEvent);
+    }
+
+    public void SetFailureListener(ILoggingFailureListener failureListener)
+    {
+        if (_sink is ISetLoggingFailureListener sfl)
+        {
+            sfl.SetFailureListener(failureListener);
+        }
     }
 
     public void Dispose()

--- a/src/Serilog/Core/Sinks/RestrictedSink.cs
+++ b/src/Serilog/Core/Sinks/RestrictedSink.cs
@@ -14,10 +14,7 @@
 
 namespace Serilog.Core.Sinks;
 
-sealed class RestrictedSink : ILogEventSink, IDisposable, ISetLoggingFailureListener
-#if FEATURE_ASYNCDISPOSABLE
-    , IAsyncDisposable
-#endif
+sealed class RestrictedSink : ILogEventSink
 {
     readonly ILogEventSink _sink;
     readonly LoggingLevelSwitch _levelSwitch;
@@ -37,28 +34,4 @@ sealed class RestrictedSink : ILogEventSink, IDisposable, ISetLoggingFailureList
 
         _sink.Emit(logEvent);
     }
-
-    public void SetFailureListener(ILoggingFailureListener failureListener)
-    {
-        if (_sink is ISetLoggingFailureListener sfl)
-        {
-            sfl.SetFailureListener(failureListener);
-        }
-    }
-
-    public void Dispose()
-    {
-        (_sink as IDisposable)?.Dispose();
-    }
-
-#if FEATURE_ASYNCDISPOSABLE
-    public ValueTask DisposeAsync()
-    {
-        if (_sink is IAsyncDisposable asyncDisposable)
-            return asyncDisposable.DisposeAsync();
-
-        Dispose();
-        return default;
-    }
-#endif
 }

--- a/src/Serilog/Debugging/SelfLog.cs
+++ b/src/Serilog/Debugging/SelfLog.cs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System.Diagnostics;
+
 namespace Serilog.Debugging;
 
 /// <summary>
@@ -75,12 +77,23 @@ public static class SelfLog
     {
         var o = _output;
         o?.Invoke(string.Format($"{DateTime.UtcNow:o} {format}", arg0, arg1, arg2));
+
+        SelfMetrics.DiagnosticsSelfLogWrites.Add(1);
     }
 
     class SelfLogFailureListener : ILoggingFailureListener
     {
         public void OnLoggingFailed(object sender, LoggingFailureKind kind, string message, IReadOnlyCollection<LogEvent>? events, Exception? exception)
         {
+            var tags = new TagList
+            {
+                // Calling `ToString()` on a valid enum member is non-allocating, so we avoid boxing, here (at the
+                // cost of invoking some minor internal `Enum` machinery).
+                { SelfMetrics.TagNames.LoggingFailureKind, kind.ToString() },
+            };
+
+            SelfMetrics.DiagnosticsDefaultFailureListenerLoggingFailures.Add(1, tags);
+
             var o = _output;
             if (o == null) return;
 

--- a/src/Serilog/Debugging/SelfMetrics.cs
+++ b/src/Serilog/Debugging/SelfMetrics.cs
@@ -1,0 +1,36 @@
+using System.Diagnostics.Metrics;
+
+namespace Serilog.Debugging;
+
+static class SelfMetrics
+{
+    static readonly Meter Meter = new("Serilog", typeof(Log).Assembly.GetName().Version?.ToString());
+
+    public static class TagNames
+    {
+        public const string LoggingFailureKind = "serilog.logging_failure_kind";
+    }
+
+    // Most applications should create only a single pipeline; creating and disposing multiple pipelines isn't a
+    // typical usage pattern so we don't try to record disposal. In general, applications that see more than a handful
+    // of increments probably have logger lifecycle bugs to resolve.
+    public static readonly Counter<long> PipelineCreated = Meter.CreateCounter<long>(
+        "serilog.pipeline.created",
+        unit: "{pipeline}",
+        description: "The number of full logging pipelines constructed.");
+
+    public static readonly Counter<long> PipelineEventEmitted = Meter.CreateCounter<long>(
+        "serilog.pipeline.event_emitted",
+        unit: "{event}",
+        description: "The number of events dispatched to sinks through the logging pipeline.");
+
+    public static readonly Counter<long> DiagnosticsSelfLogWrites = Meter.CreateCounter<long>(
+        "serilog.diagnostics.self_log_writes",
+        unit: "{write}",
+        description: "The number of calls made to write lines to Serilog's internal diagnostic log.");
+
+    public static readonly Counter<long> DiagnosticsDefaultFailureListenerLoggingFailures = Meter.CreateCounter<long>(
+        "serilog.diagnostics.default_failure_listener.logging_failures",
+        unit: "{failure}",
+        description: "The number of logging failures to reach the default failure listener.");
+}

--- a/src/Serilog/Formatting/Json/JsonValueFormatter.cs
+++ b/src/Serilog/Formatting/Json/JsonValueFormatter.cs
@@ -142,11 +142,22 @@ public class JsonValueFormatter : LogEventPropertyValueVisitor<TextWriter, bool>
             {
                 state.Write(delim.Value);
             }
+
             delim = ',';
-            WriteQuotedJsonString((element.Key.Value ?? "null").ToString()!, state);
-            state.Write(':');
+            var key = element.Key.Value;
+            if (key is null)
+            {
+                state.Write("\"null\":");
+            }
+            else
+            {
+                WriteQuotedJsonString(key.ToString()!, state);
+                state.Write(':');
+            }
+
             Visit(state, element.Value);
         }
+
         state.Write('}');
         return false;
     }

--- a/src/Serilog/LoggerConfiguration.cs
+++ b/src/Serilog/LoggerConfiguration.cs
@@ -208,6 +208,8 @@ public class LoggerConfiguration
         }
 #endif
 
+        SelfMetrics.PipelineCreated.Add(1);
+
         return new(
             processor,
             _levelSwitch != null ? LevelAlias.Minimum : _minimumLevel, _levelSwitch,

--- a/test/Serilog.Tests/Core/FailureListenerTests.cs
+++ b/test/Serilog.Tests/Core/FailureListenerTests.cs
@@ -28,6 +28,52 @@ public class FailureListenerTests
     }
 
     [Fact]
+    public void RestrictedSinkForwardsFailureListenerToInnerSink()
+    {
+        var trackingSink = new ListenerTrackingSink();
+        var restricted = new RestrictedSink(trackingSink, new LoggingLevelSwitch());
+        var listener = new CollectingFailureListener();
+
+        restricted.SetFailureListener(listener);
+
+        Assert.Same(listener, trackingSink.Listener);
+    }
+
+    [Fact]
+    public void RestrictedToMinimumLevelAllowsFailureListenerPropagation()
+    {
+        var trackingSink = new ListenerTrackingSink();
+
+        using (var logger = new LoggerConfiguration()
+                   .WriteTo.FallbackChain(
+                       wt => wt.Sink(trackingSink, restrictedToMinimumLevel: Information),
+                       wt => wt.Sink(new CollectingSink()))
+                   .CreateLogger())
+        {
+            logger.Write(Some.InformationEvent());
+        }
+
+        Assert.NotNull(trackingSink.Listener);
+    }
+
+    [Fact]
+    public void DefaultLevelAllowsFailureListenerPropagation()
+    {
+        var trackingSink = new ListenerTrackingSink();
+
+        using (var logger = new LoggerConfiguration()
+                   .WriteTo.FallbackChain(
+                       wt => wt.Sink(trackingSink),
+                       wt => wt.Sink(new CollectingSink()))
+                   .CreateLogger())
+        {
+            logger.Write(Some.InformationEvent());
+        }
+
+        Assert.NotNull(trackingSink.Listener);
+    }
+
+    [Fact]
     public void ShallowFallbackChainsAreEffective()
     {
         var disposeTracker1 = new DisposeTrackingSink();

--- a/test/Serilog.Tests/Core/FailureListenerTests.cs
+++ b/test/Serilog.Tests/Core/FailureListenerTests.cs
@@ -28,18 +28,6 @@ public class FailureListenerTests
     }
 
     [Fact]
-    public void RestrictedSinkForwardsFailureListenerToInnerSink()
-    {
-        var trackingSink = new ListenerTrackingSink();
-        var restricted = new RestrictedSink(trackingSink, new LoggingLevelSwitch());
-        var listener = new CollectingFailureListener();
-
-        restricted.SetFailureListener(listener);
-
-        Assert.Same(listener, trackingSink.Listener);
-    }
-
-    [Fact]
     public void RestrictedToMinimumLevelAllowsFailureListenerPropagation()
     {
         var trackingSink = new ListenerTrackingSink();

--- a/test/Serilog.Tests/Core/LogEventPropertyCapturingTests.cs
+++ b/test/Serilog.Tests/Core/LogEventPropertyCapturingTests.cs
@@ -142,6 +142,35 @@ public class LogEventPropertyCapturingTests
     }
 
     [Fact]
+    public void ProvidingMoreParametersThanNamedPropertiesInTheTemplateWillSelfLog()
+    {
+        var selfLogOutput = new List<string>();
+        SelfLog.Enable(selfLogOutput.Add);
+
+        Capture("Hello {who}", "world", "extra").ToList();
+
+        Assert.Single(selfLogOutput,
+            s => s.EndsWith("Named property count does not match parameter count: Hello {who}"));
+
+        SelfLog.Disable();
+    }
+
+    [Fact]
+    public void ProvidingParametersWhenTemplateHasNoPropertiesWillSelfLog()
+    {
+        var selfLogOutput = new List<string>();
+        SelfLog.Enable(selfLogOutput.Add);
+
+        var result = Capture("No properties here", 42).ToList();
+
+        Assert.Empty(result);
+        Assert.Single(selfLogOutput,
+            s => s.EndsWith("Parameters provided for message template with no properties: No properties here"));
+
+        SelfLog.Disable();
+    }
+
+    [Fact]
     public void WillCaptureProvidedPositionalValuesEvenIfSomeAreMissing()
     {
         Assert.Equal(new[]

--- a/test/Serilog.Tests/Serilog.Tests.csproj
+++ b/test/Serilog.Tests/Serilog.Tests.csproj
@@ -39,16 +39,22 @@
   <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
     <PackageReference Include="System.ServiceModel.Http" Version="8.1.0" />
     <PackageReference Include="System.ServiceModel.Primitives" Version="8.1.0" />
+    <!-- Pin transitive to patched 8.0.3 (CVE-2026-33116, CVE-2026-26171) -->
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.3" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net9.0' ">
     <PackageReference Include="System.ServiceModel.Http" Version="8.1.0" />
     <PackageReference Include="System.ServiceModel.Primitives" Version="8.1.0" />
+    <!-- Pin transitive to patched 8.0.3 (CVE-2026-33116, CVE-2026-26171) -->
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.3" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net10.0' ">
     <PackageReference Include="System.ServiceModel.Http" Version="8.1.0" />
     <PackageReference Include="System.ServiceModel.Primitives" Version="8.1.0" />
+    <!-- Pin transitive to patched 8.0.3 (CVE-2026-33116, CVE-2026-26171) -->
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.3" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net462' ">

--- a/test/Serilog.Tests/Serilog.Tests.csproj
+++ b/test/Serilog.Tests/Serilog.Tests.csproj
@@ -20,37 +20,15 @@
     <PackageReference Include="xunit" Version="2.9.2" />
   </ItemGroup>
 
+  <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' ">
+    <Reference Include="System.ServiceModel" />
+  </ItemGroup>
+
   <ItemGroup Condition=" '$(TargetFramework)' == 'net462' ">
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
-    <PackageReference Include="System.ServiceModel.Http" Version="4.10.3" />
-    <PackageReference Include="System.ServiceModel.Primitives" Version="4.10.3" />
-    <PackageReference Include="System.Formats.Asn1" Version="9.0.0" />
-    <PackageReference Include="System.Security.Cryptography.Pkcs" Version="9.0.0" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net48' ">
-    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
-    <PackageReference Include="System.ServiceModel.Http" Version="4.10.3" />
-    <PackageReference Include="System.ServiceModel.Primitives" Version="4.10.3" />
-    <PackageReference Include="System.Formats.Asn1" Version="9.0.0" />
-    <PackageReference Include="System.Security.Cryptography.Pkcs" Version="9.0.0" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
-    <PackageReference Include="System.ServiceModel.Http" Version="8.1.0" />
-    <PackageReference Include="System.ServiceModel.Primitives" Version="8.1.0" />
-    <!-- Pin transitive to patched 8.0.3 (CVE-2026-33116, CVE-2026-26171) -->
-    <PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.3" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net9.0' ">
-    <PackageReference Include="System.ServiceModel.Http" Version="8.1.0" />
-    <PackageReference Include="System.ServiceModel.Primitives" Version="8.1.0" />
-    <!-- Pin transitive to patched 8.0.3 (CVE-2026-33116, CVE-2026-26171) -->
-    <PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.3" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net10.0' ">
+  <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETCoreApp' ">
     <PackageReference Include="System.ServiceModel.Http" Version="8.1.0" />
     <PackageReference Include="System.ServiceModel.Primitives" Version="8.1.0" />
     <!-- Pin transitive to patched 8.0.3 (CVE-2026-33116, CVE-2026-26171) -->

--- a/test/Serilog.Tests/Support/ListenerTrackingSink.cs
+++ b/test/Serilog.Tests/Support/ListenerTrackingSink.cs
@@ -1,0 +1,13 @@
+namespace Serilog.Tests.Support;
+
+class ListenerTrackingSink : ILogEventSink, ISetLoggingFailureListener
+{
+    public ILoggingFailureListener? Listener { get; private set; }
+
+    public void Emit(LogEvent logEvent) { }
+
+    public void SetFailureListener(ILoggingFailureListener failureListener)
+    {
+        Listener = failureListener;
+    }
+}


### PR DESCRIPTION
 * #2237 - Capture internal logger health metrics using _System.Diagnostics.Metrics_ (@nblumhardt)
 * #2222 - Emit `SelfLog` warning when extra arguments are provided to a message template (@matantsach)
 * #2216 - Optimize JSON serialization of `null` (@SimonCropp)
 * #2232 - Pin _System.Cryptography.Xml_ in tests (@ArieGato)
 * #2231 - Forward `ISetLoggingFailureListener` through `RestrictedSink` (@ArieGato)
